### PR TITLE
Disable credential persistence in test suite checkout

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0


### PR DESCRIPTION
## Summary

Resolves zizmor `artipacked` finding [code-scanning/1](https://github.com/pydantic/httpx2/security/code-scanning/1).

`actions/checkout` defaults to `persist-credentials: true`, leaving the `GITHUB_TOKEN` on disk in `.git/config` where subsequent steps (or anything that uploads the workspace as an artifact) could leak it. The test suite doesn't push, so credentials aren't needed. `publish.yml` and `zizmor.yml` already set `persist-credentials: false`; this brings `main.yml` in line.

## Test plan

- [ ] CI green
- [ ] Code-scanning alert auto-closes on next zizmor run against `main`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.