### PR TITLE
Add Pydantic Services Inc. as maintainer

### DIFF
--- a/src/httpcore2/pyproject.toml
+++ b/src/httpcore2/pyproject.toml
@@ -19,6 +19,9 @@ requires-python = ">=3.8"
 authors = [
     { name = "Tom Christie", email = "tom@tomchristie.com" },
 ]
+maintainers = [
+    { name = "Pydantic Services Inc.", email = "engineering@pydantic.dev" }
+]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Environment :: Web Environment",

--- a/src/httpx2/pyproject.toml
+++ b/src/httpx2/pyproject.toml
@@ -18,6 +18,9 @@ requires-python = ">=3.9"
 authors = [
     { name = "Tom Christie", email = "tom@tomchristie.com" },
 ]
+maintainers = [
+    { name = "Pydantic Services Inc.", email = "engineering@pydantic.dev" }
+]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Web Environment",


### PR DESCRIPTION
## Summary

Adds Pydantic Services Inc. (engineering@pydantic.dev) as a maintainer in both `src/httpx2/pyproject.toml` and `src/httpcore2/pyproject.toml`. Original authors are kept.

## Test plan

- [x] `git diff` confirms additions only; no other metadata changed.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.