### PR TITLE
Prepare 2.1.0 CHANGELOG entries

### DIFF
--- a/src/httpcore2/CHANGELOG.md
+++ b/src/httpcore2/CHANGELOG.md
@@ -4,7 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
+## 2.1.0 (May 15th, 2026)
+
+### Removed
+
+* Drop support for Python 3.8 and 3.9. ([#208](https://github.com/pydantic/httpx2/pull/208))
+
+### Added
+
+* Add support for Python 3.14. ([#208](https://github.com/pydantic/httpx2/pull/208))
+* Bundle `LICENSE.md` in the sdist. ([#938](https://github.com/pydantic/httpx2/pull/938))
 
 ### Fixed
 

--- a/src/httpx2/CHANGELOG.md
+++ b/src/httpx2/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2.1.0 (May 15th, 2026)
+
+### Removed
+
+* Drop support for Python 3.9. ([#208](https://github.com/pydantic/httpx2/pull/208))
+
+### Added
+
+* Add support for Python 3.14. ([#208](https://github.com/pydantic/httpx2/pull/208))
+* Use stdlib `compression.zstd` for Zstd decompression on Python 3.14+; fall back to the `zstandard` package on older versions. ([#932](https://github.com/pydantic/httpx2/pull/932))
+* Bundle `LICENSE.md` in the sdist. ([#938](https://github.com/pydantic/httpx2/pull/938))
+
 ## 2.0.0
 
 Official first release of `httpx2`. No changes since `2.0.0b1`.


### PR DESCRIPTION
## Summary

- Add `2.1.0 (May 15th, 2026)` section to `src/httpcore2/CHANGELOG.md`: drop Python 3.8/3.9, add 3.14, bundle `LICENSE.md` in sdist, and the HTTP/2 flow-control fix from #935.
- Add `2.1.0 (May 15th, 2026)` section to `src/httpx2/CHANGELOG.md`: drop Python 3.9, add 3.14, use stdlib `compression.zstd` on 3.14+, bundle `LICENSE.md` in sdist.

## Test plan

- [x] Confirm entries match the user-facing changes since the 2.0.0 tag.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.