### PR TITLE
Allow IPv6 CIDR notation in `no_proxy`

### DIFF
--- a/src/httpx2/httpx2/_utils.py
+++ b/src/httpx2/httpx2/_utils.py
@@ -65,7 +65,11 @@ def get_environment_proxies() -> dict[str, str | None]:
             elif is_ipv4_hostname(hostname):
                 mounts[f"all://{hostname}"] = None
             elif is_ipv6_hostname(hostname):
-                mounts[f"all://[{hostname}]"] = None
+                if "/" in hostname:
+                    addr, _, subnet = hostname.partition("/")
+                    mounts[f"all://[{addr}]/{subnet}"] = None
+                else:
+                    mounts[f"all://[{hostname}]"] = None
             elif hostname.lower() == "localhost":
                 mounts[f"all://{hostname}"] = None
             else:

--- a/tests/httpx2/test_utils.py
+++ b/tests/httpx2/test_utils.py
@@ -99,6 +99,7 @@ def test_logging_redirect_chain(server, caplog):
         ({"no_proxy": "127.0.0.1"}, {"all://127.0.0.1": None}),
         ({"no_proxy": "192.168.0.0/16"}, {"all://192.168.0.0/16": None}),
         ({"no_proxy": "::1"}, {"all://[::1]": None}),
+        ({"no_proxy": "fe11::/16"}, {"all://[fe11::]/16": None}),
         ({"no_proxy": "localhost"}, {"all://localhost": None}),
         ({"no_proxy": "github.com"}, {"all://*github.com": None}),
         ({"no_proxy": ".github.com"}, {"all://*.github.com": None}),


### PR DESCRIPTION
no_proxy=fe80::/10 (or any IPv6 CIDR) crashed Client() construction because get_environment_proxies() bracketed the whole string including the CIDR suffix, producing the invalid URL pattern "all://[fe80::/10]". Bracket only the address portion and append the suffix outside the brackets.

Closes #899.

Upstream: https://github.com/encode/httpx/issues/3574