### PR TITLE
Avoid expensive cookie truthiness checks

### DIFF
--- a/src/httpx2/httpx2/_client.py
+++ b/src/httpx2/httpx2/_client.py
@@ -396,11 +396,15 @@ class BaseClient:
         Merge a cookies argument together with any cookies on the client,
         to create the cookies used for the outgoing request.
         """
-        if cookies or self.cookies:
-            merged_cookies = Cookies(self.cookies)
-            merged_cookies.update(cookies)
-            return merged_cookies
-        return cookies
+        if cookies is None:
+            return Cookies(self.cookies) if self.cookies else None
+
+        if not self.cookies:
+            return Cookies(cookies)
+
+        merged_cookies = Cookies(self.cookies)
+        merged_cookies.update(cookies)
+        return merged_cookies
 
     def _merge_headers(self, headers: HeaderTypes | None = None) -> HeaderTypes | None:
         """

--- a/src/httpx2/httpx2/_models.py
+++ b/src/httpx2/httpx2/_models.py
@@ -1190,6 +1190,13 @@ class Cookies(typing.MutableMapping[str, str]):
         return (cookie.name for cookie in self.jar)
 
     def __bool__(self) -> bool:
+        cookie_store = getattr(self.jar, "_cookies", None)
+        if cookie_store is not None:
+            cookie_store = typing.cast(dict[str, dict[str, dict[str, Cookie]]], cookie_store)
+            return any(
+                path_cookies for domain_cookies in cookie_store.values() for path_cookies in domain_cookies.values()
+            )
+
         for _ in self.jar:
             return True
         return False

--- a/tests/httpx2/client/test_cookies.py
+++ b/tests/httpx2/client/test_cookies.py
@@ -45,6 +45,25 @@ def test_set_per_request_cookie_is_deprecated() -> None:
     assert response.json() == {"cookies": "example-name=example-value"}
 
 
+def test_set_per_request_cookie_merges_with_client_cookies() -> None:
+    url = "http://example.org/echo_cookies"
+    cookies = {"request-name": "request-value"}
+
+    client = httpx2.Client(
+        cookies={"client-name": "client-value"},
+        transport=httpx2.MockTransport(get_and_set_cookies),
+    )
+    with pytest.warns(DeprecationWarning):
+        response = client.get(url, cookies=cookies)
+
+    assert response.status_code == 200
+    cookie_header = response.json()["cookies"]
+    assert set(cookie_header.split("; ")) == {
+        "client-name=client-value",
+        "request-name=request-value",
+    }
+
+
 def test_set_cookie_with_cookiejar() -> None:
     """
     Send a request including a cookie, using a `CookieJar` instance.

--- a/tests/httpx2/models/test_cookies.py
+++ b/tests/httpx2/models/test_cookies.py
@@ -1,4 +1,5 @@
 import http
+from collections.abc import Iterator
 
 import pytest
 
@@ -6,8 +7,40 @@ import httpx2
 
 
 class NonIterableCookieJar(http.cookiejar.CookieJar):
-    def __iter__(self):
-        raise AssertionError("CookieJar.__iter__ should not be used for truthiness")
+    def __iter__(self) -> Iterator[http.cookiejar.Cookie]:
+        raise AssertionError("CookieJar.__iter__ should not be used for truthiness")  # pragma: no cover
+
+
+class IterableOnlyCookieJar(http.cookiejar.CookieJar):
+    def __init__(self, cookies: list[http.cookiejar.Cookie]) -> None:
+        super().__init__()
+        self._iter_cookies = cookies
+        delattr(self, "_cookies")
+
+    def __iter__(self) -> Iterator[http.cookiejar.Cookie]:
+        return iter(self._iter_cookies)
+
+
+def make_cookie(name: str = "name", value: str = "value") -> http.cookiejar.Cookie:
+    return http.cookiejar.Cookie(
+        version=0,
+        name=name,
+        value=value,
+        port=None,
+        port_specified=False,
+        domain="",
+        domain_specified=False,
+        domain_initial_dot=False,
+        path="/",
+        path_specified=True,
+        secure=False,
+        expires=None,
+        discard=True,
+        comment=None,
+        comment_url=None,
+        rest={"HttpOnly": ""},
+        rfc2109=False,
+    )
 
 
 def test_cookies():
@@ -34,6 +67,11 @@ def test_cookies_bool_does_not_iterate_cookie_jar():
     cookies.set("name", "value")
 
     assert bool(cookies) is True
+
+
+def test_cookies_bool_iterates_custom_cookie_jar_without_cookie_store():
+    assert bool(httpx2.Cookies(IterableOnlyCookieJar([]))) is False
+    assert bool(httpx2.Cookies(IterableOnlyCookieJar([make_cookie()]))) is True
 
 
 def test_cookies_update():

--- a/tests/httpx2/models/test_cookies.py
+++ b/tests/httpx2/models/test_cookies.py
@@ -5,6 +5,11 @@ import pytest
 import httpx2
 
 
+class NonIterableCookieJar(http.cookiejar.CookieJar):
+    def __iter__(self):
+        raise AssertionError("CookieJar.__iter__ should not be used for truthiness")
+
+
 def test_cookies():
     cookies = httpx2.Cookies({"name": "value"})
     assert cookies["name"] == "value"
@@ -18,6 +23,17 @@ def test_cookies():
     assert len(cookies) == 0
     assert dict(cookies) == {}
     assert bool(cookies) is False
+
+
+def test_cookies_bool_does_not_iterate_cookie_jar():
+    jar = NonIterableCookieJar()
+    cookies = httpx2.Cookies(jar)
+
+    assert bool(cookies) is False
+
+    cookies.set("name", "value")
+
+    assert bool(cookies) is True
 
 
 def test_cookies_update():


### PR DESCRIPTION
## Summary

Fixes #783 by avoiding expensive cookie truthiness checks in the request cookie merge path.

- avoids truth-testing arbitrary per-request cookie inputs before merging
- makes `Cookies.__bool__` use the `CookieJar` internal cookie store when available instead of iterating through `deepvalues`
- keeps an iterator fallback for custom jars without the stdlib `_cookies` store
- adds regression coverage for the fast path, fallback path, and client/request cookie merging

## Root Cause

`CookieJar.__iter__` walks the nested cookie store via `http.cookiejar.deepvalues`. Both `BaseClient._merge_cookies()` and request construction can hit cookie truthiness checks on hot paths, so checking for cookie presence should avoid that traversal when the jar exposes its internal store.

## Validation

- `uv run --frozen python -m pytest -q tests/httpx2/models/test_cookies.py::test_cookies_bool_does_not_iterate_cookie_jar tests/httpx2/models/test_cookies.py::test_cookies_bool_iterates_custom_cookie_jar_without_cookie_store tests/httpx2/client/test_cookies.py::test_set_per_request_cookie_merges_with_client_cookies`
- `uv run --frozen python -m pytest -q tests/httpx2/models/test_cookies.py tests/httpx2/client/test_cookies.py`
- `scripts/check`
- `uv run --frozen python -m pytest -q tests/httpx2` (`1422 passed, 1 skipped`)
- `python -m compileall -q src/httpx2/httpx2/_client.py src/httpx2/httpx2/_models.py tests/httpx2/client/test_cookies.py tests/httpx2/models/test_cookies.py`
- `git diff --check origin/main...HEAD && git diff --check`

Upstream CI is also green for Python 3.10 through 3.14, the check job, and security analysis.

Microbenchmark on this branch, 1,000 cookies and 200,000 truthiness checks:

- old truthiness loop: 1.020991s, 5.105 us/op
- new truthiness: 0.303790s, 1.519 us/op
- speedup: 3.36x