### PR TITLE
Update CI triggers and project URLs to track main branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: Test Suite
 
 on:
   push:
-    branches: ["master"]
+    branches: ["main"]
   pull_request:
-    branches: ["master", "version-*"]
+    branches: ["main", "version-*"]
 
 permissions:
   contents: read

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ bench = [
 httpx2 = "httpx2:main"
 
 [project.urls]
-Changelog = "https://github.com/pydantic/httpx2/blob/master/CHANGELOG.md"
+Changelog = "https://github.com/pydantic/httpx2/blob/main/CHANGELOG.md"
 Homepage = "https://github.com/pydantic/httpx2"
 Source = "https://github.com/pydantic/httpx2"
 
@@ -136,11 +136,11 @@ path = "CHANGELOG.md"
 pattern = "\n(###.+?\n)## "
 
 [[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
-text = "\n---\n\n[Full changelog](https://github.com/encode/httpx/blob/master/CHANGELOG.md)\n"
+text = "\n---\n\n[Full changelog](https://github.com/pydantic/httpx2/blob/main/CHANGELOG.md)\n"
 
 [[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
 pattern = 'src="(docs/img/.*?)"'
-replacement = 'src="https://raw.githubusercontent.com/encode/httpx/master/\1"'
+replacement = 'src="https://raw.githubusercontent.com/pydantic/httpx2/main/\1"'
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "B", "PIE"]


### PR DESCRIPTION
## Summary

After renaming the default branch from `master` to `main`, this updates the remaining references:

- `.github/workflows/main.yml`: `on.push.branches` and `on.pull_request.branches` now target `main`. CI was not running on `main` until this lands.
- `pyproject.toml` `[project.urls].Changelog`: master -> main.
- `pyproject.toml` fancy-pypi-readme: Full-changelog link and image-src substitutions now point at `pydantic/httpx2/main` instead of `encode/httpx/master`.

This fixes CI for `httpx2` so PRs against `main` will trigger the test suite. Running httpcore2's own tests in CI is a separate todo - this PR only fixes httpx2.

## Test plan

- [ ] CI runs on this PR (this is itself the verification).

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.