### PR TITLE
Handle multi-frame zstd streams split across chunks

### DIFF
--- a/src/httpx2/httpx2/_decoders.py
+++ b/src/httpx2/httpx2/_decoders.py
@@ -199,9 +199,14 @@ class ZStandardDecoder(ContentDecoder):
         self.seen_data = False
 
     def decode(self, data: bytes) -> bytes:
+        if not data:
+            return b""
         self.seen_data = True
         output = io.BytesIO()
         try:
+            if self.decompressor.eof:
+                data = self.decompressor.unused_data + data
+                self.decompressor = ZstdDecompressor()
             output.write(self.decompressor.decompress(data))
             while self.decompressor.eof and self.decompressor.unused_data:
                 unused_data = self.decompressor.unused_data

--- a/tests/httpx2/test_decoders.py
+++ b/tests/httpx2/test_decoders.py
@@ -146,6 +146,38 @@ def test_zstd_multiframe():
     assert response.content == b"foobar"
 
 
+def test_zstd_streaming_multiple_frames():
+    body1 = b"test 123 "
+    body2 = b"another frame"
+
+    # Create two separate complete frames
+    frame1 = zstd.compress(body1)
+    frame2 = zstd.compress(body2)
+
+    # Create an iterator that yields frames separately
+    def content_iterator() -> typing.Iterator[bytes]:
+        yield frame1
+        yield frame2
+
+    headers = [(b"Content-Encoding", b"zstd")]
+    response = httpx2.Response(200, headers=headers, content=content_iterator())
+    response.read()
+
+    assert response.content == body1 + body2
+
+
+def test_zstd_empty_decode_after_eof():
+    # An empty `decode(b"")` after a complete frame must not raise EOFError on
+    # stdlib `compression.zstd`. This path is reached via `MultiDecoder.flush()`,
+    # which feeds b"" through each child to drain residue across stacked encodings.
+    body = b"test 123"
+    compressed_body = zstd.compress(body)
+
+    headers = [(b"Content-Encoding", b"zstd, identity")]
+    response = httpx2.Response(200, headers=headers, content=compressed_body)
+    assert response.content == body
+
+
 def test_multi():
     body = b"test 123"
 


### PR DESCRIPTION
Fixes https://github.com/encode/httpx/discussions/3538

Without this, zstandard decompression is broken on some servers, such as for instance

```
Python 3.14.4 (main, Apr 14 2026, 14:26:14) [Clang 22.1.3 ] on linux
>>> import httpx2; httpx2.get('https://help.netflix.com/en/node/30081')
...
EOFError: Already at the end of a Zstandard frame.
```

This is extra important since httpx2 now automatically adds zstd content decoding because it uses built-in zstandard instead of only being active when the package is installed!
