### PR TITLE
Ensure all async generators are explicitly closed

### DIFF
--- a/src/httpcore/httpcore/_async/connection_pool.py
+++ b/src/httpcore/httpcore/_async/connection_pool.py
@@ -4,12 +4,14 @@ import ssl
 import sys
 import types
 import typing
+from collections.abc import AsyncGenerator
 
 from .._backends.auto import AutoBackend
 from .._backends.base import SOCKET_OPTION, AsyncNetworkBackend
 from .._exceptions import ConnectionNotAvailable, UnsupportedProtocol
 from .._models import Origin, Proxy, Request, Response
 from .._synchronization import AsyncEvent, AsyncShieldCancellation, AsyncThreadLock
+from .._utils import safe_async_iterate
 from .connection import AsyncHTTPConnection
 from .interfaces import AsyncConnectionInterface, AsyncRequestInterface
 
@@ -398,13 +400,10 @@ class PoolByteStream:
         self._pool = pool
         self._closed = False
 
-    async def __aiter__(self) -> typing.AsyncIterator[bytes]:
-        try:
-            async for part in self._stream:
-                yield part
-        except BaseException as exc:
-            await self.aclose()
-            raise exc from None
+    async def __aiter__(self) -> AsyncGenerator[bytes]:
+        async with safe_async_iterate(self._stream) as iterator:
+            async for chunk in iterator:
+                yield chunk
 
     async def aclose(self) -> None:
         if not self._closed:

--- a/src/httpcore/httpcore/_async/http11.py
+++ b/src/httpcore/httpcore/_async/http11.py
@@ -6,6 +6,7 @@ import ssl
 import time
 import types
 import typing
+from collections.abc import AsyncGenerator
 
 import h11
 
@@ -20,6 +21,7 @@ from .._exceptions import (
 from .._models import Origin, Request, Response
 from .._synchronization import AsyncLock, AsyncShieldCancellation
 from .._trace import Trace
+from .._utils import safe_async_iterate
 from .interfaces import AsyncConnectionInterface
 
 logger = logging.getLogger("httpcore.http11")
@@ -154,9 +156,10 @@ class AsyncHTTP11Connection(AsyncConnectionInterface):
         timeout = timeouts.get("write", None)
 
         assert isinstance(request.stream, typing.AsyncIterable)
-        async for chunk in request.stream:
-            event = h11.Data(data=chunk)
-            await self._send_event(event, timeout=timeout)
+        async with safe_async_iterate(request.stream) as iterator:
+            async for chunk in iterator:
+                event = h11.Data(data=chunk)
+                await self._send_event(event, timeout=timeout)
 
         await self._send_event(h11.EndOfMessage(), timeout=timeout)
 
@@ -193,9 +196,7 @@ class AsyncHTTP11Connection(AsyncConnectionInterface):
 
         return http_version, event.status_code, event.reason, headers, trailing_data
 
-    async def _receive_response_body(
-        self, request: Request
-    ) -> typing.AsyncIterator[bytes]:
+    async def _receive_response_body(self, request: Request) -> AsyncGenerator[bytes]:
         timeouts = request.extensions.get("timeout", {})
         timeout = timeouts.get("read", None)
 
@@ -327,12 +328,15 @@ class HTTP11ConnectionByteStream:
         self._request = request
         self._closed = False
 
-    async def __aiter__(self) -> typing.AsyncIterator[bytes]:
+    async def __aiter__(self) -> AsyncGenerator[bytes]:
         kwargs = {"request": self._request}
         try:
             async with Trace("receive_response_body", logger, self._request, kwargs):
-                async for chunk in self._connection._receive_response_body(**kwargs):
-                    yield chunk
+                async with safe_async_iterate(
+                    self._connection._receive_response_body(**kwargs)
+                ) as iterator:
+                    async for chunk in iterator:
+                        yield chunk
         except BaseException as exc:
             # If we get an exception while streaming the response,
             # we want to close the response (and possibly the connection)

--- a/src/httpcore/httpcore/_async/http2.py
+++ b/src/httpcore/httpcore/_async/http2.py
@@ -5,6 +5,7 @@ import logging
 import time
 import types
 import typing
+from collections.abc import AsyncGenerator
 
 import h2.config
 import h2.connection
@@ -21,6 +22,7 @@ from .._exceptions import (
 from .._models import Origin, Request, Response
 from .._synchronization import AsyncLock, AsyncSemaphore, AsyncShieldCancellation
 from .._trace import Trace
+from .._utils import safe_async_iterate
 from .interfaces import AsyncConnectionInterface
 
 logger = logging.getLogger("httpcore.http2")
@@ -258,8 +260,10 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
             return
 
         assert isinstance(request.stream, typing.AsyncIterable)
-        async for data in request.stream:
-            await self._send_stream_data(request, stream_id, data)
+        async with safe_async_iterate(request.stream) as iterator:
+            async for chunk in iterator:
+                await self._send_stream_data(request, stream_id, chunk)
+
         await self._send_end_stream(request, stream_id)
 
     async def _send_stream_data(
@@ -308,7 +312,7 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
 
     async def _receive_response_body(
         self, request: Request, stream_id: int
-    ) -> typing.AsyncIterator[bytes]:
+    ) -> AsyncGenerator[bytes]:
         """
         Iterator that returns the bytes of the response body for a given stream ID.
         """
@@ -568,14 +572,17 @@ class HTTP2ConnectionByteStream:
         self._stream_id = stream_id
         self._closed = False
 
-    async def __aiter__(self) -> typing.AsyncIterator[bytes]:
+    async def __aiter__(self) -> AsyncGenerator[bytes]:
         kwargs = {"request": self._request, "stream_id": self._stream_id}
         try:
             async with Trace("receive_response_body", logger, self._request, kwargs):
-                async for chunk in self._connection._receive_response_body(
-                    request=self._request, stream_id=self._stream_id
-                ):
-                    yield chunk
+                async with safe_async_iterate(
+                    self._connection._receive_response_body(
+                        request=self._request, stream_id=self._stream_id
+                    )
+                ) as iterator:
+                    async for chunk in iterator:
+                        yield chunk
         except BaseException as exc:
             # If we get an exception while streaming the response,
             # we want to close the response (and possibly the connection)

--- a/src/httpcore/httpcore/_async/interfaces.py
+++ b/src/httpcore/httpcore/_async/interfaces.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import typing
+from collections.abc import AsyncGenerator
 
 from .._models import (
     URL,
@@ -58,7 +59,7 @@ class AsyncRequestInterface:
         headers: HeaderTypes = None,
         content: bytes | typing.AsyncIterator[bytes] | None = None,
         extensions: Extensions | None = None,
-    ) -> typing.AsyncIterator[Response]:
+    ) -> AsyncGenerator[Response]:
         # Strict type checking on our parameters.
         method = enforce_bytes(method, name="method")
         url = enforce_url(url, name="url")

--- a/src/httpcore/httpcore/_models.py
+++ b/src/httpcore/httpcore/_models.py
@@ -4,6 +4,9 @@ import base64
 import ssl
 import typing
 import urllib.parse
+from collections.abc import AsyncGenerator
+
+from ._utils import safe_async_iterate
 
 # Functions for typechecking...
 
@@ -151,7 +154,7 @@ class ByteStream:
     def __iter__(self) -> typing.Iterator[bytes]:
         yield self._content
 
-    async def __aiter__(self) -> typing.AsyncIterator[bytes]:
+    async def __aiter__(self) -> AsyncGenerator[bytes]:
         yield self._content
 
     def __repr__(self) -> str:
@@ -463,10 +466,11 @@ class Response:
                 "You should use 'response.read()' instead."
             )
         if not hasattr(self, "_content"):
-            self._content = b"".join([part async for part in self.aiter_stream()])
+            async with safe_async_iterate(self.aiter_stream()) as parts:
+                self._content = b"".join([part async for part in parts])
         return self._content
 
-    async def aiter_stream(self) -> typing.AsyncIterator[bytes]:
+    async def aiter_stream(self) -> AsyncGenerator[bytes]:
         if not isinstance(self.stream, typing.AsyncIterable):  # pragma: nocover
             raise RuntimeError(
                 "Attempted to stream an synchronous response using 'async for ... in "
@@ -479,8 +483,9 @@ class Response:
                 "more than once."
             )
         self._stream_consumed = True
-        async for chunk in self.stream:
-            yield chunk
+        async with safe_async_iterate(self.stream) as iterator:
+            async for chunk in iterator:
+                yield chunk
 
     async def aclose(self) -> None:
         if not isinstance(self.stream, typing.AsyncIterable):  # pragma: nocover

--- a/src/httpcore/httpcore/_sync/connection_pool.py
+++ b/src/httpcore/httpcore/_sync/connection_pool.py
@@ -4,12 +4,14 @@ import ssl
 import sys
 import types
 import typing
+from collections.abc import Generator
 
 from .._backends.sync import SyncBackend
 from .._backends.base import SOCKET_OPTION, NetworkBackend
 from .._exceptions import ConnectionNotAvailable, UnsupportedProtocol
 from .._models import Origin, Proxy, Request, Response
 from .._synchronization import Event, ShieldCancellation, ThreadLock
+from .._utils import safe_iterate
 from .connection import HTTPConnection
 from .interfaces import ConnectionInterface, RequestInterface
 
@@ -398,13 +400,10 @@ class PoolByteStream:
         self._pool = pool
         self._closed = False
 
-    def __iter__(self) -> typing.Iterator[bytes]:
-        try:
-            for part in self._stream:
-                yield part
-        except BaseException as exc:
-            self.close()
-            raise exc from None
+    def __iter__(self) -> Generator[bytes]:
+        with safe_iterate(self._stream) as iterator:
+            for chunk in iterator:
+                yield chunk
 
     def close(self) -> None:
         if not self._closed:

--- a/src/httpcore/httpcore/_sync/http11.py
+++ b/src/httpcore/httpcore/_sync/http11.py
@@ -6,6 +6,7 @@ import ssl
 import time
 import types
 import typing
+from collections.abc import Generator
 
 import h11
 
@@ -20,6 +21,7 @@ from .._exceptions import (
 from .._models import Origin, Request, Response
 from .._synchronization import Lock, ShieldCancellation
 from .._trace import Trace
+from .._utils import safe_iterate
 from .interfaces import ConnectionInterface
 
 logger = logging.getLogger("httpcore.http11")
@@ -154,9 +156,10 @@ class HTTP11Connection(ConnectionInterface):
         timeout = timeouts.get("write", None)
 
         assert isinstance(request.stream, typing.Iterable)
-        for chunk in request.stream:
-            event = h11.Data(data=chunk)
-            self._send_event(event, timeout=timeout)
+        with safe_iterate(request.stream) as iterator:
+            for chunk in iterator:
+                event = h11.Data(data=chunk)
+                self._send_event(event, timeout=timeout)
 
         self._send_event(h11.EndOfMessage(), timeout=timeout)
 
@@ -193,9 +196,7 @@ class HTTP11Connection(ConnectionInterface):
 
         return http_version, event.status_code, event.reason, headers, trailing_data
 
-    def _receive_response_body(
-        self, request: Request
-    ) -> typing.Iterator[bytes]:
+    def _receive_response_body(self, request: Request) -> Generator[bytes]:
         timeouts = request.extensions.get("timeout", {})
         timeout = timeouts.get("read", None)
 
@@ -327,12 +328,15 @@ class HTTP11ConnectionByteStream:
         self._request = request
         self._closed = False
 
-    def __iter__(self) -> typing.Iterator[bytes]:
+    def __iter__(self) -> Generator[bytes]:
         kwargs = {"request": self._request}
         try:
             with Trace("receive_response_body", logger, self._request, kwargs):
-                for chunk in self._connection._receive_response_body(**kwargs):
-                    yield chunk
+                with safe_iterate(
+                    self._connection._receive_response_body(**kwargs)
+                ) as iterator:
+                    for chunk in iterator:
+                        yield chunk
         except BaseException as exc:
             # If we get an exception while streaming the response,
             # we want to close the response (and possibly the connection)

--- a/src/httpcore/httpcore/_sync/http2.py
+++ b/src/httpcore/httpcore/_sync/http2.py
@@ -5,6 +5,7 @@ import logging
 import time
 import types
 import typing
+from collections.abc import Generator
 
 import h2.config
 import h2.connection
@@ -21,6 +22,7 @@ from .._exceptions import (
 from .._models import Origin, Request, Response
 from .._synchronization import Lock, Semaphore, ShieldCancellation
 from .._trace import Trace
+from .._utils import safe_iterate
 from .interfaces import ConnectionInterface
 
 logger = logging.getLogger("httpcore.http2")
@@ -258,8 +260,10 @@ class HTTP2Connection(ConnectionInterface):
             return
 
         assert isinstance(request.stream, typing.Iterable)
-        for data in request.stream:
-            self._send_stream_data(request, stream_id, data)
+        with safe_iterate(request.stream) as iterator:
+            for chunk in iterator:
+                self._send_stream_data(request, stream_id, chunk)
+
         self._send_end_stream(request, stream_id)
 
     def _send_stream_data(
@@ -308,7 +312,7 @@ class HTTP2Connection(ConnectionInterface):
 
     def _receive_response_body(
         self, request: Request, stream_id: int
-    ) -> typing.Iterator[bytes]:
+    ) -> Generator[bytes]:
         """
         Iterator that returns the bytes of the response body for a given stream ID.
         """
@@ -568,14 +572,17 @@ class HTTP2ConnectionByteStream:
         self._stream_id = stream_id
         self._closed = False
 
-    def __iter__(self) -> typing.Iterator[bytes]:
+    def __iter__(self) -> Generator[bytes]:
         kwargs = {"request": self._request, "stream_id": self._stream_id}
         try:
             with Trace("receive_response_body", logger, self._request, kwargs):
-                for chunk in self._connection._receive_response_body(
-                    request=self._request, stream_id=self._stream_id
-                ):
-                    yield chunk
+                with safe_iterate(
+                    self._connection._receive_response_body(
+                        request=self._request, stream_id=self._stream_id
+                    )
+                ) as iterator:
+                    for chunk in iterator:
+                        yield chunk
         except BaseException as exc:
             # If we get an exception while streaming the response,
             # we want to close the response (and possibly the connection)

--- a/src/httpcore/httpcore/_sync/interfaces.py
+++ b/src/httpcore/httpcore/_sync/interfaces.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import typing
+from collections.abc import Generator
 
 from .._models import (
     URL,
@@ -58,7 +59,7 @@ class RequestInterface:
         headers: HeaderTypes = None,
         content: bytes | typing.Iterator[bytes] | None = None,
         extensions: Extensions | None = None,
-    ) -> typing.Iterator[Response]:
+    ) -> Generator[Response]:
         # Strict type checking on our parameters.
         method = enforce_bytes(method, name="method")
         url = enforce_url(url, name="url")

--- a/src/httpcore/httpcore/_utils.py
+++ b/src/httpcore/httpcore/_utils.py
@@ -3,6 +3,19 @@ from __future__ import annotations
 import select
 import socket
 import sys
+import typing
+from collections.abc import (
+    AsyncGenerator,
+    AsyncIterable,
+    AsyncIterator,
+    Generator,
+    Iterable,
+    Iterator,
+)
+from contextlib import asynccontextmanager, contextmanager
+from inspect import isasyncgen
+
+T = typing.TypeVar("T")
 
 
 def is_socket_readable(sock: socket.socket | None) -> bool:
@@ -35,3 +48,32 @@ def is_socket_readable(sock: socket.socket | None) -> bool:
     p = select.poll()
     p.register(sock_fd, select.POLLIN)
     return bool(p.poll(0))
+
+
+@asynccontextmanager
+async def safe_async_iterate(
+    iterable_or_iterator: AsyncIterable[T] | AsyncIterator[T], /
+) -> AsyncGenerator[AsyncIterator[T]]:
+    iterator = (
+        iterable_or_iterator
+        if isinstance(iterable_or_iterator, AsyncIterator)
+        else iterable_or_iterator.__aiter__()
+    )
+    try:
+        yield iterator
+    finally:
+        if isasyncgen(iterator):
+            await iterator.aclose()
+
+
+@contextmanager
+def safe_iterate(
+    iterable_or_iterator: Iterable[T] | Iterator[T], /
+) -> Generator[Iterator[T], None, None]:
+    # This is boilerplate code, only needed to make unasync happy
+    iterator = (
+        iterable_or_iterator
+        if isinstance(iterable_or_iterator, Iterator)
+        else iterable_or_iterator.__iter__()
+    )
+    yield iterator

--- a/src/httpcore/pyproject.toml
+++ b/src/httpcore/pyproject.toml
@@ -96,7 +96,7 @@ filterwarnings = ["error"]
 
 [tool.coverage.run]
 omit = [
-    "venv/*", 
+    "venv/*",
     "httpcore/_sync/*"
 ]
 include = ["httpcore/*", "tests/*"]

--- a/src/httpcore/scripts/unasync.py
+++ b/src/httpcore/scripts/unasync.py
@@ -5,32 +5,36 @@ import sys
 from pprint import pprint
 
 SUBS = [
-    ('from .._backends.auto import AutoBackend', 'from .._backends.sync import SyncBackend'),
-    ('import trio as concurrency', 'from tests import concurrency'),
-    ('AsyncIterator', 'Iterator'),
-    ('Async([A-Z][A-Za-z0-9_]*)', r'\2'),
-    ('async def', 'def'),
-    ('async with', 'with'),
-    ('async for', 'for'),
-    ('await ', ''),
-    ('handle_async_request', 'handle_request'),
-    ('aclose', 'close'),
-    ('aiter_stream', 'iter_stream'),
-    ('aread', 'read'),
-    ('asynccontextmanager', 'contextmanager'),
-    ('__aenter__', '__enter__'),
-    ('__aexit__', '__exit__'),
-    ('__aiter__', '__iter__'),
-    ('@pytest.mark.anyio', ''),
-    ('@pytest.mark.trio', ''),
-    ('AutoBackend', 'SyncBackend'),
+    (
+        "from .._backends.auto import AutoBackend",
+        "from .._backends.sync import SyncBackend",
+    ),
+    ("import trio as concurrency", "from tests import concurrency"),
+    ("AsyncIterator", "Iterator"),
+    ("Async([A-Z][A-Za-z0-9_]*)", r"\2"),
+    ("async def", "def"),
+    ("async with", "with"),
+    ("async for", "for"),
+    ("await ", ""),
+    ("handle_async_request", "handle_request"),
+    ("aclose", "close"),
+    ("aiter_stream", "iter_stream"),
+    ("aread", "read"),
+    ("asynccontextmanager", "contextmanager"),
+    ("safe_async_iterate", "safe_iterate"),
+    ("__aenter__", "__enter__"),
+    ("__aexit__", "__exit__"),
+    ("__aiter__", "__iter__"),
+    ("@pytest.mark.anyio", ""),
+    ("@pytest.mark.trio", ""),
+    ("AutoBackend", "SyncBackend"),
 ]
 COMPILED_SUBS = [
-    (re.compile(r'(^|\b)' + regex + r'($|\b)'), repl)
-    for regex, repl in SUBS
+    (re.compile(r"(^|\b)" + regex + r"($|\b)"), repl) for regex, repl in SUBS
 ]
 
 USED_SUBS = set()
+
 
 def unasync_line(line):
     for index, (regex, repl) in enumerate(COMPILED_SUBS):
@@ -55,22 +59,22 @@ def unasync_file_check(in_path, out_path):
             for in_line, out_line in zip(in_file.readlines(), out_file.readlines()):
                 expected = unasync_line(in_line)
                 if out_line != expected:
-                    print(f'unasync mismatch between {in_path!r} and {out_path!r}')
-                    print(f'Async code:         {in_line!r}')
-                    print(f'Expected sync code: {expected!r}')
-                    print(f'Actual sync code:   {out_line!r}')
+                    print(f"unasync mismatch between {in_path!r} and {out_path!r}")
+                    print(f"Async code:         {in_line!r}")
+                    print(f"Expected sync code: {expected!r}")
+                    print(f"Actual sync code:   {out_line!r}")
                     sys.exit(1)
 
 
 def unasync_dir(in_dir, out_dir, check_only=False):
     for dirpath, dirnames, filenames in os.walk(in_dir):
         for filename in filenames:
-            if not filename.endswith('.py'):
+            if not filename.endswith(".py"):
                 continue
             rel_dir = os.path.relpath(dirpath, in_dir)
             in_path = os.path.normpath(os.path.join(in_dir, rel_dir, filename))
             out_path = os.path.normpath(os.path.join(out_dir, rel_dir, filename))
-            print(in_path, '->', out_path)
+            print(in_path, "->", out_path)
             if check_only:
                 unasync_file_check(in_path, out_path)
             else:
@@ -78,7 +82,7 @@ def unasync_dir(in_dir, out_dir, check_only=False):
 
 
 def main():
-    check_only = '--check' in sys.argv
+    check_only = "--check" in sys.argv
     unasync_dir("httpcore/_async", "httpcore/_sync", check_only=check_only)
     unasync_dir("tests/_async", "tests/_sync", check_only=check_only)
 
@@ -87,8 +91,8 @@ def main():
 
         print("These patterns were not used:")
         pprint(unused_subs)
-        exit(1)   
-        
+        exit(1)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/src/httpcore/tests/test_cancellations.py
+++ b/src/httpcore/tests/test_cancellations.py
@@ -171,7 +171,6 @@ async def test_h11_timeout_during_response():
         assert conn.is_closed()
 
 
-@pytest.mark.xfail
 @pytest.mark.anyio
 async def test_h2_timeout_during_handshake():
     """
@@ -186,7 +185,6 @@ async def test_h2_timeout_during_handshake():
         assert conn.is_closed()
 
 
-@pytest.mark.xfail
 @pytest.mark.anyio
 async def test_h2_timeout_during_request():
     """
@@ -207,7 +205,6 @@ async def test_h2_timeout_during_request():
         assert conn.is_idle()
 
 
-@pytest.mark.xfail
 @pytest.mark.anyio
 async def test_h2_timeout_during_response():
     """


### PR DESCRIPTION
## Summary

Backports [encode/httpcore#1019](https://github.com/encode/httpcore/pull/1019) by @agronholm into our vendored `src/httpcore/`.

The upstream PR wraps `async for` iterations over request/response body streams in a `safe_async_iterate()` helper that explicitly calls `aclose()` in a try/finally, rather than relying on the GC.

Under trio this surfaced for us as `test_write_timeout[trio]` failing with `PytestUnraisableExceptionWarning: Exception ignored in: <async_generator object ByteStream.__aiter__>` during teardown. The exception was the body iterator being garbage-collected after the timeout aborted the request, with the trio event loop already torn down.

## Test plan

- [x] `uv run pytest` — 1417 passed, 1 skipped, 0 failed (was 1416 passed, 1 failed)
- [x] `tests/test_timeouts.py::test_write_timeout[trio]` now passes
- [ ] CI green on all Python versions

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.