### PR TITLE
Bundle LICENSE.md in httpx2 and httpcore2 sdists

### DIFF
--- a/src/httpcore2/LICENSE.md
+++ b/src/httpcore2/LICENSE.md
@@ -1,3 +1,4 @@
+Copyright © 2026 to present Pydantic Services Inc. and individual contributors.
 Copyright © 2020, [Encode OSS Ltd](https://www.encode.io/).
 All rights reserved.
 

--- a/src/httpcore2/pyproject.toml
+++ b/src/httpcore2/pyproject.toml
@@ -67,6 +67,7 @@ Source = "https://github.com/encode/httpcore"
 include = [
     "/httpcore2",
     "/CHANGELOG.md",
+    "/LICENSE.md",
     "/README.md",
     "/tests"
 ]

--- a/src/httpx2/pyproject.toml
+++ b/src/httpx2/pyproject.toml
@@ -83,6 +83,7 @@ include = ["/httpx2"]
 [tool.hatch.build.targets.sdist.force-include]
 "../../README.md" = "README.md"
 "../../CHANGELOG.md" = "CHANGELOG.md"
+"../../LICENSE.md" = "LICENSE.md"
 
 [tool.hatch.build.targets.wheel]
 packages = ["httpx2"]


### PR DESCRIPTION
The `httpx2` PyPI sdist did not include `LICENSE.md` (its `force-include` only pulled `README.md` and `CHANGELOG.md` from the repo root). The `httpcore2` sdist included it implicitly; this makes it explicit. Required by downstream packagers - the in-flight conda-forge recipe currently has to fetch `LICENSE.md` from the GitHub tag as a second source.

Also adds the Pydantic Services Inc. copyright line to `src/httpcore2/LICENSE.md` so it matches the repo-root `LICENSE.md`.

Verified locally with `uv build --sdist --package httpx2` and `--package httpcore2` - both tarballs now contain `LICENSE.md`.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.