### PR TITLE
Update docs site config and landing page for HTTPX2

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,0 @@
-www.python-httpx.org

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,41 +1,42 @@
-<p align="center" style="margin: 0 0 10px">
-  <img width="350" height="208" src="https://raw.githubusercontent.com/encode/httpx/master/docs/img/butterfly.png" alt='HTTPX'>
-</p>
-
 <h1 align="center" style="font-size: 3rem; margin: -15px 0">
-HTTPX
+HTTPX2
 </h1>
 
 ---
 
 <div align="center">
 <p>
-<a href="https://github.com/encode/httpx/actions">
-    <img src="https://github.com/encode/httpx/workflows/Test%20Suite/badge.svg" alt="Test Suite">
+<a href="https://github.com/pydantic/httpx2/actions">
+    <img src="https://github.com/pydantic/httpx2/workflows/Test%20Suite/badge.svg" alt="Test Suite">
 </a>
-<a href="https://pypi.org/project/httpx/">
-    <img src="https://badge.fury.io/py/httpx.svg" alt="Package version">
+<a href="https://pypi.org/project/httpx2/">
+    <img src="https://badge.fury.io/py/httpx2.svg" alt="Package version">
 </a>
 </p>
 
 <em>A next-generation HTTP client for Python.</em>
 </div>
 
-HTTPX is a fully featured HTTP client for Python 3, which provides sync and async APIs, and support for both HTTP/1.1 and HTTP/2.
+HTTPX2 is a fully featured HTTP client for Python 3, which provides sync and async APIs, and support for both HTTP/1.1 and HTTP/2.
+
+!!! note
+    HTTPX2 is a continuation of the wonderful work started by [@lovelydinosaur](https://github.com/lovelydinosaur) and the broader HTTPX community. We're enormously grateful for everything that has gone into HTTPX over the years - it has been a foundational piece of the modern Python ecosystem, and this project would not exist without it.
+
+    With HTTPX itself seeing limited activity recently, Pydantic Services is picking up stewardship under the HTTPX2 name so that users have a reliably maintained path forward - including timely security updates for a library that sits in the critical path of so many production systems. Our aim is to honour the original project's design, keep it stable for everyone relying on it, and continue evolving it carefully. Thank you to [@lovelydinosaur](https://github.com/lovelydinosaur) and every past contributor for laying such a strong foundation. 💙
 
 ---
 
-Install HTTPX using pip:
+Install HTTPX2 using pip:
 
 ```shell
-$ pip install httpx
+$ pip install httpx2
 ```
 
 Now, let's get started:
 
 ```pycon
->>> import httpx
->>> r = httpx.get('https://www.example.org/')
+>>> import httpx2
+>>> r = httpx2.get('https://www.example.org/')
 >>> r
 <Response [200 OK]>
 >>> r.status_code
@@ -50,20 +51,20 @@ Or, using the command-line client.
 
 ```shell
 # The command line client is an optional dependency.
-$ pip install 'httpx[cli]'
+$ pip install 'httpx2[cli]'
 ```
 
-Which now allows us to use HTTPX directly from the command-line...
+Which now allows us to use HTTPX2 directly from the command-line...
 
-![httpx --help](img/httpx-help.png)
+![httpx2 --help](img/httpx-help.png)
 
 Sending a request...
 
-![httpx http://httpbin.org/json](img/httpx-request.png)
+![httpx2 http://httpbin.org/json](img/httpx-request.png)
 
 ## Features
 
-HTTPX builds on the well-established usability of `requests`, and gives you:
+HTTPX2 builds on the well-established usability of `requests`, and gives you:
 
 * A broadly [requests-compatible API](compatibility.md).
 * Standard synchronous interface, but with [async support if you need it](async.md).
@@ -100,26 +101,26 @@ the [async support](async.md) section, or the [HTTP/2](http2.md) section.
 
 The [Developer Interface](api.md) provides a comprehensive API reference.
 
-To find out about tools that integrate with HTTPX, see [Third Party Packages](third_party_packages.md).
+To find out about tools that integrate with HTTPX2, see [Third Party Packages](third_party_packages.md).
 
 ## Dependencies
 
-The HTTPX project relies on these excellent libraries:
+The HTTPX2 project relies on these excellent libraries:
 
-* `httpcore` - The underlying transport implementation for `httpx`.
+* `httpcore2` - The underlying transport implementation for `httpx2`.
   * `h11` - HTTP/1.1 support.
+* `anyio` - Structured concurrency primitives, used to support both `asyncio` and `trio`.
 * `certifi` - SSL certificates.
 * `idna` - Internationalized domain name support.
-* `sniffio` - Async library autodetection.
 
 As well as these optional installs:
 
-* `h2` - HTTP/2 support. *(Optional, with `httpx[http2]`)*
-* `socksio` - SOCKS proxy support. *(Optional, with `httpx[socks]`)*
-* `rich` - Rich terminal support. *(Optional, with `httpx[cli]`)*
-* `click` - Command line client support. *(Optional, with `httpx[cli]`)*
-* `brotli` or `brotlicffi` - Decoding for "brotli" compressed responses. *(Optional, with `httpx[brotli]`)*
-* `zstandard` - Decoding for "zstd" compressed responses. *(Optional, with `httpx[zstd]`)*
+* `h2` - HTTP/2 support. *(Optional, with `httpx2[http2]`)*
+* `socksio` - SOCKS proxy support. *(Optional, with `httpx2[socks]`)*
+* `rich` - Rich terminal support. *(Optional, with `httpx2[cli]`)*
+* `click` - Command line client support. *(Optional, with `httpx2[cli]`)*
+* `brotli` or `brotlicffi` - Decoding for "brotli" compressed responses. *(Optional, with `httpx2[brotli]`)*
+* `zstandard` - Decoding for "zstd" compressed responses. *(Optional, with `httpx2[zstd]`)*
 
 A huge amount of credit is due to `requests` for the API layout that
 much of this work follows, as well as to `urllib3` for plenty of design
@@ -130,21 +131,19 @@ inspiration around the lower-level networking details.
 Install with pip:
 
 ```shell
-$ pip install httpx
+$ pip install httpx2
 ```
 
 Or, to include the optional HTTP/2 support, use:
 
 ```shell
-$ pip install httpx[http2]
+$ pip install httpx2[http2]
 ```
 
 To include the optional brotli and zstandard decoders support, use:
 
 ```shell
-$ pip install httpx[brotli,zstd]
+$ pip install httpx2[brotli,zstd]
 ```
 
-HTTPX requires Python 3.9+
-
-[sync-support]: https://github.com/encode/httpx/issues/572
+HTTPX2 requires Python 3.9+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,5 @@
-site_name: HTTPX
+site_name: HTTPX2
 site_description: A next-generation HTTP client for Python.
-site_url: https://www.python-httpx.org/
 
 theme:
     name: 'material'
@@ -18,8 +17,8 @@ theme:
           icon: 'material/lightbulb-outline'
           name: 'Switch to light mode'
 
-repo_name: encode/httpx
-repo_url: https://github.com/encode/httpx/
+repo_name: pydantic/httpx2
+repo_url: https://github.com/pydantic/httpx2/
 edit_uri: ""
 
 nav:


### PR DESCRIPTION
## Summary

- `mkdocs.yml`: rename `site_name` to `HTTPX2`, point `repo_name`/`repo_url` at `pydantic/httpx2`, and drop the `site_url` (no production domain decided yet).
- Delete `docs/CNAME` so the site no longer claims the encode-owned `www.python-httpx.org` domain. Docs will publish at the default GitHub Pages URL until a Pydantic-owned domain is wired up.
- Update the docs landing page (`docs/index.md`) to mirror the README: HTTPX2 branding, no encode butterfly logo, badges and links pointing at `pydantic/httpx2`, install/import/CLI examples using `httpx2`, and a dependency list matching the current `pyproject.toml` (drop `sniffio`, add `anyio`, rename `httpcore` to `httpcore2`). Includes the same acknowledgement note as the README, adapted to mkdocs admonition syntax.
- Scope is intentionally narrow: site config + landing page only. The rest of the docs still reference the original `httpx` package name and will be renamed in a follow-up.

## Test plan

- [ ] Run `mkdocs build` (or `scripts/build`) locally and confirm the site renders without broken links on the landing page.
- [ ] Visually inspect the landing page in the rendered site.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.