### PR TITLE
Add uv lock --check to scripts/check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ package = false
 default-groups = ["dev", "docs", "bench"]
 required-version = ">=0.8.6"
 exclude-newer = "7 days"
-exclude-newer-package = { urllib3 = "2026-05-08", zensical = "2026-05-10" }
+exclude-newer-package = { urllib3 = "2026-05-09T00:00:00Z", zensical = "2026-05-11T00:00:00Z" }
 
 [tool.uv.workspace]
 members = ["src/httpx2", "src/httpcore2"]

--- a/scripts/check
+++ b/scripts/check
@@ -4,6 +4,7 @@ export SOURCE_FILES="src/httpx2 tests/httpx2"
 
 set -x
 
+uv lock --check
 uv run ruff format --check --diff $SOURCE_FILES
 uv run mypy $SOURCE_FILES
 uv run ruff check $SOURCE_FILES

--- a/uv.lock
+++ b/uv.lock
@@ -13,8 +13,8 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-urllib3 = "2026-05-08T22:00:00Z"
-zensical = "2026-05-10T22:00:00Z"
+urllib3 = "2026-05-09T07:00:00Z"
+zensical = "2026-05-11T07:00:00Z"
 
 [manifest]
 members = [

--- a/uv.lock
+++ b/uv.lock
@@ -13,8 +13,8 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-urllib3 = "2026-05-09T07:00:00Z"
-zensical = "2026-05-11T07:00:00Z"
+urllib3 = "2026-05-09T00:00:00Z"
+zensical = "2026-05-11T00:00:00Z"
 
 [manifest]
 members = [


### PR DESCRIPTION
## Summary

- Run `uv lock --check` from `scripts/check` so out-of-sync `uv.lock` files are caught locally and in CI rather than silently re-resolving on each `uv run`.

## Test plan

- [x] `./scripts/check` passes locally

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.