### PR TITLE
Ruff lint and format the whole codebase

### DIFF
--- a/scripts/check
+++ b/scripts/check
@@ -5,7 +5,7 @@ export SOURCE_FILES="src/httpx2 tests/httpx2 src/httpcore2 tests/httpcore2"
 set -x
 
 uv lock --check
-uv run ruff format --check --diff $SOURCE_FILES
+uv run ruff format --check --diff
 uv run mypy $SOURCE_FILES
-uv run ruff check $SOURCE_FILES
+uv run ruff check
 uv run python scripts/unasync.py --check

--- a/scripts/unasync.py
+++ b/scripts/unasync.py
@@ -29,9 +29,7 @@ SUBS = [
     ("@pytest.mark.trio", ""),
     ("AutoBackend", "SyncBackend"),
 ]
-COMPILED_SUBS = [
-    (re.compile(r"(^|\b)" + regex + r"($|\b)"), repl) for regex, repl in SUBS
-]
+COMPILED_SUBS = [(re.compile(r"(^|\b)" + regex + r"($|\b)"), repl) for regex, repl in SUBS]
 
 USED_SUBS = set()
 
@@ -67,7 +65,7 @@ def unasync_file_check(in_path, out_path):
 
 
 def unasync_dir(in_dir, out_dir, check_only=False):
-    for dirpath, dirnames, filenames in os.walk(in_dir):
+    for dirpath, _dirnames, filenames in os.walk(in_dir):
         for filename in filenames:
             if not filename.endswith(".py"):
                 continue


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX2! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Changes in `scripts/check`:
```diff
  export SOURCE_FILES="src/httpx2 tests/httpx2 src/httpcore2 tests/httpcore2"

- uv run ruff format --check --diff $SOURCE_FILES
- uv run ruff check $SOURCE_FILES
+ uv run ruff format --check --diff
+ uv run ruff check
```
__Why?__  We rely on files in `scripts/` and`tests/` that are not in `$SOURCE_FILES` which are not currently being linted.
This trend could worsen as new files are added to the codebase.

`Ruff` is perfectly capable of finding Python files in the codebase, so let's lint and format them all to detect issues and maintain consistency.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
