### PR TITLE
Switch benchmarks to real HTTP roundtrips against a localhost WSGI server

### DIFF
--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -19,8 +19,8 @@ LARGE_JSON: dict[str, object] = {
     ],
 }
 LARGE_JSON_BODY = json.dumps(LARGE_JSON).encode()
-LARGE_UPLOAD_BODY = b"x" * 4 * 1024 * 1024  # 4 MB
-LARGE_DOWNLOAD_BODY = b"y" * 4 * 1024 * 1024  # 4 MB
+LARGE_UPLOAD_BODY = b"x" * 16 * 1024 * 1024  # 16 MB
+LARGE_DOWNLOAD_BODY = b"y" * 16 * 1024 * 1024  # 16 MB
 
 
 class _SilentHandler(WSGIRequestHandler):
@@ -67,24 +67,29 @@ def test_bench_url_parse_and_join() -> None:
 
 
 def test_bench_request_build_json() -> None:
-    for _ in range(256):
+    for _ in range(32):
         httpx2.Request("POST", "https://example.org/api", json=LARGE_JSON)
 
 
 def test_bench_client_get_json(server: str) -> None:
     with httpx2.Client(base_url=server) as client:
-        for _ in range(16):
+        client.get("/json")  # warmup: establish connection + prime caches
+        for _ in range(32):
             client.get("/json").json()
 
 
 def test_bench_client_post_large(server: str) -> None:
     with httpx2.Client(base_url=server) as client:
+        client.post("/upload", content=LARGE_UPLOAD_BODY)  # warmup
         for _ in range(8):
             client.post("/upload", content=LARGE_UPLOAD_BODY)
 
 
 def test_bench_client_stream_download(server: str) -> None:
     with httpx2.Client(base_url=server) as client:
+        with client.stream("GET", "/download") as response:  # warmup
+            for _ in response.iter_bytes(chunk_size=65536):
+                pass
         for _ in range(8):
             with client.stream("GET", "/download") as response:
                 for _ in response.iter_bytes(chunk_size=65536):

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,128 +1,97 @@
 from __future__ import annotations
 
-import gzip
-import io
 import json
-import socket
 import threading
+from collections.abc import Callable, Generator, Iterable
+from typing import Any
+from wsgiref.simple_server import WSGIRequestHandler, WSGIServer, make_server
 
 import pytest
 
 import httpx2
-from httpcore2._backends.sync import SyncStream
 
 pytestmark = pytest.mark.benchmark
 
-TYPICAL_URL = "https://www.example.org:8443/path/to/resource?key=value&other=1#frag"
-
-HEADERS: list[tuple[str, str]] = [
-    ("host", "example.org"),
-    ("user-agent", "httpx2-bench/1.0"),
-    ("accept", "*/*"),
-    ("accept-encoding", "gzip, deflate, br"),
-    *[(f"x-custom-{i}", f"value-{i}") for i in range(16)],
-]
-
-SMALL_JSON: dict[str, object] = {
-    "id": 12345,
-    "items": [{"sku": f"SKU-{i}", "qty": i, "price": i * 1.5} for i in range(50)],
-}
 LARGE_JSON: dict[str, object] = {
     "records": [
         {"id": i, "name": f"record-{i}", "tags": [f"t{j}" for j in range(8)], "active": bool(i % 2)}
         for i in range(2048)
     ],
 }
-SMALL_JSON_BODY = json.dumps(SMALL_JSON).encode()
 LARGE_JSON_BODY = json.dumps(LARGE_JSON).encode()
-GZIPPED_LARGE_JSON_BODY = gzip.compress(LARGE_JSON_BODY)
+LARGE_UPLOAD_BODY = b"x" * 4 * 1024 * 1024  # 4 MB
+LARGE_DOWNLOAD_BODY = b"y" * 4 * 1024 * 1024  # 4 MB
 
 
-def test_bench_url_join() -> None:
-    base = httpx2.URL(TYPICAL_URL)
+class _SilentHandler(WSGIRequestHandler):
+    def log_message(self, format: str, *args: Any) -> None:
+        pass
+
+
+StartResponse = Callable[[str, list[tuple[str, str]]], Any]
+
+
+def _app(environ: dict[str, Any], start_response: StartResponse) -> Iterable[bytes]:
+    path = environ.get("PATH_INFO", "/")
+    content_length = int(environ.get("CONTENT_LENGTH") or 0)
+    if content_length:
+        environ["wsgi.input"].read(content_length)
+    if path == "/download":
+        body = LARGE_DOWNLOAD_BODY
+        headers = [("content-type", "application/octet-stream"), ("content-length", str(len(body)))]
+    else:
+        body = LARGE_JSON_BODY
+        headers = [("content-type", "application/json"), ("content-length", str(len(body)))]
+    start_response("200 OK", headers)
+    return [body]
+
+
+@pytest.fixture(scope="module")
+def server() -> Generator[str, None, None]:
+    httpd: WSGIServer = make_server("127.0.0.1", 0, _app, handler_class=_SilentHandler)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    try:
+        host, port = httpd.server_address[:2]
+        yield f"http://{host!s}:{port}"
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join()
+
+
+def test_bench_url_parse_and_join() -> None:
+    base = httpx2.URL("https://www.example.org:8443/path/to/resource?key=value&other=1#frag")
     for _ in range(1024):
-        base.join("/path/to/resource?key=value")
+        base.join("/another/path?x=1&y=2")
 
 
-def test_bench_request_json_post() -> None:
+def test_bench_request_build_json() -> None:
     for _ in range(256):
-        httpx2.Request("POST", TYPICAL_URL, headers=HEADERS, json=SMALL_JSON)
+        httpx2.Request("POST", "https://example.org/api", json=LARGE_JSON)
 
 
-def test_bench_request_multipart() -> None:
-    for _ in range(64):
-        request = httpx2.Request(
-            "POST",
-            "https://example.org/upload",
-            data={"name": "value", "other": "field", "description": "a longer text field"},
-            files={
-                "small": ("hello.txt", b"x" * 4096, "text/plain"),
-                "large": ("payload.bin", io.BytesIO(b"y" * 65536), "application/octet-stream"),
-            },
-        )
-        request.read()
-
-
-def test_bench_response_gzip_decode_large() -> None:
-    for _ in range(64):
-        response = httpx2.Response(
-            200,
-            headers=[("content-type", "application/json"), ("content-encoding", "gzip")],
-            content=GZIPPED_LARGE_JSON_BODY,
-        )
-        response.read()
-
-
-def _large_json_handler(request: httpx2.Request) -> httpx2.Response:
-    return httpx2.Response(200, content=LARGE_JSON_BODY, headers=[("content-type", "application/json")])
-
-
-def _stream_handler(request: httpx2.Request) -> httpx2.Response:
-    return httpx2.Response(200, content=b"x" * 1024 * 1024)
-
-
-def test_bench_client_post_large_json() -> None:
-    with httpx2.Client(transport=httpx2.MockTransport(_large_json_handler)) as client:
+def test_bench_client_get_json(server: str) -> None:
+    with httpx2.Client(base_url=server) as client:
         for _ in range(16):
-            client.post(TYPICAL_URL, json=LARGE_JSON).json()
+            client.get("/json").json()
 
 
-def test_bench_client_stream_download() -> None:
-    with httpx2.Client(transport=httpx2.MockTransport(_stream_handler)) as client:
-        for _ in range(16):
-            with client.stream("GET", TYPICAL_URL) as response:
-                for _ in response.iter_bytes(chunk_size=8192):
+def test_bench_client_post_large(server: str) -> None:
+    with httpx2.Client(base_url=server) as client:
+        for _ in range(8):
+            client.post("/upload", content=LARGE_UPLOAD_BODY)
+
+
+def test_bench_client_stream_download(server: str) -> None:
+    with httpx2.Client(base_url=server) as client:
+        for _ in range(8):
+            with client.stream("GET", "/download") as response:
+                for _ in response.iter_bytes(chunk_size=65536):
                     pass
 
 
-def test_bench_sync_stream_write_large() -> None:
-    payload = b"x" * 64 * 1024 * 1024  # 64 MB
-    reader_sock, writer_sock = socket.socketpair()
-    try:
-        # Small kernel buffers + small reader chunks force many partial sends on Linux,
-        # which is what exercises the buffer-slicing loop inside SyncStream.write.
-        writer_sock.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 8192)
-        reader_sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 8192)
-
-        drained: list[int] = []
-
-        def drain() -> None:
-            total = 0
-            while True:
-                chunk = reader_sock.recv(8192)
-                if not chunk:
-                    break
-                total += len(chunk)
-            drained.append(total)
-
-        thread = threading.Thread(target=drain)
-        thread.start()
-
-        stream = SyncStream(writer_sock)
-        stream.write(payload)
-        stream.close()
-        thread.join()
-
-        assert drained == [len(payload)]
-    finally:
-        reader_sock.close()
+def test_bench_client_keepalive_burst(server: str) -> None:
+    with httpx2.Client(base_url=server) as client:
+        for _ in range(64):
+            client.get("/json")


### PR DESCRIPTION
## Summary

- The previous suite mixed pure-Python microbenchmarks (URL parsing, header construction) with MockTransport-based "client" benchmarks that short-circuited every transport-layer code path. Optimisations to the network backends (e.g. #954) could not be detected because MockTransport never touches `httpcore2._backends`.
- This PR replaces the suite with six benchmarks that exercise the user-facing path: a tiny in-process WSGI server runs on a random localhost port, and the benchmarks drive a real `httpx2.Client` against it. The whole stack runs - Client, Transport, connection pool, real sockets - so any optimisation along that path now produces a measurable signal.

## Benchmarks

- `test_bench_url_parse_and_join` - pure CPU, URL parse + join regression canary.
- `test_bench_request_build_json` - request construction + JSON encode.
- `test_bench_client_get_json` - GET a moderate JSON response from the real server.
- `test_bench_client_post_large` - POST 4MB through the full client (exercises socket write).
- `test_bench_client_stream_download` - stream 4MB from the server (exercises socket read).
- `test_bench_client_keepalive_burst` - 64 sequential GETs over a kept-alive connection.

## Test plan

- [ ] CodSpeed walltime CI runs cleanly on this PR
- [ ] Re-run #954 against main with this suite in place and confirm regressions/improvements at the socket layer now register

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.