### PR TITLE
Add 7-day cooldown for dependency resolution via uv exclude-newer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 package = false
 default-groups = ["dev", "docs", "bench"]
 required-version = ">=0.8.6"
+exclude-newer = "7 days"
 
 [tool.uv.workspace]
 members = ["src/httpx2", "src/httpcore2"]


### PR DESCRIPTION
## Summary

- Adds `exclude-newer = "7 days"` to `[tool.uv]` in `pyproject.toml`.
- Mirrors a dependabot-style 7-day cooldown: uv will skip package versions uploaded within the last 7 days when resolving dependencies, giving freshly released versions time to shake out before they land here.
- uv supports relative durations directly for this setting, so no extra tooling is needed.

Ref: https://docs.astral.sh/uv/reference/settings/#exclude-newer

## Test plan

- [ ] `uv lock` resolves successfully with the new setting.
- [ ] CI passes.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.