### PR TITLE
Version 2.2.0

### DIFF
--- a/src/httpcore2/CHANGELOG.md
+++ b/src/httpcore2/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2.2.0 (May 16th, 2026)
+
+No changes since `2.1.0`. Version bumped to stay in lockstep with `httpx2`.
+
 ## 2.1.0 (May 15th, 2026)
 
 ### Removed

--- a/src/httpx2/CHANGELOG.md
+++ b/src/httpx2/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2.2.0 (May 16th, 2026)
+
+### Fixed
+
+* Handle multi-frame zstd streams split across chunks. ([#946](https://github.com/pydantic/httpx2/pull/946))
+
+### Changed
+
+* Lazily import the `_main` CLI module to speed up `import httpx2`. ([#947](https://github.com/pydantic/httpx2/pull/947))
+
 ## 2.1.0 (May 15th, 2026)
 
 ### Removed


### PR DESCRIPTION
## Summary

- `httpx2` 2.2.0: fix multi-frame zstd streams split across chunks (#946); lazy import of the `_main` CLI module (#947).
- `httpcore2` 2.2.0: no functional changes; version bumped to stay in lockstep with `httpx2` (which pins `httpcore2==<same version>`).

## Test plan

- [ ] CI green on this branch
- [ ] After merge, tag `v2.2.0` to trigger the release workflow

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.