### PR TITLE
Update docs references from httpx to httpx2

### DIFF
--- a/docs/advanced/authentication.md
+++ b/docs/advanced/authentication.md
@@ -1,16 +1,16 @@
 Authentication can either be included on a per-request basis...
 
 ```pycon
->>> auth = httpx.BasicAuth(username="username", password="secret")
->>> client = httpx.Client()
+>>> auth = httpx2.BasicAuth(username="username", password="secret")
+>>> client = httpx2.Client()
 >>> response = client.get("https://www.example.com/", auth=auth)
 ```
 
 Or configured on the client instance, ensuring that all outgoing requests will include authentication credentials...
 
 ```pycon
->>> auth = httpx.BasicAuth(username="username", password="secret")
->>> client = httpx.Client(auth=auth)
+>>> auth = httpx2.BasicAuth(username="username", password="secret")
+>>> client = httpx2.Client(auth=auth)
 >>> response = client.get("https://www.example.com/")
 ```
 
@@ -19,8 +19,8 @@ Or configured on the client instance, ensuring that all outgoing requests will i
 HTTP basic authentication is an unencrypted authentication scheme that uses a simple encoding of the username and password in the request `Authorization` header. Since it is unencrypted it should typically only be used over `https`, although this is not strictly enforced.
 
 ```pycon
->>> auth = httpx.BasicAuth(username="finley", password="secret")
->>> client = httpx.Client(auth=auth)
+>>> auth = httpx2.BasicAuth(username="finley", password="secret")
+>>> client = httpx2.Client(auth=auth)
 >>> response = client.get("https://httpbin.org/basic-auth/finley/secret")
 >>> response
 <Response [200 OK]>
@@ -31,8 +31,8 @@ HTTP basic authentication is an unencrypted authentication scheme that uses a si
 HTTP digest authentication is a challenge-response authentication scheme. Unlike basic authentication it provides encryption, and can be used over unencrypted `http` connections. It requires an additional round-trip in order to negotiate the authentication. 
 
 ```pycon
->>> auth = httpx.DigestAuth(username="olivia", password="secret")
->>> client = httpx.Client(auth=auth)
+>>> auth = httpx2.DigestAuth(username="olivia", password="secret")
+>>> client = httpx2.Client(auth=auth)
 >>> response = client.get("https://httpbin.org/digest-auth/auth/olivia/secret")
 >>> response
 <Response [200 OK]>
@@ -53,33 +53,33 @@ machine example.org
 login example-username
 password example-password
 
-machine python-httpx.org
+machine python-httpx2.org
 login other-username
 password other-password
 ```
 
-Some examples of configuring `.netrc` authentication with `httpx`.
+Some examples of configuring `.netrc` authentication with `httpx2`.
 
 Use the default `.netrc` file in the users home directory:
 
 ```pycon
->>> auth = httpx.NetRCAuth()
->>> client = httpx.Client(auth=auth)
+>>> auth = httpx2.NetRCAuth()
+>>> client = httpx2.Client(auth=auth)
 ```
 
 Use an explicit path to a `.netrc` file:
 
 ```pycon
->>> auth = httpx.NetRCAuth(file="/path/to/.netrc")
->>> client = httpx.Client(auth=auth)
+>>> auth = httpx2.NetRCAuth(file="/path/to/.netrc")
+>>> client = httpx2.Client(auth=auth)
 ```
 
 Use the `NETRC` environment variable to configure a path to the `.netrc` file,
 or fallback to the default.
 
 ```pycon
->>> auth = httpx.NetRCAuth(file=os.environ.get("NETRC"))
->>> client = httpx.Client(auth=auth)
+>>> auth = httpx2.NetRCAuth(file=os.environ.get("NETRC"))
+>>> client = httpx2.Client(auth=auth)
 ```
 
 The `NetRCAuth()` class uses [the `netrc.netrc()` function from the Python standard library](https://docs.python.org/3/library/netrc.html). See the documentation there for more details on exceptions that may be raised if the `.netrc` file is not found, or cannot be parsed.
@@ -89,14 +89,14 @@ The `NetRCAuth()` class uses [the `netrc.netrc()` function from the Python stand
 When issuing requests or instantiating a client, the `auth` argument can be used to pass an authentication scheme to use. The `auth` argument may be one of the following...
 
 * A two-tuple of `username`/`password`, to be used with basic authentication.
-* An instance of `httpx.BasicAuth()`, `httpx.DigestAuth()`, or `httpx.NetRCAuth()`.
+* An instance of `httpx2.BasicAuth()`, `httpx2.DigestAuth()`, or `httpx2.NetRCAuth()`.
 * A callable, accepting a request and returning an authenticated request instance.
-* An instance of subclasses of `httpx.Auth`.
+* An instance of subclasses of `httpx2.Auth`.
 
-The most involved of these is the last, which allows you to create authentication flows involving one or more requests. A subclass of `httpx.Auth` should implement `def auth_flow(request)`, and yield any requests that need to be made...
+The most involved of these is the last, which allows you to create authentication flows involving one or more requests. A subclass of `httpx2.Auth` should implement `def auth_flow(request)`, and yield any requests that need to be made...
 
 ```python
-class MyCustomAuth(httpx.Auth):
+class MyCustomAuth(httpx2.Auth):
     def __init__(self, token):
         self.token = token
 
@@ -109,7 +109,7 @@ class MyCustomAuth(httpx.Auth):
 If the auth flow requires more than one request, you can issue multiple yields, and obtain the response in each case...
 
 ```python
-class MyCustomAuth(httpx.Auth):
+class MyCustomAuth(httpx2.Auth):
     def __init__(self, token):
         self.token = token
 
@@ -127,7 +127,7 @@ Custom authentication classes are designed to not perform any I/O, so that they 
 You will then be able to access `request.content` inside the `.auth_flow()` method.
 
 ```python
-class MyCustomAuth(httpx.Auth):
+class MyCustomAuth(httpx2.Auth):
     requires_request_body = True
 
     def __init__(self, token):
@@ -150,7 +150,7 @@ class MyCustomAuth(httpx.Auth):
 Similarly, if you are implementing a scheme that requires access to the response body, then use the `requires_response_body` property.   You will then be able to access response body properties and methods such as `response.content`, `response.text`, `response.json()`, etc.
 
 ```python
-class MyCustomAuth(httpx.Auth):
+class MyCustomAuth(httpx2.Auth):
     requires_response_body = True
 
     def __init__(self, access_token, refresh_token, refresh_url):
@@ -172,7 +172,7 @@ class MyCustomAuth(httpx.Auth):
             yield request
 
     def build_refresh_request(self):
-        # Return an `httpx.Request` for refreshing tokens.
+        # Return an `httpx2.Request` for refreshing tokens.
         ...
 
     def update_tokens(self, response):
@@ -182,15 +182,15 @@ class MyCustomAuth(httpx.Auth):
         ...
 ```
 
-If you _do_ need to perform I/O other than HTTP requests, such as accessing a disk-based cache, or you need to use concurrency primitives, such as locks, then you should override `.sync_auth_flow()` and `.async_auth_flow()` (instead of `.auth_flow()`). The former will be used by `httpx.Client`, while the latter will be used by `httpx.AsyncClient`.
+If you _do_ need to perform I/O other than HTTP requests, such as accessing a disk-based cache, or you need to use concurrency primitives, such as locks, then you should override `.sync_auth_flow()` and `.async_auth_flow()` (instead of `.auth_flow()`). The former will be used by `httpx2.Client`, while the latter will be used by `httpx2.AsyncClient`.
 
 ```python
 import asyncio
 import threading
-import httpx
+import httpx2
 
 
-class MyCustomAuth(httpx.Auth):
+class MyCustomAuth(httpx2.Auth):
     def __init__(self):
         self._sync_lock = threading.RLock()
         self._async_lock = asyncio.Lock()
@@ -217,16 +217,16 @@ class MyCustomAuth(httpx.Auth):
 If you only want to support one of the two methods, then you should still override it, but raise an explicit `RuntimeError`.
 
 ```python
-import httpx
+import httpx2
 import sync_only_library
 
 
-class MyCustomAuth(httpx.Auth):
+class MyCustomAuth(httpx2.Auth):
     def sync_auth_flow(self, request):
         token = sync_only_library.get_token(...)
         request.headers["Authorization"] = f"Token {token}"
         yield request
 
     async def async_auth_flow(self, request):
-        raise RuntimeError("Cannot use a sync authentication class with httpx.AsyncClient")
+        raise RuntimeError("Cannot use a sync authentication class with httpx2.AsyncClient")
 ```

--- a/docs/advanced/clients.md
+++ b/docs/advanced/clients.md
@@ -1,5 +1,5 @@
 !!! hint
-    If you are coming from Requests, `httpx.Client()` is what you can use instead of `requests.Session()`.
+    If you are coming from Requests, `httpx2.Client()` is what you can use instead of `requests.Session()`.
 
 ## Why use a Client?
 
@@ -34,14 +34,14 @@ The other sections on this page go into further detail about what you can do wit
 The recommended way to use a `Client` is as a context manager. This will ensure that connections are properly cleaned up when leaving the `with` block:
 
 ```python
-with httpx.Client() as client:
+with httpx2.Client() as client:
     ...
 ```
 
 Alternatively, you can explicitly close the connection pool without block-usage using `.close()`:
 
 ```python
-client = httpx.Client()
+client = httpx2.Client()
 try:
     ...
 finally:
@@ -53,19 +53,19 @@ finally:
 Once you have a `Client`, you can send requests using `.get()`, `.post()`, etc. For example:
 
 ```pycon
->>> with httpx.Client() as client:
+>>> with httpx2.Client() as client:
 ...     r = client.get('https://example.com')
 ...
 >>> r
 <Response [200 OK]>
 ```
 
-These methods accept the same arguments as `httpx.get()`, `httpx.post()`, etc. This means that all features documented in the [Quickstart](../quickstart.md) guide are also available at the client level.
+These methods accept the same arguments as `httpx2.get()`, `httpx2.post()`, etc. This means that all features documented in the [Quickstart](../quickstart.md) guide are also available at the client level.
 
 For example, to send a request with custom headers:
 
 ```pycon
->>> with httpx.Client() as client:
+>>> with httpx2.Client() as client:
 ...     headers = {'X-Custom': 'value'}
 ...     r = client.get('https://example.com', headers=headers)
 ...
@@ -82,7 +82,7 @@ For example, to apply a set of custom headers _on every request_:
 ```pycon
 >>> url = 'http://httpbin.org/headers'
 >>> headers = {'user-agent': 'my-app/0.0.1'}
->>> with httpx.Client(headers=headers) as client:
+>>> with httpx2.Client(headers=headers) as client:
 ...     r = client.get(url)
 ...
 >>> r.json()['headers']['User-Agent']
@@ -98,7 +98,7 @@ When a configuration option is provided at both the client-level and request-lev
 ```pycon
 >>> headers = {'X-Auth': 'from-client'}
 >>> params = {'client_id': 'client1'}
->>> with httpx.Client(headers=headers, params=params) as client:
+>>> with httpx2.Client(headers=headers, params=params) as client:
 ...     headers = {'X-Custom': 'from-request'}
 ...     params = {'request_id': 'request1'}
 ...     r = client.get('https://example.com', headers=headers, params=params)
@@ -114,7 +114,7 @@ URL('https://example.com?client_id=client1&request_id=request1')
 - For all other parameters, the request-level value takes priority. For example:
 
 ```pycon
->>> with httpx.Client(auth=('tom', 'mot123')) as client:
+>>> with httpx2.Client(auth=('tom', 'mot123')) as client:
 ...     r = client.get('https://example.com', auth=('alice', 'ecila123'))
 ...
 >>> _, _, auth = r.request.headers['Authorization'].partition(' ')
@@ -132,7 +132,7 @@ Additionally, `Client` accepts some configuration options that aren't available 
 For example, `base_url` allows you to prepend an URL to all outgoing requests:
 
 ```pycon
->>> with httpx.Client(base_url='http://httpbin.org') as client:
+>>> with httpx2.Client(base_url='http://httpbin.org') as client:
 ...     r = client.get('/headers')
 ...
 >>> r.request.url
@@ -148,13 +148,13 @@ For a list of all available client parameters, see the [`Client`](../api.md#clie
 For maximum control on what gets sent over the wire, HTTPX supports building explicit [`Request`](../api.md#request) instances:
 
 ```python
-request = httpx.Request("GET", "https://example.com")
+request = httpx2.Request("GET", "https://example.com")
 ```
 
 To dispatch a `Request` instance across to the network, create a [`Client` instance](#sharing-configuration-across-requests) and use `.send()`:
 
 ```python
-with httpx.Client() as client:
+with httpx2.Client() as client:
     response = client.send(request)
     ...
 ```
@@ -164,7 +164,7 @@ If you need to mix client-level and request-level options in a way that is not s
 ```python
 headers = {"X-Api-Key": "...", "X-Client-ID": "ABC123"}
 
-with httpx.Client(headers=headers) as client:
+with httpx2.Client(headers=headers) as client:
     request = client.build_request("GET", "https://api.example.com")
 
     print(request.headers["X-Client-ID"])  # "ABC123"
@@ -187,12 +187,12 @@ For example, showing a progress bar using the [`tqdm`](https://github.com/tqdm/t
 ```python
 import tempfile
 
-import httpx
+import httpx2
 from tqdm import tqdm
 
 with tempfile.NamedTemporaryFile() as download_file:
     url = "https://speed.hetzner.de/100MB.bin"
-    with httpx.stream("GET", url) as response:
+    with httpx2.stream("GET", url) as response:
         total = int(response.headers["Content-Length"])
 
         with tqdm(total=total, unit_scale=True, unit_divisor=1024, unit="B") as progress:
@@ -209,12 +209,12 @@ Or an alternate example, this time using the [`rich`](https://github.com/willmcg
 
 ```python
 import tempfile
-import httpx
+import httpx2
 import rich.progress
 
 with tempfile.NamedTemporaryFile() as download_file:
     url = "https://speed.hetzner.de/100MB.bin"
-    with httpx.stream("GET", url) as response:
+    with httpx2.stream("GET", url) as response:
         total = int(response.headers["Content-Length"])
 
         with rich.progress.Progress(
@@ -241,7 +241,7 @@ For example, showing a progress bar using the [`tqdm`](https://github.com/tqdm/t
 import io
 import random
 
-import httpx
+import httpx2
 from tqdm import tqdm
 
 
@@ -258,7 +258,7 @@ def gen():
                 bar.update(len(data))
 
 
-httpx.post("https://httpbin.org/post", content=gen())
+httpx2.post("https://httpbin.org/post", content=gen())
 ```
 
 ![tqdm progress bar](../img/tqdm-progress.gif)
@@ -272,7 +272,7 @@ name of the payloads as keys and either tuple of elements or a file-like object 
 ```pycon
 >>> with open('report.xls', 'rb') as report_file:
 ...     files = {'upload-file': ('report.xls', report_file, 'application/vnd.ms-excel')}
-...     r = httpx.post("https://httpbin.org/post", files=files)
+...     r = httpx2.post("https://httpbin.org/post", files=files)
 >>> print(r.text)
 {
   ...
@@ -297,7 +297,7 @@ MIME header field.
 
 ```pycon
 >>> files = {'upload-file': (None, 'text content', 'text/plain')}
->>> r = httpx.post("https://httpbin.org/post", files=files)
+>>> r = httpx2.post("https://httpbin.org/post", files=files)
 >>> print(r.text)
 {
   ...
@@ -324,5 +324,5 @@ For instance this request sends 2 files, `foo.png` and `bar.png` in one request 
 ...         ('images', ('foo.png', foo_file, 'image/png')),
 ...         ('images', ('bar.png', bar_file, 'image/png')),
 ...     ]
-...     r = httpx.post("https://httpbin.org/post", files=files)
+...     r = httpx2.post("https://httpbin.org/post", files=files)
 ```

--- a/docs/advanced/event-hooks.md
+++ b/docs/advanced/event-hooks.md
@@ -16,18 +16,18 @@ def log_response(response):
     request = response.request
     print(f"Response event hook: {request.method} {request.url} - Status {response.status_code}")
 
-client = httpx.Client(event_hooks={'request': [log_request], 'response': [log_response]})
+client = httpx2.Client(event_hooks={'request': [log_request], 'response': [log_response]})
 ```
 
 You can also use these hooks to install response processing code, such as this
-example, which creates a client instance that always raises `httpx.HTTPStatusError`
+example, which creates a client instance that always raises `httpx2.HTTPStatusError`
 on 4xx and 5xx responses.
 
 ```python
 def raise_on_4xx_5xx(response):
     response.raise_for_status()
 
-client = httpx.Client(event_hooks={'response': [raise_on_4xx_5xx]})
+client = httpx2.Client(event_hooks={'response': [raise_on_4xx_5xx]})
 ```
 
 !!! note
@@ -43,7 +43,7 @@ The hooks are also allowed to modify `request` and `response` objects.
 def add_timestamp(request):
     request.headers['x-request-timestamp'] = datetime.now(tz=datetime.utc).isoformat()
 
-client = httpx.Client(event_hooks={'request': [add_timestamp]})
+client = httpx2.Client(event_hooks={'request': [add_timestamp]})
 ```
 
 Event hooks must always be set as a **list of callables**, and you may register
@@ -54,12 +54,12 @@ is also an `.event_hooks` property, that allows you to inspect and modify
 the installed hooks.
 
 ```python
-client = httpx.Client()
+client = httpx2.Client()
 client.event_hooks['request'] = [log_request]
 client.event_hooks['response'] = [log_response, raise_on_4xx_5xx]
 ```
 
 !!! note
     If you are using HTTPX's async support, then you need to be aware that
-    hooks registered with `httpx.AsyncClient` MUST be async functions,
+    hooks registered with `httpx2.AsyncClient` MUST be async functions,
     rather than plain functions.

--- a/docs/advanced/extensions.md
+++ b/docs/advanced/extensions.md
@@ -10,7 +10,7 @@ Several extensions are supported on the request:
 # Request timeouts actually implemented as an extension on
 # the request, ensuring that they are passed throughout the
 # entire call stack.
-client = httpx.Client()
+client = httpx2.Client()
 response = client.get(
     "https://www.example.com",
     extensions={"timeout": {"connect": 5.0}}
@@ -22,7 +22,7 @@ response.request.extensions["timeout"]
 And on the response:
 
 ```python
-client = httpx.Client()
+client = httpx2.Client()
 response = client.get("https://www.example.com")
 print(response.extensions["http_version"])  # b"HTTP/1.1"
 # Other server responses could have been
@@ -39,12 +39,12 @@ flow of events within the underlying `httpcore` transport.
 The simplest way to explain this is with an example:
 
 ```python
-import httpx
+import httpx2
 
 def log(event_name, info):
     print(event_name, info)
 
-client = httpx.Client()
+client = httpx2.Client()
 response = client.get("https://www.example.com/", extensions={"trace": log})
 # connection.connect_tcp.started {'host': 'www.example.com', 'port': 443, 'local_address': None, 'timeout': None}
 # connection.connect_tcp.complete {'return_value': <httpcore.backends.sync.SyncStream object at 0x1093f94d0>}
@@ -108,7 +108,7 @@ For example:
 ``` python
 # Connect to '185.199.108.153' but use 'www.encode.io' in the Host header,
 # and use 'www.encode.io' when SSL verifying the server hostname.
-client = httpx.Client()
+client = httpx2.Client()
 headers = {"Host": "www.encode.io"}
 extensions = {"sni_hostname": "www.encode.io"}
 response = client.get(
@@ -129,14 +129,14 @@ For example:
 ```python
 # Timeout if a connection takes more than 5 seconds to established, or if
 # we are blocked waiting on the connection pool for more than 10 seconds.
-client = httpx.Client()
+client = httpx2.Client()
 response = client.get(
     "https://www.example.com",
     extensions={"timeout": {"connect": 5.0, "pool": 10.0}}
 )
 ```
 
-This extension is how the `httpx` timeouts are implemented, ensuring that the timeout values are associated with the request instance and passed throughout the stack. You shouldn't typically be working with this extension directly, but use the higher level `timeout` API instead.
+This extension is how the `httpx2` timeouts are implemented, ensuring that the timeout values are associated with the request instance and passed throughout the stack. You shouldn't typically be working with this extension directly, but use the higher level `timeout` API instead.
 
 ### `"target"`
 
@@ -166,7 +166,7 @@ Using the 'target' extension to send requests without the standard path escaping
 # Note that requests must still be valid HTTP requests.
 # For example including whitespace in the target will raise a `LocalProtocolError`.
 extensions = {"target": b"/test^path"}
-response = httpx.get("https://www.example.com", extensions=extensions)
+response = httpx2.get("https://www.example.com", extensions=extensions)
 ```
 
 The `target` extension also allows server-wide `OPTIONS *` requests to be constructed...
@@ -176,7 +176,7 @@ The `target` extension also allows server-wide `OPTIONS *` requests to be constr
 #
 # CONNECT * HTTP/1.1
 extensions = {"target": b"*"}
-response = httpx.request("CONNECT", "https://www.example.com", extensions=extensions)
+response = httpx2.request("CONNECT", "https://www.example.com", extensions=extensions)
 ```
 
 ## Response Extensions
@@ -222,7 +222,7 @@ See the [network backends documentation](https://www.encode.io/httpcore/network-
 The network stream abstraction also allows access to various low-level information that may be exposed by the underlying socket:
 
 ```python
-response = httpx.get("https://www.example.com")
+response = httpx2.get("https://www.example.com")
 network_stream = response.extensions["network_stream"]
 
 client_addr = network_stream.get_extra_info("client_addr")
@@ -234,7 +234,7 @@ print("Server address", server_addr)
 The socket SSL information is also available through this interface, although you need to ensure that the underlying connection is still open, in order to access it...
 
 ```python
-with httpx.stream("GET", "https://www.example.com") as response:
+with httpx2.stream("GET", "https://www.example.com") as response:
     network_stream = response.extensions["network_stream"]
 
     ssl_object = network_stream.get_extra_info("ssl_object")

--- a/docs/advanced/proxies.md
+++ b/docs/advanced/proxies.md
@@ -1,4 +1,4 @@
-HTTPX supports setting up [HTTP proxies](https://en.wikipedia.org/wiki/Proxy_server#Web_proxy_servers) via the `proxy` parameter to be passed on client initialization or top-level API functions like `httpx.get(..., proxy=...)`.
+HTTPX supports setting up [HTTP proxies](https://en.wikipedia.org/wiki/Proxy_server#Web_proxy_servers) via the `proxy` parameter to be passed on client initialization or top-level API functions like `httpx2.get(..., proxy=...)`.
 
 <div align="center">
     <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/2/27/Open_proxy_h2g2bob.svg/480px-Open_proxy_h2g2bob.svg.png"/>
@@ -10,7 +10,7 @@ HTTPX supports setting up [HTTP proxies](https://en.wikipedia.org/wiki/Proxy_ser
 To route all traffic (HTTP and HTTPS) to a proxy located at `http://localhost:8030`, pass the proxy URL to the client...
 
 ```python
-with httpx.Client(proxy="http://localhost:8030") as client:
+with httpx2.Client(proxy="http://localhost:8030") as client:
     ...
 ```
 
@@ -18,11 +18,11 @@ For more advanced use cases, pass a mounts `dict`. For example, to route HTTP an
 
 ```python
 proxy_mounts = {
-    "http://": httpx.HTTPTransport(proxy="http://localhost:8030"),
-    "https://": httpx.HTTPTransport(proxy="http://localhost:8031"),
+    "http://": httpx2.HTTPTransport(proxy="http://localhost:8030"),
+    "https://": httpx2.HTTPTransport(proxy="http://localhost:8031"),
 }
 
-with httpx.Client(mounts=proxy_mounts) as client:
+with httpx2.Client(mounts=proxy_mounts) as client:
     ...
 ```
 
@@ -40,7 +40,7 @@ For detailed information about how `mounts` routes requests, see the [Routing](t
 Proxy credentials can be passed as the `userinfo` section of the proxy URL. For example:
 
 ```python
-with httpx.Client(proxy="http://username:password@localhost:8030") as client:
+with httpx2.Client(proxy="http://username:password@localhost:8030") as client:
     ...
 ```
 
@@ -73,11 +73,11 @@ This is an optional feature that requires an additional third-party library be i
 You can install SOCKS support using `pip`:
 
 ```shell
-pip install 'httpx[socks]'
+pip install 'httpx2[socks]'
 ```
 
 You can now configure a client to make requests via a proxy using the SOCKS protocol:
 
 ```python
-httpx.Client(proxy='socks5://user:pass@host:port')
+httpx2.Client(proxy='socks5://user:pass@host:port')
 ```

--- a/docs/advanced/resource-limits.md
+++ b/docs/advanced/resource-limits.md
@@ -1,5 +1,5 @@
 You can control the connection pool size using the `limits` keyword
-argument on the client. It takes instances of `httpx.Limits` which define:
+argument on the client. It takes instances of `httpx2.Limits` which define:
 
 - `max_keepalive_connections`, number of allowable keep-alive connections, or `None` to always
 allow. (Defaults 20)
@@ -8,6 +8,6 @@ allow. (Defaults 20)
 - `keepalive_expiry`, time limit on idle keep-alive connections in seconds, or `None` for no limits. (Default 5)
 
 ```python
-limits = httpx.Limits(max_keepalive_connections=5, max_connections=10)
-client = httpx.Client(limits=limits)
+limits = httpx2.Limits(max_keepalive_connections=5, max_connections=10)
+client = httpx2.Client(limits=limits)
 ```

--- a/docs/advanced/ssl.md
+++ b/docs/advanced/ssl.md
@@ -2,17 +2,17 @@ When making a request over HTTPS, HTTPX needs to verify the identity of the requ
 
 ### Enabling and disabling verification
 
-By default httpx will verify HTTPS connections, and raise an error for invalid SSL cases...
+By default httpx2 will verify HTTPS connections, and raise an error for invalid SSL cases...
 
 ```pycon
->>> httpx.get("https://expired.badssl.com/")
-httpx.ConnectError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: certificate has expired (_ssl.c:997)
+>>> httpx2.get("https://expired.badssl.com/")
+httpx2.ConnectError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: certificate has expired (_ssl.c:997)
 ```
 
 You can disable SSL verification completely and allow insecure requests...
 
 ```pycon
->>> httpx.get("https://expired.badssl.com/", verify=False)
+>>> httpx2.get("https://expired.badssl.com/", verify=False)
 <Response [200 OK]>
 ```
 
@@ -26,12 +26,12 @@ For more complex configurations you can pass an [SSL Context](https://docs.pytho
 
 ```python
 import certifi
-import httpx
+import httpx2
 import ssl
 
 # This SSL context is equivalent to the default `verify=True`.
 ctx = ssl.create_default_context(cafile=certifi.where())
-client = httpx.Client(verify=ctx)
+client = httpx2.Client(verify=ctx)
 ```
 
 Using [the `truststore` package](https://truststore.readthedocs.io/) to support system certificate stores...
@@ -39,22 +39,22 @@ Using [the `truststore` package](https://truststore.readthedocs.io/) to support 
 ```python
 import ssl
 import truststore
-import httpx
+import httpx2
 
 # Use system certificate stores.
 ctx = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-client = httpx.Client(verify=ctx)
+client = httpx2.Client(verify=ctx)
 ```
 
 Loding an alternative certificate verification store using [the standard SSL context API](https://docs.python.org/3/library/ssl.html)...
 
 ```python
-import httpx
+import httpx2
 import ssl
 
 # Use an explicitly configured certificate store.
 ctx = ssl.create_default_context(cafile="path/to/certs.pem")  # Either cafile or capath.
-client = httpx.Client(verify=ctx)
+client = httpx2.Client(verify=ctx)
 ```
 
 ### Client side certificates
@@ -66,12 +66,12 @@ You can specify client-side certificates, using the [`.load_cert_chain()`](https
 ```python
 ctx = ssl.create_default_context()
 ctx.load_cert_chain(certfile="path/to/client.pem")  # Optionally also keyfile or password.
-client = httpx.Client(verify=ctx)
+client = httpx2.Client(verify=ctx)
 ```
 
 ### Working with `SSL_CERT_FILE` and `SSL_CERT_DIR`
 
-`httpx` does respect the `SSL_CERT_FILE` and `SSL_CERT_DIR` environment variables by default. For details, refer to [the section on the environment variables page](../environment_variables.md#ssl_cert_file).
+`httpx2` does respect the `SSL_CERT_FILE` and `SSL_CERT_DIR` environment variables by default. For details, refer to [the section on the environment variables page](../environment_variables.md#ssl_cert_file).
 
 ### Making HTTPS requests to a local server
 
@@ -81,9 +81,9 @@ If you do need to make HTTPS connections to a local server, for example to test 
 
 1. Use [trustme](https://github.com/python-trio/trustme) to generate a pair of server key/cert files, and a client cert file.
 2. Pass the server key/cert files when starting your local server. (This depends on the particular web server you're using. For example, [Uvicorn](https://www.uvicorn.org) provides the `--ssl-keyfile` and `--ssl-certfile` options.)
-3. Configure `httpx` to use the certificates stored in `client.pem`.
+3. Configure `httpx2` to use the certificates stored in `client.pem`.
 
 ```python
 ctx = ssl.create_default_context(cafile="client.pem")
-client = httpx.Client(verify=ctx)
+client = httpx2.Client(verify=ctx)
 ```

--- a/docs/advanced/text-encodings.md
+++ b/docs/advanced/text-encodings.md
@@ -1,6 +1,6 @@
 When accessing `response.text`, we need to decode the response bytes into a unicode text representation.
 
-By default `httpx` will use `"charset"` information included in the response `Content-Type` header to determine how the response bytes should be decoded into text.
+By default `httpx2` will use `"charset"` information included in the response `Content-Type` header to determine how the response bytes should be decoded into text.
 
 In cases where no charset information is included on the response, the default behaviour is to assume "utf-8" encoding, which is by far the most widely used text encoding on the internet.
 
@@ -9,9 +9,9 @@ In cases where no charset information is included on the response, the default b
 To understand this better let's start by looking at the default behaviour for text decoding...
 
 ```python
-import httpx
+import httpx2
 # Instantiate a client with the default configuration.
-client = httpx.Client()
+client = httpx2.Client()
 # Using the client...
 response = client.get(...)
 print(response.encoding)  # This will either print the charset given in
@@ -27,9 +27,9 @@ This is normally absolutely fine. Most servers will respond with a properly form
 In some cases we might be making requests to a site where no character set information is being set explicitly by the server, but we know what the encoding is. In this case it's best to set the default encoding explicitly on the client.
 
 ```python
-import httpx
+import httpx2
 # Instantiate a client with a Japanese character set as the default encoding.
-client = httpx.Client(default_encoding="shift-jis")
+client = httpx2.Client(default_encoding="shift-jis")
 # Using the client...
 response = client.get(...)
 print(response.encoding)  # This will either print the charset given in
@@ -52,21 +52,21 @@ There are two widely used Python packages which both handle this functionality:
 Let's take a look at installing autodetection using one of these packages...
 
 ```shell
-pip install httpx
+pip install httpx2
 pip install chardet
 ```
 
 Once `chardet` is installed, we can configure a client to use character-set autodetection.
 
 ```python
-import httpx
+import httpx2
 import chardet
 
 def autodetect(content):
     return chardet.detect(content).get("encoding")
 
 # Using a client with character-set autodetection enabled.
-client = httpx.Client(default_encoding=autodetect)
+client = httpx2.Client(default_encoding=autodetect)
 response = client.get(...)
 print(response.encoding)  # This will either print the charset given in
                           # the Content-Type charset, or else the auto-detected

--- a/docs/advanced/timeouts.md
+++ b/docs/advanced/timeouts.md
@@ -9,10 +9,10 @@ You can set timeouts for an individual request:
 
 ```python
 # Using the top-level API:
-httpx.get('http://example.com/api/v1/example', timeout=10.0)
+httpx2.get('http://example.com/api/v1/example', timeout=10.0)
 
 # Using a client instance:
-with httpx.Client() as client:
+with httpx2.Client() as client:
     client.get("http://example.com/api/v1/example", timeout=10.0)
 ```
 
@@ -20,10 +20,10 @@ Or disable timeouts for an individual request:
 
 ```python
 # Using the top-level API:
-httpx.get('http://example.com/api/v1/example', timeout=None)
+httpx2.get('http://example.com/api/v1/example', timeout=None)
 
 # Using a client instance:
-with httpx.Client() as client:
+with httpx2.Client() as client:
     client.get("http://example.com/api/v1/example", timeout=None)
 ```
 
@@ -33,9 +33,9 @@ You can set a timeout on a client instance, which results in the given
 `timeout` being used as the default for requests made with this client:
 
 ```python
-client = httpx.Client()              # Use a default 5s timeout everywhere.
-client = httpx.Client(timeout=10.0)  # Use a default 10s timeout everywhere.
-client = httpx.Client(timeout=None)  # Disable all timeouts by default.
+client = httpx2.Client()              # Use a default 5s timeout everywhere.
+client = httpx2.Client(timeout=10.0)  # Use a default 10s timeout everywhere.
+client = httpx2.Client(timeout=None)  # Disable all timeouts by default.
 ```
 
 ## Fine tuning the configuration
@@ -64,8 +64,8 @@ You can configure the timeout behavior for any of these values...
 
 ```python
 # A client with a 60s timeout for connecting, and a 10s timeout elsewhere.
-timeout = httpx.Timeout(10.0, connect=60.0)
-client = httpx.Client(timeout=timeout)
+timeout = httpx2.Timeout(10.0, connect=60.0)
+client = httpx2.Client(timeout=timeout)
 
 response = client.get('http://example.com/')
 ```

--- a/docs/advanced/transports.md
+++ b/docs/advanced/transports.md
@@ -9,27 +9,27 @@ class directly, and pass it to the client instance. One example is the
 `local_address` configuration which is only available via this low-level API.
 
 ```pycon
->>> import httpx
->>> transport = httpx.HTTPTransport(local_address="0.0.0.0")
->>> client = httpx.Client(transport=transport)
+>>> import httpx2
+>>> transport = httpx2.HTTPTransport(local_address="0.0.0.0")
+>>> client = httpx2.Client(transport=transport)
 ```
 
-Connection retries are also available via this interface. Requests will be retried the given number of times in case an `httpx.ConnectError` or an `httpx.ConnectTimeout` occurs, allowing smoother operation under flaky networks. If you need other forms of retry behaviors, such as handling read/write errors or reacting to `503 Service Unavailable`, consider general-purpose tools such as [tenacity](https://github.com/jd/tenacity).
+Connection retries are also available via this interface. Requests will be retried the given number of times in case an `httpx2.ConnectError` or an `httpx2.ConnectTimeout` occurs, allowing smoother operation under flaky networks. If you need other forms of retry behaviors, such as handling read/write errors or reacting to `503 Service Unavailable`, consider general-purpose tools such as [tenacity](https://github.com/jd/tenacity).
 
 ```pycon
->>> import httpx
->>> transport = httpx.HTTPTransport(retries=1)
->>> client = httpx.Client(transport=transport)
+>>> import httpx2
+>>> transport = httpx2.HTTPTransport(retries=1)
+>>> client = httpx2.Client(transport=transport)
 ```
 
 Similarly, instantiating a transport directly provides a `uds` option for
 connecting via a Unix Domain Socket that is only available via this low-level API:
 
 ```pycon
->>> import httpx
+>>> import httpx2
 >>> # Connect to the Docker API via a Unix Socket.
->>> transport = httpx.HTTPTransport(uds="/var/run/docker.sock")
->>> client = httpx.Client(transport=transport)
+>>> transport = httpx2.HTTPTransport(uds="/var/run/docker.sock")
+>>> client = httpx2.Client(transport=transport)
 >>> response = client.get("http://docker/info")
 >>> response.json()
 {"ID": "...", "Containers": 4, "Images": 74, ...}
@@ -37,11 +37,11 @@ connecting via a Unix Domain Socket that is only available via this low-level AP
 
 ## WSGI Transport
 
-You can configure an `httpx` client to call directly into a Python web application using the WSGI protocol.
+You can configure an `httpx2` client to call directly into a Python web application using the WSGI protocol.
 
 This is particularly useful for two main use-cases:
 
-* Using `httpx` as a client inside test cases.
+* Using `httpx2` as a client inside test cases.
 * Mocking out external services during tests or in dev or staging environments.
 
 ### Example
@@ -50,7 +50,7 @@ Here's an example of integrating against a Flask application:
 
 ```python
 from flask import Flask
-import httpx
+import httpx2
 
 
 app = Flask(__name__)
@@ -59,8 +59,8 @@ app = Flask(__name__)
 def hello():
     return "Hello World!"
 
-transport = httpx.WSGITransport(app=app)
-with httpx.Client(transport=transport, base_url="http://testserver") as client:
+transport = httpx2.WSGITransport(app=app)
+with httpx2.Client(transport=transport, base_url="http://testserver") as client:
     r = client.get("/")
     assert r.status_code == 200
     assert r.text == "Hello World!"
@@ -78,18 +78,18 @@ For example:
 
 ```python
 # Instantiate a client that makes WSGI requests with a client IP of "1.2.3.4".
-transport = httpx.WSGITransport(app=app, remote_addr="1.2.3.4")
-with httpx.Client(transport=transport, base_url="http://testserver") as client:
+transport = httpx2.WSGITransport(app=app, remote_addr="1.2.3.4")
+with httpx2.Client(transport=transport, base_url="http://testserver") as client:
     ...
 ```
 
 ## ASGI Transport
 
-You can configure an `httpx` client to call directly into an async Python web application using the ASGI protocol.
+You can configure an `httpx2` client to call directly into an async Python web application using the ASGI protocol.
 
 This is particularly useful for two main use-cases:
 
-* Using `httpx` as a client inside test cases.
+* Using `httpx2` as a client inside test cases.
 * Mocking out external services during tests or in dev or staging environments.
 
 ### Example
@@ -112,9 +112,9 @@ app = Starlette(routes=[Route("/", hello)])
 We can make requests directly against the application, like so:
 
 ```python
-transport = httpx.ASGITransport(app=app)
+transport = httpx2.ASGITransport(app=app)
 
-async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+async with httpx2.AsyncClient(transport=transport, base_url="http://testserver") as client:
     r = await client.get("/")
     assert r.status_code == 200
     assert r.text == "Hello World!"
@@ -133,8 +133,8 @@ For example:
 ```python
 # Instantiate a client that makes ASGI requests with a client IP of "1.2.3.4",
 # on port 123.
-transport = httpx.ASGITransport(app=app, client=("1.2.3.4", 123))
-async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+transport = httpx2.ASGITransport(app=app, client=("1.2.3.4", 123))
+async with httpx2.AsyncClient(transport=transport, base_url="http://testserver") as client:
     ...
 ```
 
@@ -150,8 +150,8 @@ However it is suggested to use `LifespanManager` from [asgi-lifespan](https://gi
 
 A transport instance must implement the low-level Transport API which deals
 with sending a single request, and returning a response. You should either
-subclass `httpx.BaseTransport` to implement a transport to use with `Client`,
-or subclass `httpx.AsyncBaseTransport` to implement a transport to
+subclass `httpx2.BaseTransport` to implement a transport to use with `Client`,
+or subclass `httpx2.AsyncBaseTransport` to implement a transport to
 use with `AsyncClient`.
 
 At the layer of the transport API we're using the familiar `Request` and
@@ -164,42 +164,42 @@ A complete example of a custom transport implementation would be:
 
 ```python
 import json
-import httpx
+import httpx2
 
-class HelloWorldTransport(httpx.BaseTransport):
+class HelloWorldTransport(httpx2.BaseTransport):
     """
     A mock transport that always returns a JSON "Hello, world!" response.
     """
 
     def handle_request(self, request):
-        return httpx.Response(200, json={"text": "Hello, world!"})
+        return httpx2.Response(200, json={"text": "Hello, world!"})
 ```
 
-Or this example, which uses a custom transport and `httpx.Mounts` to always redirect `http://` requests.
+Or this example, which uses a custom transport and `httpx2.Mounts` to always redirect `http://` requests.
 
 ```python
-class HTTPSRedirect(httpx.BaseTransport):
+class HTTPSRedirect(httpx2.BaseTransport):
     """
     A transport that always redirects to HTTPS.
     """
     def handle_request(self, request):
         url = request.url.copy_with(scheme="https")
-        return httpx.Response(303, headers={"Location": str(url)})
+        return httpx2.Response(303, headers={"Location": str(url)})
 
 # A client where any `http` requests are always redirected to `https`
-transport = httpx.Mounts({
+transport = httpx2.Mounts({
     'http://': HTTPSRedirect()
-    'https://': httpx.HTTPTransport()
+    'https://': httpx2.HTTPTransport()
 })
-client = httpx.Client(transport=transport)
+client = httpx2.Client(transport=transport)
 ```
 
 A useful pattern here is custom transport classes that wrap the default HTTP implementation. For example...
 
 ```python
-class DebuggingTransport(httpx.BaseTransport):
+class DebuggingTransport(httpx2.BaseTransport):
     def __init__(self, **kwargs):
-        self._wrapper = httpx.HTTPTransport(**kwargs)
+        self._wrapper = httpx2.HTTPTransport(**kwargs)
 
     def handle_request(self, request):
         print(f">>> {request}")
@@ -211,16 +211,16 @@ class DebuggingTransport(httpx.BaseTransport):
         self._wrapper.close()
 
 transport = DebuggingTransport()
-client = httpx.Client(transport=transport)
+client = httpx2.Client(transport=transport)
 ```
 
 Here's another case, where we're using a round-robin across a number of different proxies...
 
 ```python
-class ProxyRoundRobin(httpx.BaseTransport):
+class ProxyRoundRobin(httpx2.BaseTransport):
     def __init__(self, proxies, **kwargs):
         self._transports = [
-            httpx.HTTPTransport(proxy=proxy, **kwargs)
+            httpx2.HTTPTransport(proxy=proxy, **kwargs)
             for proxy in proxies
         ]
         self._idx = 0
@@ -235,12 +235,12 @@ class ProxyRoundRobin(httpx.BaseTransport):
             transport.close()
 
 proxies = [
-    httpx.Proxy("http://127.0.0.1:8081"),
-    httpx.Proxy("http://127.0.0.1:8082"),
-    httpx.Proxy("http://127.0.0.1:8083"),
+    httpx2.Proxy("http://127.0.0.1:8081"),
+    httpx2.Proxy("http://127.0.0.1:8082"),
+    httpx2.Proxy("http://127.0.0.1:8083"),
 ]
 transport = ProxyRoundRobin(proxies=proxies)
-client = httpx.Client(transport=transport)
+client = httpx2.Client(transport=transport)
 ```
 
 ## Mock transports
@@ -248,25 +248,25 @@ client = httpx.Client(transport=transport)
 During testing it can often be useful to be able to mock out a transport,
 and return pre-determined responses, rather than making actual network requests.
 
-The `httpx.MockTransport` class accepts a handler function, which can be used
+The `httpx2.MockTransport` class accepts a handler function, which can be used
 to map requests onto pre-determined responses:
 
 ```python
 def handler(request):
-    return httpx.Response(200, json={"text": "Hello, world!"})
+    return httpx2.Response(200, json={"text": "Hello, world!"})
 
 
 # Switch to a mock transport, if the TESTING environment variable is set.
 if os.environ.get('TESTING', '').upper() == "TRUE":
-    transport = httpx.MockTransport(handler)
+    transport = httpx2.MockTransport(handler)
 else:
-    transport = httpx.HTTPTransport()
+    transport = httpx2.HTTPTransport()
 
-client = httpx.Client(transport=transport)
+client = httpx2.Client(transport=transport)
 ```
 
 For more advanced use-cases you might want to take a look at either [the third-party
-mocking library, RESPX](https://lundberg.github.io/respx/), or the [pytest-httpx library](https://github.com/Colin-b/pytest_httpx).
+mocking library, RESPX](https://lundberg.github.io/respx/), or the [pytest-httpx2 library](https://github.com/Colin-b/pytest_httpx).
 
 ## Mounting transports
 
@@ -275,9 +275,9 @@ which transport an outgoing request should be routed via, with [the same style
 used for specifying proxy routing](#routing).
 
 ```python
-import httpx
+import httpx2
 
-class HTTPSRedirectTransport(httpx.BaseTransport):
+class HTTPSRedirectTransport(httpx2.BaseTransport):
     """
     A transport that always redirects to HTTPS.
     """
@@ -288,7 +288,7 @@ class HTTPSRedirectTransport(httpx.BaseTransport):
             location = b"https://%s%s" % (host, path)
         else:
             location = b"https://%s:%d%s" % (host, port, path)
-        stream = httpx.ByteStream(b"")
+        stream = httpx2.ByteStream(b"")
         headers = [(b"location", location)]
         extensions = {}
         return 303, headers, stream, extensions
@@ -296,7 +296,7 @@ class HTTPSRedirectTransport(httpx.BaseTransport):
 
 # A client where any `http` requests are always redirected to `https`
 mounts = {'http://': HTTPSRedirectTransport()}
-client = httpx.Client(mounts=mounts)
+client = httpx2.Client(mounts=mounts)
 ```
 
 A couple of other sketches of how you might take advantage of mounted transports...
@@ -305,10 +305,10 @@ Disabling HTTP/2 on a single given domain...
 
 ```python
 mounts = {
-    "all://": httpx.HTTPTransport(http2=True),
-    "all://*example.org": httpx.HTTPTransport()
+    "all://": httpx2.HTTPTransport(http2=True),
+    "all://*example.org": httpx2.HTTPTransport()
 }
-client = httpx.Client(mounts=mounts)
+client = httpx2.Client(mounts=mounts)
 ```
 
 Mocking requests to a given domain:
@@ -317,10 +317,10 @@ Mocking requests to a given domain:
 # All requests to "example.org" should be mocked out.
 # Other requests occur as usual.
 def handler(request):
-    return httpx.Response(200, json={"text": "Hello, World!"})
+    return httpx2.Response(200, json={"text": "Hello, World!"})
 
-mounts = {"all://example.org": httpx.MockTransport(handler)}
-client = httpx.Client(mounts=mounts)
+mounts = {"all://example.org": httpx2.MockTransport(handler)}
+client = httpx2.Client(mounts=mounts)
 ```
 
 Adding support for custom schemes:
@@ -328,7 +328,7 @@ Adding support for custom schemes:
 ```python
 # Support URLs like "file:///Users/sylvia_green/websites/new_client/index.html"
 mounts = {"file://": FileSystemTransport()}
-client = httpx.Client(mounts=mounts)
+client = httpx2.Client(mounts=mounts)
 ```
 
 ### Routing
@@ -345,7 +345,7 @@ Route everything through a transport...
 
 ```python
 mounts = {
-    "all://": httpx.HTTPTransport(proxy="http://localhost:8030"),
+    "all://": httpx2.HTTPTransport(proxy="http://localhost:8030"),
 }
 ```
 
@@ -355,8 +355,8 @@ Route HTTP requests through one transport, and HTTPS requests through another...
 
 ```python
 mounts = {
-    "http://": httpx.HTTPTransport(proxy="http://localhost:8030"),
-    "https://": httpx.HTTPTransport(proxy="http://localhost:8031"),
+    "http://": httpx2.HTTPTransport(proxy="http://localhost:8030"),
+    "https://": httpx2.HTTPTransport(proxy="http://localhost:8031"),
 }
 ```
 
@@ -366,7 +366,7 @@ Proxy all requests on domain "example.com", let other requests pass through...
 
 ```python
 mounts = {
-    "all://example.com": httpx.HTTPTransport(proxy="http://localhost:8030"),
+    "all://example.com": httpx2.HTTPTransport(proxy="http://localhost:8030"),
 }
 ```
 
@@ -374,7 +374,7 @@ Proxy HTTP requests on domain "example.com", let HTTPS and other requests pass t
 
 ```python
 mounts = {
-    "http://example.com": httpx.HTTPTransport(proxy="http://localhost:8030"),
+    "http://example.com": httpx2.HTTPTransport(proxy="http://localhost:8030"),
 }
 ```
 
@@ -382,7 +382,7 @@ Proxy all requests to "example.com" and its subdomains, let other requests pass 
 
 ```python
 mounts = {
-    "all://*example.com": httpx.HTTPTransport(proxy="http://localhost:8030"),
+    "all://*example.com": httpx2.HTTPTransport(proxy="http://localhost:8030"),
 }
 ```
 
@@ -390,7 +390,7 @@ Proxy all requests to strict subdomains of "example.com", let "example.com" and 
 
 ```python
 mounts = {
-    "all://*.example.com": httpx.HTTPTransport(proxy="http://localhost:8030"),
+    "all://*.example.com": httpx2.HTTPTransport(proxy="http://localhost:8030"),
 }
 ```
 
@@ -400,7 +400,7 @@ Proxy HTTPS requests on port 1234 to "example.com"...
 
 ```python
 mounts = {
-    "https://example.com:1234": httpx.HTTPTransport(proxy="http://localhost:8030"),
+    "https://example.com:1234": httpx2.HTTPTransport(proxy="http://localhost:8030"),
 }
 ```
 
@@ -408,7 +408,7 @@ Proxy all requests on port 1234...
 
 ```python
 mounts = {
-    "all://*:1234": httpx.HTTPTransport(proxy="http://localhost:8030"),
+    "all://*:1234": httpx2.HTTPTransport(proxy="http://localhost:8030"),
 }
 ```
 
@@ -421,7 +421,7 @@ To do so, pass `None` as the proxy URL. For example...
 ```python
 mounts = {
     # Route requests through a proxy by default...
-    "all://": httpx.HTTPTransport(proxy="http://localhost:8031"),
+    "all://": httpx2.HTTPTransport(proxy="http://localhost:8031"),
     # Except those for "example.com".
     "all://example.com": None,
 }
@@ -434,14 +434,14 @@ You can combine the routing features outlined above to build complex proxy routi
 ```python
 mounts = {
     # Route all traffic through a proxy by default...
-    "all://": httpx.HTTPTransport(proxy="http://localhost:8030"),
+    "all://": httpx2.HTTPTransport(proxy="http://localhost:8030"),
     # But don't use proxies for HTTPS requests to "domain.io"...
     "https://domain.io": None,
     # And use another proxy for requests to "example.com" and its subdomains...
-    "all://*example.com": httpx.HTTPTransport(proxy="http://localhost:8031"),
+    "all://*example.com": httpx2.HTTPTransport(proxy="http://localhost:8031"),
     # And yet another proxy if HTTP is used,
     # and the "internal" subdomain on port 5550 is requested...
-    "http://internal.example.com:5550": httpx.HTTPTransport(proxy="http://localhost:8032"),
+    "http://internal.example.com:5550": httpx2.HTTPTransport(proxy="http://localhost:8032"),
 }
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -116,7 +116,7 @@
 what gets sent over the wire.*
 
 ```pycon
->>> request = httpx.Request("GET", "https://example.org", headers={'host': 'example.org'})
+>>> request = httpx2.Request("GET", "https://example.org", headers={'host': 'example.org'})
 >>> response = client.send(request)
 ```
 

--- a/docs/async.md
+++ b/docs/async.md
@@ -15,7 +15,7 @@ async client for sending outgoing HTTP requests.
 To make asynchronous requests, you'll need an `AsyncClient`.
 
 ```pycon
->>> async with httpx.AsyncClient() as client:
+>>> async with httpx2.AsyncClient() as client:
 ...     r = await client.get('https://www.example.com/')
 ...
 >>> r
@@ -46,10 +46,10 @@ The request methods are all async, so you should use `response = await client.ge
 
 ### Opening and closing clients
 
-Use `async with httpx.AsyncClient()` if you want a context-managed client...
+Use `async with httpx2.AsyncClient()` if you want a context-managed client...
 
 ```python
-async with httpx.AsyncClient() as client:
+async with httpx2.AsyncClient() as client:
     ...
 ```
 
@@ -59,7 +59,7 @@ async with httpx.AsyncClient() as client:
 Alternatively, use `await client.aclose()` if you want to close a client explicitly:
 
 ```python
-client = httpx.AsyncClient()
+client = httpx2.AsyncClient()
 ...
 await client.aclose()
 ```
@@ -69,7 +69,7 @@ await client.aclose()
 The `AsyncClient.stream(method, url, ...)` method is an async context block.
 
 ```pycon
->>> client = httpx.AsyncClient()
+>>> client = httpx2.AsyncClient()
 >>> async with client.stream('GET', 'https://www.example.com/') as response:
 ...     async for chunk in response.aiter_bytes():
 ...         ...
@@ -89,11 +89,11 @@ For situations when context block usage is not practical, it is possible to ente
 Example in the context of forwarding the response to a streaming web endpoint with [Starlette](https://www.starlette.io):
 
 ```python
-import httpx
+import httpx2
 from starlette.background import BackgroundTask
 from starlette.responses import StreamingResponse
 
-client = httpx.AsyncClient()
+client = httpx2.AsyncClient()
 
 async def home(request):
     req = client.build_request("GET", "https://www.example.com/")
@@ -117,14 +117,14 @@ await client.post(url, content=upload_bytes())
 
 ### Explicit transport instances
 
-When instantiating a transport instance directly, you need to use `httpx.AsyncHTTPTransport`.
+When instantiating a transport instance directly, you need to use `httpx2.AsyncHTTPTransport`.
 
 For instance:
 
 ```pycon
->>> import httpx
->>> transport = httpx.AsyncHTTPTransport(retries=1)
->>> async with httpx.AsyncClient(transport=transport) as client:
+>>> import httpx2
+>>> transport = httpx2.AsyncHTTPTransport(retries=1)
+>>> async with httpx2.AsyncClient(transport=transport) as client:
 >>>     ...
 ```
 
@@ -142,10 +142,10 @@ for writing concurrent code with the async/await syntax.
 
 ```python
 import asyncio
-import httpx
+import httpx2
 
 async def main():
-    async with httpx.AsyncClient() as client:
+    async with httpx2.AsyncClient() as client:
         response = await client.get('https://www.example.com/')
         print(response)
 
@@ -158,11 +158,11 @@ Trio is [an alternative async library](https://trio.readthedocs.io/en/stable/),
 designed around the [the principles of structured concurrency](https://en.wikipedia.org/wiki/Structured_concurrency).
 
 ```python
-import httpx
+import httpx2
 import trio
 
 async def main():
-    async with httpx.AsyncClient() as client:
+    async with httpx2.AsyncClient() as client:
         response = await client.get('https://www.example.com/')
         print(response)
 
@@ -178,11 +178,11 @@ trio.run(main)
 AnyIO is an [asynchronous networking and concurrency library](https://anyio.readthedocs.io/) that works on top of either `asyncio` or `trio`. It blends in with native libraries of your chosen backend (defaults to `asyncio`).
 
 ```python
-import httpx
+import httpx2
 import anyio
 
 async def main():
-    async with httpx.AsyncClient() as client:
+    async with httpx2.AsyncClient() as client:
         response = await client.get('https://www.example.com/')
         print(response)
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -22,12 +22,12 @@ response = client.get(url, follow_redirects=True)
 Or else instantiate a client, with redirect following enabled by default...
 
 ```python
-client = httpx.Client(follow_redirects=True)
+client = httpx2.Client(follow_redirects=True)
 ```
 
 ## Client instances
 
-The HTTPX equivalent of `requests.Session` is `httpx.Client`.
+The HTTPX equivalent of `requests.Session` is `httpx2.Client`.
 
 ```python
 session = requests.Session(**kwargs)
@@ -36,7 +36,7 @@ session = requests.Session(**kwargs)
 is generally equivalent to
 
 ```python
-client = httpx.Client(**kwargs)
+client = httpx2.Client(**kwargs)
 ```
 
 ## Request URLs
@@ -60,7 +60,7 @@ while request is not None:
 In HTTPX, this attribute is instead named `response.next_request`. For example:
 
 ```python
-client = httpx.Client()
+client = httpx2.Client()
 request = client.build_request("GET", ...)
 while request is not None:
     response = client.send(request)
@@ -76,14 +76,14 @@ For example, using `content=...` to upload raw content:
 
 ```python
 # Uploading text, bytes, or a bytes iterator.
-httpx.post(..., content=b"Hello, world")
+httpx2.post(..., content=b"Hello, world")
 ```
 
 And using `data=...` to send form data:
 
 ```python
 # Uploading form data.
-httpx.post(..., data={"message": "Hello, world"})
+httpx2.post(..., data={"message": "Hello, world"})
 ```
 
 Using the `data=<text/byte content>` will raise a deprecation warning,
@@ -107,14 +107,14 @@ If using a client instance, then cookies should always be set on the client rath
 This usage is supported:
 
 ```python
-client = httpx.Client(cookies=...)
+client = httpx2.Client(cookies=...)
 client.post(...)
 ```
 
 This usage is **not** supported:
 
 ```python
-client = httpx.Client()
+client = httpx2.Client()
 client.post(..., cookies=...)
 ```
 
@@ -133,7 +133,7 @@ HTTPX provides a `.stream()` interface rather than using `stream=True`. This ens
 For example:
 
 ```python
-with httpx.stream("GET", "https://www.example.com") as response:
+with httpx2.stream("GET", "https://www.example.com") as response:
     ...
 ```
 
@@ -152,7 +152,7 @@ HTTPX defaults to including reasonable [timeouts](quickstart.md#timeouts) for al
 To get the same behavior as Requests, set the `timeout` parameter to `None`:
 
 ```python
-httpx.get('https://www.example.com', timeout=None)
+httpx2.get('https://www.example.com', timeout=None)
 ```
 
 ## Proxy keys
@@ -161,13 +161,13 @@ HTTPX uses the mounts argument for HTTP proxying and transport routing.
 It can do much more than proxies and allows you to configure more than just the proxy route.
 For more detailed documentation, see [Mounting Transports](advanced/transports.md#mounting-transports).
 
-When using `httpx.Client(mounts={...})` to map to a selection of different transports, we use full URL schemes, such as `mounts={"http://": ..., "https://": ...}`.
+When using `httpx2.Client(mounts={...})` to map to a selection of different transports, we use full URL schemes, such as `mounts={"http://": ..., "https://": ...}`.
 
 This is different to the `requests` usage of `proxies={"http": ..., "https": ...}`.
 
-This change is for better consistency with more complex mappings, that might also include domain names, such as `mounts={"all://": ..., httpx.HTTPTransport(proxy="all://www.example.com": None})` which maps all requests onto a proxy, except for requests to "www.example.com" which have an explicit exclusion.
+This change is for better consistency with more complex mappings, that might also include domain names, such as `mounts={"all://": ..., httpx2.HTTPTransport(proxy="all://www.example.com": None})` which maps all requests onto a proxy, except for requests to "www.example.com" which have an explicit exclusion.
 
-Also note that `requests.Session.request(...)` allows a `proxies=...` parameter, whereas `httpx.Client.request(...)` does not allow `mounts=...`.
+Also note that `requests.Session.request(...)` allows a `proxies=...` parameter, whereas `httpx2.Client.request(...)` does not allow `mounts=...`.
 
 ## SSL configuration
 
@@ -182,7 +182,7 @@ The HTTP `GET`, `DELETE`, `HEAD`, and `OPTIONS` methods are specified as not sup
 If you really do need to send request data using these http methods you should use the generic `.request` function instead.
 
 ```python
-httpx.request(
+httpx2.request(
   method="DELETE",
   url="https://www.example.com/",
   content=b'A request body on a DELETE request.'
@@ -197,7 +197,7 @@ We don't support `response.is_ok` since the naming is ambiguous there, and might
 
 There is no notion of [prepared requests](https://requests.readthedocs.io/en/stable/user/advanced/#prepared-requests) in HTTPX. If you need to customize request instantiation, see [Request instances](advanced/clients.md#request-instances).
 
-Besides, `httpx.Request()` does not support the `auth`, `timeout`, `follow_redirects`, `mounts`, `verify` and `cert` parameters. However these are available in `httpx.request`, `httpx.get`, `httpx.post` etc., as well as on [`Client` instances](advanced/clients.md#sharing-configuration-across-requests).
+Besides, `httpx2.Request()` does not support the `auth`, `timeout`, `follow_redirects`, `mounts`, `verify` and `cert` parameters. However these are available in `httpx2.request`, `httpx2.get`, `httpx2.post` etc., as well as on [`Client` instances](advanced/clients.md#sharing-configuration-across-requests).
 
 ## Mocking
 
@@ -217,7 +217,7 @@ On the other hand, HTTPX uses [HTTPCore](https://github.com/encode/httpcore) as 
 
 `requests` omits `params` whose values are `None` (e.g. `requests.get(..., params={"foo": None})`). This is not supported by HTTPX.
 
-For both query params (`params=`) and form data (`data=`), `requests` supports sending a list of tuples (e.g. `requests.get(..., params=[('key1', 'value1'), ('key1', 'value2')])`). This is not supported by HTTPX. Instead, use a dictionary with lists as values. E.g.: `httpx.get(..., params={'key1': ['value1', 'value2']})` or with form data: `httpx.post(..., data={'key1': ['value1', 'value2']})`.
+For both query params (`params=`) and form data (`data=`), `requests` supports sending a list of tuples (e.g. `requests.get(..., params=[('key1', 'value1'), ('key1', 'value2')])`). This is not supported by HTTPX. Instead, use a dictionary with lists as values. E.g.: `httpx2.get(..., params={'key1': ['value1', 'value2']})` or with form data: `httpx2.post(..., data={'key1': ['value1', 'value2']})`.
 
 ## Event Hooks
 
@@ -229,4 +229,4 @@ If you are looking for more control, consider checking out [Custom Transports](a
 
 ## Exceptions and Errors
 
-`requests` exception hierarchy is slightly different to the `httpx` exception hierarchy. `requests` exposes a top level `RequestException`, where as `httpx` exposes a top level `HTTPError`. see the exceptions exposes in requests [here](https://requests.readthedocs.io/en/latest/_modules/requests/exceptions/). See the `httpx` error hierarchy [here](https://httpx2.pydantic.dev/exceptions/).
+`requests` exception hierarchy is slightly different to the `httpx2` exception hierarchy. `requests` exposes a top level `RequestException`, where as `httpx2` exposes a top level `HTTPError`. see the exceptions exposes in requests [here](https://requests.readthedocs.io/en/latest/_modules/requests/exceptions/). See the `httpx2` error hierarchy [here](https://httpx2.pydantic.dev/exceptions/).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -3,9 +3,9 @@
 Thank you for being interested in contributing to HTTPX.
 There are many ways you can contribute to the project:
 
-- Try HTTPX and [report bugs/issues you find](https://github.com/encode/httpx/issues/new)
-- [Implement new features](https://github.com/encode/httpx/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
-- [Review Pull Requests of others](https://github.com/encode/httpx/pulls)
+- Try HTTPX and [report bugs/issues you find](https://github.com/pydantic/httpx2/issues/new)
+- [Implement new features](https://github.com/pydantic/httpx2/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+- [Review Pull Requests of others](https://github.com/pydantic/httpx2/pulls)
 - Write documentation
 - Participate in discussions
 
@@ -14,7 +14,7 @@ There are many ways you can contribute to the project:
 Found something that HTTPX should support?
 Stumbled upon some unexpected behaviour?
 
-Contributions should generally start out with [a discussion](https://github.com/encode/httpx/discussions).
+Contributions should generally start out with [a discussion](https://github.com/pydantic/httpx2/discussions).
 Possible bugs may be raised as a "Potential Issue" discussion, feature requests may
 be raised as an "Ideas" discussion. We can then determine if the discussion needs
 to be escalated into an "Issue" or not, or if we'd consider a pull request.
@@ -40,19 +40,19 @@ Some possibly useful tips for narrowing down potential issues...
 ## Development
 
 To start developing HTTPX create a **fork** of the
-[HTTPX repository](https://github.com/encode/httpx) on GitHub.
+[HTTPX repository](https://github.com/pydantic/httpx2) on GitHub.
 
 Then clone your fork with the following command replacing `YOUR-USERNAME` with
 your GitHub username:
 
 ```shell
-$ git clone https://github.com/YOUR-USERNAME/httpx
+$ git clone https://github.com/YOUR-USERNAME/httpx2
 ```
 
 You can now install the project and its dependencies using:
 
 ```shell
-$ cd httpx
+$ cd httpx2
 $ scripts/install
 ```
 
@@ -107,7 +107,7 @@ Once you've submitted your pull request, the test suite will automatically run, 
 If the test suite fails, you'll want to click through to the "Details" link, and try to identify why the test suite failed.
 
 <p align="center" style="margin: 0 0 10px">
-  <img src="https://raw.githubusercontent.com/encode/httpx/master/docs/img/gh-actions-fail.png" alt='Failing PR commit status'>
+  <img src="https://raw.githubusercontent.com/pydantic/httpx2/master/docs/img/gh-actions-fail.png" alt='Failing PR commit status'>
 </p>
 
 Here are some common ways the test suite can fail:
@@ -115,7 +115,7 @@ Here are some common ways the test suite can fail:
 ### Check Job Failed
 
 <p align="center" style="margin: 0 0 10px">
-  <img src="https://raw.githubusercontent.com/encode/httpx/master/docs/img/gh-actions-fail-check.png" alt='Failing GitHub action lint job'>
+  <img src="https://raw.githubusercontent.com/pydantic/httpx2/master/docs/img/gh-actions-fail-check.png" alt='Failing GitHub action lint job'>
 </p>
 
 This job failing means there is either a code formatting issue or type-annotation issue.
@@ -136,7 +136,7 @@ a variety of reasons like invalid markdown or missing configuration within `mkdo
 ### Python 3.X Job Failed
 
 <p align="center" style="margin: 0 0 10px">
-  <img src="https://raw.githubusercontent.com/encode/httpx/master/docs/img/gh-actions-fail-test.png" alt='Failing GitHub action test job'>
+  <img src="https://raw.githubusercontent.com/pydantic/httpx2/master/docs/img/gh-actions-fail-test.png" alt='Failing GitHub action test job'>
 </p>
 
 This job failing means the unit tests failed or not all code paths are covered by unit tests.
@@ -158,7 +158,7 @@ Before releasing a new version, create a pull request that includes:
 
 - **An update to the changelog**:
     - We follow the format from [keepachangelog](https://keepachangelog.com/en/1.0.0/).
-    - [Compare](https://github.com/encode/httpx/compare/) `master` with the tag of the latest release, and list all entries that are of interest to our users:
+    - [Compare](https://github.com/pydantic/httpx2/compare/) `master` with the tag of the latest release, and list all entries that are of interest to our users:
         - Things that **must** go in the changelog: added, changed, deprecated or removed features, and bug fixes.
         - Things that **should not** go in the changelog: changes to documentation, tests or tooling.
         - Try sorting entries in descending order of impact / importance.
@@ -168,7 +168,7 @@ Before releasing a new version, create a pull request that includes:
 For an example, see [#1006](https://github.com/encode/httpx/pull/1006).
 
 Once the release PR is merged, create a
-[new release](https://github.com/encode/httpx/releases/new) including:
+[new release](https://github.com/pydantic/httpx2/releases/new) including:
 
 - Tag version like `0.13.3`.
 - Release title `Version 0.13.3`
@@ -212,7 +212,7 @@ this is where our previously generated `client.pem` comes in:
 
 ```python
 ctx = ssl.create_default_context(cafile="/path/to/client.pem")
-client = httpx.Client(proxy="http://127.0.0.1:8080/", verify=ctx)
+client = httpx2.Client(proxy="http://127.0.0.1:8080/", verify=ctx)
 ```
 
 Note, however, that HTTPS requests will only succeed to the host specified

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -3,8 +3,8 @@
 The HTTPX library can be configured via environment variables.
 Environment variables are used by default. To ignore environment variables, `trust_env` has to be set `False`. There are two ways to set `trust_env` to disable environment variables:
 
-* On the client via `httpx.Client(trust_env=False)`.
-* Using the top-level API, such as `httpx.get("<url>", trust_env=False)`.
+* On the client via `httpx2.Client(trust_env=False)`.
+* Using the top-level API, such as `httpx2.get("<url>", trust_env=False)`.
 
 Here is a list of environment variables that HTTPX recognizes and what function they serve:
 
@@ -27,10 +27,10 @@ Valid values: A URL to a proxy
 export HTTP_PROXY=http://my-external-proxy.com:1234
 
 # This request will be sent through the proxy
-python -c "import httpx; httpx.get('http://example.com')"
+python -c "import httpx2; httpx2.get('http://example.com')"
 
 # This request will be sent directly, as we set `trust_env=False`
-python -c "import httpx; httpx.get('http://example.com', trust_env=False)"
+python -c "import httpx2; httpx2.get('http://example.com', trust_env=False)"
 
 ```
 
@@ -42,14 +42,14 @@ Valid values: a comma-separated list of hostnames/urls
 
 ```bash
 export HTTP_PROXY=http://my-external-proxy.com:1234
-export NO_PROXY=http://127.0.0.1,python-httpx.org
+export NO_PROXY=http://127.0.0.1,python-httpx2.org
 
 # As in the previous example, this request will be sent through the proxy
-python -c "import httpx; httpx.get('http://example.com')"
+python -c "import httpx2; httpx2.get('http://example.com')"
 
 # These requests will be sent directly, bypassing the proxy
-python -c "import httpx; httpx.get('http://127.0.0.1:5000/my-api')"
-python -c "import httpx; httpx.get('https://httpx2.pydantic.dev')"
+python -c "import httpx2; httpx2.get('http://127.0.0.1:5000/my-api')"
+python -c "import httpx2; httpx2.get('https://httpx2.pydantic.dev')"
 ```
 
 ## `SSL_CERT_FILE`
@@ -63,7 +63,7 @@ location.
 Example:
 
 ```console
-SSL_CERT_FILE=/path/to/ca-certs/ca-bundle.crt python -c "import httpx; httpx.get('https://example.com')"
+SSL_CERT_FILE=/path/to/ca-certs/ca-bundle.crt python -c "import httpx2; httpx2.get('https://example.com')"
 ```
 
 ## `SSL_CERT_DIR`
@@ -75,5 +75,5 @@ If this environment variable is set and the directory follows an [OpenSSL specif
 Example:
 
 ```console
-SSL_CERT_DIR=/path/to/ca-certs/ python -c "import httpx; httpx.get('https://example.com')"
+SSL_CERT_DIR=/path/to/ca-certs/ python -c "import httpx2; httpx2.get('https://example.com')"
 ```

--- a/docs/http2.md
+++ b/docs/http2.md
@@ -18,23 +18,23 @@ For a comprehensive guide to HTTP/2 you may want to check out "[http2 explained]
 
 ## Enabling HTTP/2
 
-When using the `httpx` client, HTTP/2 support is not enabled by default, because
+When using the `httpx2` client, HTTP/2 support is not enabled by default, because
 HTTP/1.1 is a mature, battle-hardened transport layer, and our HTTP/1.1
 implementation may be considered the more robust option at this point in time.
-It is possible that a future version of `httpx` may enable HTTP/2 support by default.
+It is possible that a future version of `httpx2` may enable HTTP/2 support by default.
 
 If you're issuing highly concurrent requests you might want to consider
 trying out our HTTP/2 support. You can do so by first making sure to install
 the optional HTTP/2 dependencies...
 
 ```shell
-pip install 'httpx[http2]'
+pip install 'httpx2[http2]'
 ```
 
 And then instantiating a client with HTTP/2 support enabled:
 
 ```python
-client = httpx.AsyncClient(http2=True)
+client = httpx2.AsyncClient(http2=True)
 ...
 ```
 
@@ -43,7 +43,7 @@ HTTP connections are nicely scoped, and will be closed once the context block
 is exited.
 
 ```python
-async with httpx.AsyncClient(http2=True) as client:
+async with httpx2.AsyncClient(http2=True) as client:
     ...
 ```
 
@@ -62,7 +62,7 @@ You can determine which version of the HTTP protocol was used by examining
 the `.http_version` property on the response.
 
 ```python
-client = httpx.AsyncClient(http2=True)
+client = httpx2.AsyncClient(http2=True)
 response = await client.get(...)
 print(response.http_version)  # "HTTP/1.0", "HTTP/1.1", or "HTTP/2".
 ```

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,12 +1,12 @@
 # Logging
 
-If you need to inspect the internal behaviour of `httpx`, you can use Python's standard logging to output information about the underlying network behaviour.
+If you need to inspect the internal behaviour of `httpx2`, you can use Python's standard logging to output information about the underlying network behaviour.
 
 For example, the following configuration...
 
 ```python
 import logging
-import httpx
+import httpx2
 
 logging.basicConfig(
     format="%(levelname)s [%(asctime)s] %(name)s - %(message)s",
@@ -14,7 +14,7 @@ logging.basicConfig(
     level=logging.DEBUG
 )
 
-httpx.get("https://www.example.com")
+httpx2.get("https://www.example.com")
 ```
 
 Will send debug level output to the console, or wherever `stdout` is directed too...
@@ -30,7 +30,7 @@ DEBUG [2024-09-28 17:27:41] httpcore.http11 - send_request_body.started request=
 DEBUG [2024-09-28 17:27:41] httpcore.http11 - send_request_body.complete
 DEBUG [2024-09-28 17:27:41] httpcore.http11 - receive_response_headers.started request=<Request [b'GET']>
 DEBUG [2024-09-28 17:27:41] httpcore.http11 - receive_response_headers.complete return_value=(b'HTTP/1.1', 200, b'OK', [(b'Content-Encoding', b'gzip'), (b'Accept-Ranges', b'bytes'), (b'Age', b'407727'), (b'Cache-Control', b'max-age=604800'), (b'Content-Type', b'text/html; charset=UTF-8'), (b'Date', b'Sat, 28 Sep 2024 13:27:42 GMT'), (b'Etag', b'"3147526947+gzip"'), (b'Expires', b'Sat, 05 Oct 2024 13:27:42 GMT'), (b'Last-Modified', b'Thu, 17 Oct 2019 07:18:26 GMT'), (b'Server', b'ECAcc (dcd/7D43)'), (b'Vary', b'Accept-Encoding'), (b'X-Cache', b'HIT'), (b'Content-Length', b'648')])
-INFO [2024-09-28 17:27:41] httpx - HTTP Request: GET https://www.example.com "HTTP/1.1 200 OK"
+INFO [2024-09-28 17:27:41] httpx2 - HTTP Request: GET https://www.example.com "HTTP/1.1 200 OK"
 DEBUG [2024-09-28 17:27:41] httpcore.http11 - receive_response_body.started request=<Request [b'GET']>
 DEBUG [2024-09-28 17:27:41] httpcore.http11 - receive_response_body.complete
 DEBUG [2024-09-28 17:27:41] httpcore.http11 - response_closed.started
@@ -39,13 +39,13 @@ DEBUG [2024-09-28 17:27:41] httpcore.connection - close.started
 DEBUG [2024-09-28 17:27:41] httpcore.connection - close.complete
 ```
 
-Logging output includes information from both the high-level `httpx` logger, and the network-level `httpcore` logger, which can be configured separately.
+Logging output includes information from both the high-level `httpx2` logger, and the network-level `httpcore` logger, which can be configured separately.
 
 For handling more complex logging configurations you might want to use the dictionary configuration style...
 
 ```python
 import logging.config
-import httpx
+import httpx2
 
 LOGGING_CONFIG = {
     "version": 1,
@@ -63,7 +63,7 @@ LOGGING_CONFIG = {
         }
     },
     'loggers': {
-        'httpx': {
+        'httpx2': {
             'handlers': ['default'],
             'level': 'DEBUG',
         },
@@ -75,7 +75,7 @@ LOGGING_CONFIG = {
 }
 
 logging.config.dictConfig(LOGGING_CONFIG)
-httpx.get('https://www.example.com')
+httpx2.get('https://www.example.com')
 ```
 
-The exact formatting of the debug logging may be subject to change across different versions of `httpx` and `httpcore`. If you need to rely on a particular format it is recommended that you pin installation of these packages to fixed versions.
+The exact formatting of the debug logging may be subject to change across different versions of `httpx2` and `httpcore`. If you need to rely on a particular format it is recommended that you pin installation of these packages to fixed versions.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -3,13 +3,13 @@
 First, start by importing HTTPX:
 
 ```pycon
->>> import httpx
+>>> import httpx2
 ```
 
 Now, let’s try to get a webpage.
 
 ```pycon
->>> r = httpx.get('https://httpbin.org/get')
+>>> r = httpx2.get('https://httpbin.org/get')
 >>> r
 <Response [200 OK]>
 ```
@@ -17,16 +17,16 @@ Now, let’s try to get a webpage.
 Similarly, to make an HTTP POST request:
 
 ```pycon
->>> r = httpx.post('https://httpbin.org/post', data={'key': 'value'})
+>>> r = httpx2.post('https://httpbin.org/post', data={'key': 'value'})
 ```
 
 The PUT, DELETE, HEAD, and OPTIONS requests all follow the same style:
 
 ```pycon
->>> r = httpx.put('https://httpbin.org/put', data={'key': 'value'})
->>> r = httpx.delete('https://httpbin.org/delete')
->>> r = httpx.head('https://httpbin.org/get')
->>> r = httpx.options('https://httpbin.org/get')
+>>> r = httpx2.put('https://httpbin.org/put', data={'key': 'value'})
+>>> r = httpx2.delete('https://httpbin.org/delete')
+>>> r = httpx2.head('https://httpbin.org/get')
+>>> r = httpx2.options('https://httpbin.org/get')
 ```
 
 ## Passing Parameters in URLs
@@ -35,7 +35,7 @@ To include URL query parameters in the request, use the `params` keyword:
 
 ```pycon
 >>> params = {'key1': 'value1', 'key2': 'value2'}
->>> r = httpx.get('https://httpbin.org/get', params=params)
+>>> r = httpx2.get('https://httpbin.org/get', params=params)
 ```
 
 To see how the values get encoding into the URL string, we can inspect the
@@ -50,7 +50,7 @@ You can also pass a list of items as a value:
 
 ```pycon
 >>> params = {'key1': 'value1', 'key2': ['value2', 'value3']}
->>> r = httpx.get('https://httpbin.org/get', params=params)
+>>> r = httpx2.get('https://httpbin.org/get', params=params)
 >>> r.url
 URL('https://httpbin.org/get?key1=value1&key2=value2&key2=value3')
 ```
@@ -60,7 +60,7 @@ URL('https://httpbin.org/get?key1=value1&key2=value2&key2=value3')
 HTTPX will automatically handle decoding the response content into Unicode text.
 
 ```pycon
->>> r = httpx.get('https://www.example.org/')
+>>> r = httpx2.get('https://www.example.org/')
 >>> r.text
 '<!doctype html>\n<html>\n<head>\n<title>Example Domain</title>...'
 ```
@@ -117,7 +117,7 @@ For example, to create an image from binary data returned by a request, you can 
 Often Web API responses will be encoded as JSON.
 
 ```pycon
->>> r = httpx.get('https://api.github.com/events')
+>>> r = httpx2.get('https://api.github.com/events')
 >>> r.json()
 [{u'repository': {u'open_issues': 0, u'url': 'https://github.com/...' ...  }}]
 ```
@@ -129,7 +129,7 @@ To include additional headers in the outgoing request, use the `headers` keyword
 ```pycon
 >>> url = 'https://httpbin.org/headers'
 >>> headers = {'user-agent': 'my-app/0.0.1'}
->>> r = httpx.get(url, headers=headers)
+>>> r = httpx2.get(url, headers=headers)
 ```
 
 ## Sending Form Encoded Data
@@ -140,7 +140,7 @@ which is used for HTML forms.
 
 ```pycon
 >>> data = {'key1': 'value1', 'key2': 'value2'}
->>> r = httpx.post("https://httpbin.org/post", data=data)
+>>> r = httpx2.post("https://httpbin.org/post", data=data)
 >>> print(r.text)
 {
   ...
@@ -156,7 +156,7 @@ Form encoded data can also include multiple values from a given key.
 
 ```pycon
 >>> data = {'key1': ['value1', 'value2']}
->>> r = httpx.post("https://httpbin.org/post", data=data)
+>>> r = httpx2.post("https://httpbin.org/post", data=data)
 >>> print(r.text)
 {
   ...
@@ -177,7 +177,7 @@ You can also upload files, using HTTP multipart encoding:
 ```pycon
 >>> with open('report.xls', 'rb') as report_file:
 ...     files = {'upload-file': report_file}
-...     r = httpx.post("https://httpbin.org/post", files=files)
+...     r = httpx2.post("https://httpbin.org/post", files=files)
 >>> print(r.text)
 {
   ...
@@ -194,7 +194,7 @@ of items for the file value:
 ```pycon
 >>> with open('report.xls', 'rb') as report_file:
 ...     files = {'upload-file': ('report.xls', report_file, 'application/vnd.ms-excel')}
-...     r = httpx.post("https://httpbin.org/post", files=files)
+...     r = httpx2.post("https://httpbin.org/post", files=files)
 >>> print(r.text)
 {
   ...
@@ -211,7 +211,7 @@ If you need to include non-file data fields in the multipart form, use the `data
 >>> data = {'message': 'Hello, world!'}
 >>> with open('report.xls', 'rb') as report_file:
 ...     files = {'file': report_file}
-...     r = httpx.post("https://httpbin.org/post", data=data, files=files)
+...     r = httpx2.post("https://httpbin.org/post", data=data, files=files)
 >>> print(r.text)
 {
   ...
@@ -232,7 +232,7 @@ For more complicated data structures you'll often want to use JSON encoding inst
 
 ```pycon
 >>> data = {'integer': 123, 'boolean': True, 'list': ['a', 'b', 'c']}
->>> r = httpx.post("https://httpbin.org/post", json=data)
+>>> r = httpx2.post("https://httpbin.org/post", json=data)
 >>> print(r.text)
 {
   ...
@@ -256,7 +256,7 @@ either a `bytes` type or a generator that yields `bytes`.
 
 ```pycon
 >>> content = b'Hello, world'
->>> r = httpx.post("https://httpbin.org/post", content=content)
+>>> r = httpx2.post("https://httpbin.org/post", content=content)
 ```
 
 You may also want to set a custom `Content-Type` header when uploading
@@ -267,7 +267,7 @@ binary data.
 We can inspect the HTTP status code of the response:
 
 ```pycon
->>> r = httpx.get('https://httpbin.org/get')
+>>> r = httpx2.get('https://httpbin.org/get')
 >>> r.status_code
 200
 ```
@@ -275,21 +275,21 @@ We can inspect the HTTP status code of the response:
 HTTPX also includes an easy shortcut for accessing status codes by their text phrase.
 
 ```pycon
->>> r.status_code == httpx.codes.OK
+>>> r.status_code == httpx2.codes.OK
 True
 ```
 
 We can raise an exception for any responses which are not a 2xx success code:
 
 ```pycon
->>> not_found = httpx.get('https://httpbin.org/status/404')
+>>> not_found = httpx2.get('https://httpbin.org/status/404')
 >>> not_found.status_code
 404
 >>> not_found.raise_for_status()
 Traceback (most recent call last):
-  File "/Users/tomchristie/GitHub/encode/httpcore/httpx/models.py", line 837, in raise_for_status
+  File "/Users/tomchristie/GitHub/encode/httpcore/httpx2/models.py", line 837, in raise_for_status
     raise HTTPStatusError(message, response=self)
-httpx._exceptions.HTTPStatusError: 404 Client Error: Not Found for url: https://httpbin.org/status/404
+httpx2._exceptions.HTTPStatusError: 404 Client Error: Not Found for url: https://httpbin.org/status/404
 For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
 ```
 
@@ -302,8 +302,8 @@ Any successful response codes will return the `Response` instance rather than ra
 The method returns the response instance, allowing you to use it inline. For example:
 
 ```pycon
->>> r = httpx.get('...').raise_for_status()
->>> data = httpx.get('...').raise_for_status().json()
+>>> r = httpx2.get('...').raise_for_status()
+>>> data = httpx2.get('...').raise_for_status().json()
 ```
 
 ## Response Headers
@@ -344,7 +344,7 @@ For large downloads you may want to use streaming responses that do not load the
 You can stream the binary content of the response...
 
 ```pycon
->>> with httpx.stream("GET", "https://www.example.com") as r:
+>>> with httpx2.stream("GET", "https://www.example.com") as r:
 ...     for data in r.iter_bytes():
 ...         print(data)
 ```
@@ -352,7 +352,7 @@ You can stream the binary content of the response...
 Or the text of the response...
 
 ```pycon
->>> with httpx.stream("GET", "https://www.example.com") as r:
+>>> with httpx2.stream("GET", "https://www.example.com") as r:
 ...     for text in r.iter_text():
 ...         print(text)
 ```
@@ -360,7 +360,7 @@ Or the text of the response...
 Or stream the text, on a line-by-line basis...
 
 ```pycon
->>> with httpx.stream("GET", "https://www.example.com") as r:
+>>> with httpx2.stream("GET", "https://www.example.com") as r:
 ...     for line in r.iter_lines():
 ...         print(line)
 ```
@@ -371,7 +371,7 @@ In some cases you might want to access the raw bytes on the response without app
 not be automatically decoded.
 
 ```pycon
->>> with httpx.stream("GET", "https://www.example.com") as r:
+>>> with httpx2.stream("GET", "https://www.example.com") as r:
 ...     for chunk in r.iter_raw():
 ...         print(chunk)
 ```
@@ -379,7 +379,7 @@ not be automatically decoded.
 If you're using streaming responses in any of these ways then the `response.content` and `response.text` attributes will not be available, and will raise errors if accessed. However you can also use the response streaming functionality to conditionally load the response body:
 
 ```pycon
->>> with httpx.stream("GET", "https://www.example.com") as r:
+>>> with httpx2.stream("GET", "https://www.example.com") as r:
 ...     if int(r.headers['Content-Length']) < TOO_LONG:
 ...         r.read()
 ...         print(r.text)
@@ -390,7 +390,7 @@ If you're using streaming responses in any of these ways then the `response.cont
 Any cookies that are set on the response can be easily accessed:
 
 ```pycon
->>> r = httpx.get('https://httpbin.org/cookies/set?chocolate=chip')
+>>> r = httpx2.get('https://httpbin.org/cookies/set?chocolate=chip')
 >>> r.cookies['chocolate']
 'chip'
 ```
@@ -399,7 +399,7 @@ To include cookies in an outgoing request, use the `cookies` parameter:
 
 ```pycon
 >>> cookies = {"peanut": "butter"}
->>> r = httpx.get('https://httpbin.org/cookies', cookies=cookies)
+>>> r = httpx2.get('https://httpbin.org/cookies', cookies=cookies)
 >>> r.json()
 {'cookies': {'peanut': 'butter'}}
 ```
@@ -408,10 +408,10 @@ Cookies are returned in a `Cookies` instance, which is a dict-like data structur
 with additional API for accessing cookies by their domain or path.
 
 ```pycon
->>> cookies = httpx.Cookies()
+>>> cookies = httpx2.Cookies()
 >>> cookies.set('cookie_on_domain', 'hello, there!', domain='httpbin.org')
 >>> cookies.set('cookie_off_domain', 'nope.', domain='example.org')
->>> r = httpx.get('http://httpbin.org/cookies', cookies=cookies)
+>>> r = httpx2.get('http://httpbin.org/cookies', cookies=cookies)
 >>> r.json()
 {'cookies': {'cookie_on_domain': 'hello, there!'}}
 ```
@@ -424,7 +424,7 @@ this can be explicitly enabled.
 For example, GitHub redirects all HTTP requests to HTTPS.
 
 ```pycon
->>> r = httpx.get('http://github.com/')
+>>> r = httpx2.get('http://github.com/')
 >>> r.status_code
 301
 >>> r.history
@@ -436,7 +436,7 @@ For example, GitHub redirects all HTTP requests to HTTPS.
 You can modify the default redirection handling with the `follow_redirects` parameter:
 
 ```pycon
->>> r = httpx.get('http://github.com/', follow_redirects=True)
+>>> r = httpx2.get('http://github.com/', follow_redirects=True)
 >>> r.url
 URL('https://github.com/')
 >>> r.status_code
@@ -459,13 +459,13 @@ The default timeout for network inactivity is five seconds. You can modify the
 value to be more or less strict:
 
 ```pycon
->>> httpx.get('https://github.com/', timeout=0.001)
+>>> httpx2.get('https://github.com/', timeout=0.001)
 ```
 
 You can also disable the timeout behavior completely...
 
 ```pycon
->>> httpx.get('https://github.com/', timeout=None)
+>>> httpx2.get('https://github.com/', timeout=None)
 ```
 
 For advanced timeout management, see [Timeout fine-tuning](advanced/timeouts.md#fine-tuning-the-configuration).
@@ -479,7 +479,7 @@ plaintext `str` or `bytes` objects as the `auth` argument to the request
 functions:
 
 ```pycon
->>> httpx.get("https://example.com", auth=("my_user", "password123"))
+>>> httpx2.get("https://example.com", auth=("my_user", "password123"))
 ```
 
 To provide credentials for Digest authentication you'll need to instantiate
@@ -488,8 +488,8 @@ This object can be then passed as the `auth` argument to the request methods
 as above:
 
 ```pycon
->>> auth = httpx.DigestAuth("my_user", "password123")
->>> httpx.get("https://example.com", auth=auth)
+>>> auth = httpx2.DigestAuth("my_user", "password123")
+>>> httpx2.get("https://example.com", auth=auth)
 <Response [200 OK]>
 ```
 
@@ -504,8 +504,8 @@ while issuing an HTTP request. These exceptions include a `.request` attribute.
 
 ```python
 try:
-    response = httpx.get("https://www.example.com/")
-except httpx.RequestError as exc:
+    response = httpx2.get("https://www.example.com/")
+except httpx2.RequestError as exc:
     print(f"An error occurred while requesting {exc.request.url!r}.")
 ```
 
@@ -513,10 +513,10 @@ The `HTTPStatusError` class is raised by `response.raise_for_status()` on respon
 These exceptions include both a `.request` and a `.response` attribute.
 
 ```python
-response = httpx.get("https://www.example.com/")
+response = httpx2.get("https://www.example.com/")
 try:
     response.raise_for_status()
-except httpx.HTTPStatusError as exc:
+except httpx2.HTTPStatusError as exc:
     print(f"Error response {exc.response.status_code} while requesting {exc.request.url!r}.")
 ```
 
@@ -527,9 +527,9 @@ You can either use this base class to catch both categories...
 
 ```python
 try:
-    response = httpx.get("https://www.example.com/")
+    response = httpx2.get("https://www.example.com/")
     response.raise_for_status()
-except httpx.HTTPError as exc:
+except httpx2.HTTPError as exc:
     print(f"Error while requesting {exc.request.url!r}.")
 ```
 
@@ -537,11 +537,11 @@ Or handle each case explicitly...
 
 ```python
 try:
-    response = httpx.get("https://www.example.com/")
+    response = httpx2.get("https://www.example.com/")
     response.raise_for_status()
-except httpx.RequestError as exc:
+except httpx2.RequestError as exc:
     print(f"An error occurred while requesting {exc.request.url!r}.")
-except httpx.HTTPStatusError as exc:
+except httpx2.HTTPStatusError as exc:
     print(f"Error response {exc.response.status_code} while requesting {exc.request.url!r}.")
 ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -11,7 +11,7 @@ This page lists some common problems or issues you could encounter while develop
 **Description**: When using a proxy and making an HTTPS request, you see an exception looking like this:
 
 ```console
-httpx.ProxyError: _ssl.c:1091: The handshake operation timed out
+httpx2.ProxyError: _ssl.c:1091: The handshake operation timed out
 ```
 
 **Similar issues**: [encode/httpx#1412](https://github.com/encode/httpx/issues/1412), [encode/httpx#1433](https://github.com/encode/httpx/issues/1433)
@@ -20,8 +20,8 @@ httpx.ProxyError: _ssl.c:1091: The handshake operation timed out
 
 ```python
 mounts = {
-  "http://": httpx.HTTPTransport(proxy="http://myproxy.org"),
-  "https://": httpx.HTTPTransport(proxy="https://myproxy.org"),
+  "http://": httpx2.HTTPTransport(proxy="http://myproxy.org"),
+  "https://": httpx2.HTTPTransport(proxy="https://myproxy.org"),
 }
 ```
 
@@ -33,8 +33,8 @@ Change the scheme of your HTTPS proxy to `http://...` instead of `https://...`:
 
 ```python
 mounts = {
-  "http://": httpx.HTTPTransport(proxy="http://myproxy.org"),
-  "https://": httpx.HTTPTransport(proxy="http://myproxy.org"),
+  "http://": httpx2.HTTPTransport(proxy="http://myproxy.org"),
+  "https://": httpx2.HTTPTransport(proxy="http://myproxy.org"),
 }
 ```
 
@@ -42,7 +42,7 @@ This can be simplified to:
 
 ```python
 proxy = "http://myproxy.org"
-with httpx.Client(proxy=proxy) as client:
+with httpx2.Client(proxy=proxy) as client:
   ...
 ```
 
@@ -55,7 +55,7 @@ For more information, see [Proxies: FORWARD vs TUNNEL](advanced/proxies.md#forwa
 **Description**: your proxy _does_ support connecting via HTTPS, but you are seeing errors along the lines of...
 
 ```console
-httpx.ProxyError: [SSL: PRE_MAC_LENGTH_TOO_LONG] invalid alert (_ssl.c:1091)
+httpx2.ProxyError: [SSL: PRE_MAC_LENGTH_TOO_LONG] invalid alert (_ssl.c:1091)
 ```
 
 **Similar issues**: [encode/httpx#1424](https://github.com/encode/httpx/issues/1424).


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX2! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

Fixes: https://httpx2.pydantic.dev/quickstart etc.

# Summary

<!-- Write a small summary about what is happening here. -->

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.

Create a pull request that modifies files in the `docs/` directory (and its subdirectories) to change `httpx` to `httpx2`. In these files:
* Change any dependency mentions from `httpx` to `httpx2`.
* Change all imports such as `import httpx` to `import httpx2`.
* Change all from imports such as `from httpx import xyz` to `from httpx2 import xyz`.
* etc.

In the modified files, please replace URLs containing `https://github.com/encode/httpx/` with `https://github.com/pydantic/httpx2/`.  Test each modified URL, and if the resource is unreachable, then revert to the original URL that starts with https://github.com/encode/httpx/

The file `docs/third_party_packages.md` is not ready, so please do:
`git checkout main -- docs/third_party_packages.md`

Agent-Logs-Url: https://github.com/cclauss/httpx2/sessions/9a801e7e-2c67-43e4-b70e-3c914523170d