### PR TITLE
Add Pydantic Services copyright to LICENSE

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,4 @@
+Copyright © 2026 to present Pydantic Services Inc. and individual contributors.
 Copyright © 2019, [Encode OSS Ltd](https://www.encode.io/).
 All rights reserved.
 


### PR DESCRIPTION
## Summary

- Add a `Copyright © 2026 to present Pydantic Services Inc. and individual contributors.` line to `LICENSE.md`, above the existing Encode OSS Ltd line.
- Stacking the newest maintainer on top while preserving the upstream copyright follows the convention used by other long-lived projects that changed stewardship - for example, [Celery's LICENSE](https://github.com/celery/celery/blob/main/LICENSE) lists each maintainership era in reverse chronological order:

  ```
  Copyright (c) 2017-2026 Asif Saif Uddin, core team & contributors. All rights reserved.
  Copyright (c) 2015-2016 Ask Solem & contributors. All rights reserved.
  Copyright (c) 2012-2014 GoPivotal, Inc.  All rights reserved.
  Copyright (c) 2009, 2010, 2011, 2012 Ask Solem, and individual contributors. All rights reserved.
  ```

## Test plan

- [ ] Confirm `LICENSE.md` renders correctly on GitHub.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.