### PR TITLE
Drop venv/ references from scripts and coverage config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,5 +79,4 @@ markers = [
 ]
 
 [tool.coverage.run]
-omit = ["venv/*"]
-include = ["src/httpx2/*", "tests/*"]
+source_pkgs = ["httpx2", "tests"]

--- a/scripts/docs
+++ b/scripts/docs
@@ -1,10 +1,5 @@
 #!/bin/sh -e
 
-export PREFIX=""
-if [ -d 'venv' ] ; then
-    export PREFIX="venv/bin/"
-fi
-
 set -x
 
-${PREFIX}mkdocs serve
+uv run mkdocs serve

--- a/src/httpcore2/pyproject.toml
+++ b/src/httpcore2/pyproject.toml
@@ -100,11 +100,8 @@ markers = ["copied_from(source, changes=None): mark test as copied from somewher
 filterwarnings = ["error"]
 
 [tool.coverage.run]
-omit = [
-    "venv/*",
-    "httpcore2/_sync/*"
-]
-include = ["httpcore2/*", "tests/*"]
+omit = ["httpcore2/_sync/*"]
+source_pkgs = ["httpcore2", "tests"]
 
 [tool.ruff]
 exclude = [


### PR DESCRIPTION
## Summary

Aligns with the convention Starlette uses: rely on `uv`'s default `.venv` and `uv run`, no script-level venv detection.

- `scripts/docs`: dropped the `PREFIX=venv/bin/` boilerplate; now just `uv run mkdocs serve`. The other scripts (`install`, `check`, `lint`, `test`, `coverage`, `build`) already used this pattern - `docs` was the last holdout.
- Root `pyproject.toml` `[tool.coverage.run]`: replaced `omit = ["venv/*"]` + `include = ["src/httpx2/*", "tests/*"]` with `source_pkgs = ["httpx2", "tests"]`, matching Starlette's pattern. Coverage now discovers package locations by importable name, so venv contents (under any name - `venv`, `.venv`, etc.) are never measured.
- `src/httpcore2/pyproject.toml`: same coverage migration, preserving the existing `httpcore2/_sync/*` omit.

## Test plan

- [x] `scripts/test` -> 1417 passed, 1 skipped, 0 failed.
- [x] `scripts/coverage` -> 100% maintained (60 files skipped due to complete coverage).

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.