### PR TITLE
Update community links to pydantic/httpx2

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-issue.md
+++ b/.github/ISSUE_TEMPLATE/1-issue.md
@@ -5,7 +5,7 @@ about: Please only raise an issue if you've been advised to do so after discussi
 
 The starting point for issues should usually be a discussion...
 
-https://github.com/encode/httpx/discussions
+https://github.com/pydantic/httpx2/discussions
 
 Possible bugs may be raised as a "Potential Issue" discussion, feature requests may be raised as an "Ideas" discussion. We can then determine if the discussion needs to be escalated into an "Issue" or not.
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,10 +2,6 @@
 blank_issues_enabled: false
 contact_links:
 - name: Discussions
-  url: https://github.com/encode/httpx/discussions
+  url: https://github.com/pydantic/httpx2/discussions
   about: >
     The "Discussions" forum is where you want to start. 💖
-- name: Chat
-  url: https://gitter.im/encode/community
-  about: >
-    Our community chat forum.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,3 +5,7 @@ contact_links:
   url: https://github.com/pydantic/httpx2/discussions
   about: >
     The "Discussions" forum is where you want to start. 💖
+- name: 💬 Join Slack
+  url: https://logfire.pydantic.dev/docs/join-slack/
+  about: >
+    Join our Slack community to ask questions, get help, and chat about HTTPX2.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!-- Thanks for contributing to HTTPX! 💚
+<!-- Thanks for contributing to HTTPX2! 💚
 Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->
 
 # Summary

--- a/docs/code_of_conduct.md
+++ b/docs/code_of_conduct.md
@@ -49,7 +49,7 @@ Community members asked to stop any inappropriate behavior are expected to compl
 
 We take Code of Conduct violations seriously, and will act to ensure our spaces are welcoming, inclusive, and professional environments to communicate in.
 
-If you need to raise a Code of Conduct report, you may do so privately by email to tom@tomchristie.com.
+If you need to raise a Code of Conduct report, you may do so privately by email to hello@pydantic.dev.
 
 Reports will be treated confidentially.
 


### PR DESCRIPTION
## Summary

- Point issue template discussions URL at `pydantic/httpx2`.
- Drop the old encode gitter chat link from the issue template config.
- Update the PR template greeting from HTTPX to HTTPX2.
- Route Code of Conduct reports to `hello@pydantic.dev` instead of the personal email.

## Test plan

- [x] Confirm no remaining references to `encode/httpx` or `tom@tomchristie.com` in the touched files.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.