### PR TITLE
Use tmp_path in test_load_ssl_with_keylog to avoid stray ./test file

### DIFF
--- a/tests/httpx2/test_config.py
+++ b/tests/httpx2/test_config.py
@@ -20,10 +20,11 @@ def test_load_ssl_config_verify_non_existing_file():
         context.load_verify_locations(cafile="/path/to/nowhere")
 
 
-def test_load_ssl_with_keylog(monkeypatch: typing.Any) -> None:
-    monkeypatch.setenv("SSLKEYLOGFILE", "test")
+def test_load_ssl_with_keylog(monkeypatch: typing.Any, tmp_path: Path) -> None:
+    keylog_file = tmp_path / "sslkeylog"
+    monkeypatch.setenv("SSLKEYLOGFILE", str(keylog_file))
     context = httpx2.create_ssl_context()
-    assert context.keylog_filename == "test"
+    assert context.keylog_filename == str(keylog_file)
 
 
 def test_load_ssl_config_verify_existing_file():


### PR DESCRIPTION
## Summary

`tests/httpx2/test_config.py::test_load_ssl_with_keylog` set `SSLKEYLOGFILE=test`, which causes Python's ssl module to open `./test` (relative to cwd) for writing keylog entries. This leaves a stray `test` file in the repo root after the suite runs.

Fix: use the `tmp_path` fixture so the keylog filename is unique per test run and lives in pytest's tmp dir.

## Test plan

- [x] `uv run pytest tests/httpx2/test_config.py::test_load_ssl_with_keylog` -> passes.
- [x] Running the test no longer modifies `./test` in the repo root (verified mtime).
- [x] `scripts/check` clean.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.