### PR TITLE
Allow `default_encoding` callable to return None

### DIFF
--- a/src/httpx2/httpx2/_client.py
+++ b/src/httpx2/httpx2/_client.py
@@ -189,7 +189,7 @@ class BaseClient:
         event_hooks: None | (typing.Mapping[str, list[EventHook]]) = None,
         base_url: URL | str = "",
         trust_env: bool = True,
-        default_encoding: str | typing.Callable[[bytes], str] = "utf-8",
+        default_encoding: str | typing.Callable[[bytes], str | None] = "utf-8",
     ) -> None:
         event_hooks = {} if event_hooks is None else event_hooks
 
@@ -628,7 +628,7 @@ class Client(BaseClient):
         event_hooks: None | (typing.Mapping[str, list[EventHook]]) = None,
         base_url: URL | str = "",
         transport: BaseTransport | None = None,
-        default_encoding: str | typing.Callable[[bytes], str] = "utf-8",
+        default_encoding: str | typing.Callable[[bytes], str | None] = "utf-8",
     ) -> None:
         super().__init__(
             auth=auth,
@@ -1330,7 +1330,7 @@ class AsyncClient(BaseClient):
         base_url: URL | str = "",
         transport: AsyncBaseTransport | None = None,
         trust_env: bool = True,
-        default_encoding: str | typing.Callable[[bytes], str] = "utf-8",
+        default_encoding: str | typing.Callable[[bytes], str | None] = "utf-8",
     ) -> None:
         super().__init__(
             auth=auth,

--- a/src/httpx2/httpx2/_models.py
+++ b/src/httpx2/httpx2/_models.py
@@ -507,7 +507,7 @@ class Response:
         request: Request | None = None,
         extensions: ResponseExtensions | None = None,
         history: list[Response] | None = None,
-        default_encoding: str | typing.Callable[[bytes], str] = "utf-8",
+        default_encoding: str | typing.Callable[[bytes], str | None] = "utf-8",
     ) -> None:
         self.status_code = status_code
         self.headers = Headers(headers)


### PR DESCRIPTION
## Summary

Widens `default_encoding`'s callable signature from `Callable[[bytes], str]` to `Callable[[bytes], str | None]`. `Response.encoding` already handles a `None` return via the `encoding or "utf-8"` fallback at the end of the property, and our own `docs/advanced/text-encodings.md` example uses `chardet.detect(content).get("encoding")`, which can return `None`.

Backport of upstream [encode/httpx#3079](https://github.com/encode/httpx/pull/3079) by @JelleZijlstra (still open upstream, but the change is straightforwardly correct).

## Test plan

- [x] `mypy` passes
- [ ] CI green

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.