### PR TITLE
Bump sync_stream_write benchmark payload to 64MB

### DIFF
--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -96,7 +96,7 @@ def test_bench_client_stream_download() -> None:
 
 
 def test_bench_sync_stream_write_large() -> None:
-    payload = b"x" * 4 * 1024 * 1024  # 4 MB
+    payload = b"x" * 64 * 1024 * 1024  # 64 MB
     reader_sock, writer_sock = socket.socketpair()
     try:
         # Small kernel buffers + small reader chunks force many partial sends on Linux,


### PR DESCRIPTION
## Summary

- The 4MB payload in `test_bench_sync_stream_write_large` wasn't forcing enough partial sends on the CodSpeed Macro Runner to expose the buffer-slicing cost that #954 optimizes.
- Bumping to 64MB guarantees many partial-send iterations regardless of how the kernel sizes SO_SNDBUF, which is the path the memoryview optimization targets.

## Test plan

- [ ] CodSpeed walltime run completes on this PR
- [ ] Re-run #954 with main updated to this commit and confirm the memoryview change now shows a measurable improvement on `test_bench_sync_stream_write_large`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.