### PR TITLE
Add pytest-HTTPX2 plugin details to documentation

### DIFF
--- a/docs/third_party_packages.md
+++ b/docs/third_party_packages.md
@@ -60,6 +60,12 @@ WebSocket support for HTTPX.
 
 Provides a [pytest](https://docs.pytest.org/en/latest/) fixture to mock HTTPX within test cases.
 
+### pytest-HTTPX2
+
+[GitHub](https://github.com/lundberg/pytest-httpx2)
+
+A pytest plugin for mocking out HTTPX2 using RESPX.
+
 ### RESPX
 
 [GitHub](https://github.com/lundberg/respx) - [Documentation](https://lundberg.github.io/respx/)


### PR DESCRIPTION
Added information about the `pytest-httpx2` plugin for mocking out HTTPX2 using RESPX.