### PR TITLE
perf: use anyio fast_acquire for Lock and Semaphore

### DIFF
--- a/src/httpcore2/httpcore2/_synchronization.py
+++ b/src/httpcore2/httpcore2/_synchronization.py
@@ -61,7 +61,7 @@ class AsyncLock:
         if self._backend == "trio":
             self._trio_lock = trio.Lock()
         elif self._backend == "asyncio":
-            self._anyio_lock = anyio.Lock()
+            self._anyio_lock = anyio.Lock(fast_acquire=True)
 
     async def __aenter__(self) -> AsyncLock:
         if not self._backend:
@@ -161,7 +161,7 @@ class AsyncSemaphore:
         if self._backend == "trio":
             self._trio_semaphore = trio.Semaphore(initial_value=self._bound, max_value=self._bound)
         elif self._backend == "asyncio":
-            self._anyio_semaphore = anyio.Semaphore(initial_value=self._bound, max_value=self._bound)
+            self._anyio_semaphore = anyio.Semaphore(initial_value=self._bound, max_value=self._bound, fast_acquire=True)
 
     async def acquire(self) -> None:
         if not self._backend:

--- a/src/httpcore2/pyproject.toml
+++ b/src/httpcore2/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = ["certifi", "h11>=0.16"]
 http2 = ["h2>=3,<5"]
 socks = ["socksio==1.*"]
 trio = ["trio>=0.22.0,<1.0"]
-asyncio = ["anyio>=4.0,<5.0"]
+asyncio = ["anyio>=4.5.0,<5.0"]
 
 [project.urls]
 Documentation = "https://www.encode.io/httpcore"

--- a/uv.lock
+++ b/uv.lock
@@ -1337,7 +1337,7 @@ trio = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anyio", marker = "extra == 'asyncio'", specifier = ">=4.0,<5.0" },
+    { name = "anyio", marker = "extra == 'asyncio'", specifier = ">=4.5.0,<5.0" },
     { name = "certifi" },
     { name = "h11", specifier = ">=0.16" },
     { name = "h2", marker = "extra == 'http2'", specifier = ">=3,<5" },


### PR DESCRIPTION
Reinstates encode/httpcore#953 which was reverted in encode/httpcore#1002 for process reasons, not technical ones. fast_acquire=True skips an unnecessary event loop yield on uncontended lock acquires, eliminating two round-trips per request through the connection pool.

Requires anyio >= 4.5.0 (bumped in pyproject.toml).