### PR TITLE
Update Python version requirement from 3.9+ to 3.10+ in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Or, to include the optional HTTP/2 support, use:
 pip install httpx2[http2]
 ```
 
-HTTPX2 requires Python 3.9+.
+HTTPX2 requires Python 3.10+.
 
 ## Documentation
 

--- a/docs/async.md
+++ b/docs/async.md
@@ -23,7 +23,7 @@ To make asynchronous requests, you'll need an `AsyncClient`.
 ```
 
 !!! tip
-    Use [IPython](https://ipython.readthedocs.io/en/stable/) or Python 3.9+ with `python -m asyncio` to try this code interactively, as they support executing `async`/`await` expressions in the console.
+    Use [IPython](https://ipython.readthedocs.io/en/stable/) or Python 3.10+ with `python -m asyncio` to try this code interactively, as they support executing `async`/`await` expressions in the console.
 
 ## API Differences
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -146,4 +146,4 @@ To include the optional brotli and zstandard decoders support, use:
 pip install 'httpx2[brotli,zstd]'
 ```
 
-HTTPX2 requires Python 3.9+
+HTTPX2 requires Python 3.10+


### PR DESCRIPTION
## Summary
- Follow-up to 37447d0 which dropped Python 3.9 support
- Update remaining `Python 3.9+` references to `Python 3.10+` in `README.md`, `docs/index.md`, and `docs/async.md`

## Test plan
- [ ] Verify the three files render correctly on the docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)