### PR TITLE
Remove explicit Python version requirements from Markdown docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,6 @@ Or, to include the optional HTTP/2 support, use:
 pip install httpx2[http2]
 ```
 
-HTTPX2 requires Python 3.10+.
-
 ## Documentation
 
 Project documentation is available at [https://httpx2.pydantic.dev/](https://httpx2.pydantic.dev/).

--- a/docs/async.md
+++ b/docs/async.md
@@ -23,7 +23,7 @@ To make asynchronous requests, you'll need an `AsyncClient`.
 ```
 
 !!! tip
-    Use [IPython](https://ipython.readthedocs.io/en/stable/) or Python 3.10+ with `python -m asyncio` to try this code interactively, as they support executing `async`/`await` expressions in the console.
+    Use [IPython](https://ipython.readthedocs.io/en/stable/) or Python with `python -m asyncio` to try this code interactively, as they support executing `async`/`await` expressions in the console.
 
 ## API Differences
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -143,5 +143,3 @@ To include the optional brotli and zstandard decoders support, use:
 ```shell
 pip install 'httpx2[brotli,zstd]'
 ```
-
-HTTPX2 requires Python 3.10+

--- a/src/httpcore2/README.md
+++ b/src/httpcore2/README.md
@@ -23,10 +23,6 @@ Some things HTTP Core does do:
 * Provides both sync and async interfaces.
 * Async backend support for `asyncio` and `trio`.
 
-## Requirements
-
-Python 3.8+
-
 ## Installation
 
 For HTTP/1.1 only support, install with:

--- a/src/httpcore2/docs/index.md
+++ b/src/httpcore2/docs/index.md
@@ -23,10 +23,6 @@ Some things HTTP Core does do:
 * Provides both sync and async interfaces.
 * Async backend support for `asyncio` and `trio`.
 
-## Requirements
-
-Python 3.8+
-
 ## Installation
 
 For HTTP/1.1 only support, install with:


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->

Update httpcore2 docs to say 3.10 is the minimum required.

Or better yet, because these tend to be forgotten each year, let's delete them (and the httpx2 ones) and rely on the package metadata instead?

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
