### PR TITLE
Add zizmor GitHub Actions security analysis workflow

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,27 @@
+name: GitHub Actions Security Analysis
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+      contents: read # Only needed for private repos. Needed to clone the repo.
+      actions: read # Only needed for private repos. Needed for upload-sarif to read workflow run info.
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -14,8 +14,6 @@ jobs:
 
     permissions:
       security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
-      contents: read # Only needed for private repos. Needed to clone the repo.
-      actions: read # Only needed for private repos. Needed for upload-sarif to read workflow run info.
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/zizmor.yml` to run [zizmor](https://github.com/zizmorcore/zizmor) on push to `main` and on pull requests.
- Mirrors the workflow used in [uvicorn](https://github.com/Kludex/uvicorn/blob/main/.github/workflows/zizmor.yml), with pinned SHAs for `actions/checkout` and `zizmor-action`, `permissions: {}` at the top level, and only the permissions zizmor needs scoped to the job.
- Findings are uploaded as SARIF and surface in GitHub's code-scanning UI.

## Test plan

- [ ] Workflow runs on this PR and reports any findings without failing the merge gate unexpectedly.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.