### PR TITLE
Enable C4 and PERF ruff rule sets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ exclude = ["src/httpcore2/httpcore2/_sync", "tests/httpcore2/_sync"]
 
 [tool.ruff.lint]
 select = ["B", "C4", "E", "F", "I", "PERF", "PIE", "W"]
-ignore = ["B904", "B028"]
+ignore = ["B904", "B028", "C401", "PERF203"]
 
 [tool.ruff.lint.isort]
 combine-as-imports = true
@@ -58,8 +58,6 @@ known-first-party = ["httpx2", "httpcore2"]
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F403", "F405"]
-"src/httpcore2/httpcore2/_async/connection.py" = ["PERF203"]
-"src/httpcore2/httpcore2/_async/http_proxy.py" = ["C401"]
 
 [tool.mypy]
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ line-length = 120
 exclude = ["src/httpcore2/httpcore2/_sync", "tests/httpcore2/_sync"]
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I", "B", "PIE"]
+select = ["B", "C4", "E", "F", "I", "PERF", "PIE", "W"]
 ignore = ["B904", "B028"]
 
 [tool.ruff.lint.isort]
@@ -58,6 +58,8 @@ known-first-party = ["httpx2", "httpcore2"]
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F403", "F405"]
+"src/httpcore2/httpcore2/_async/connection.py" = ["PERF203"]
+"src/httpcore2/httpcore2/_async/http_proxy.py" = ["C401"]
 
 [tool.mypy]
 ignore_missing_imports = true

--- a/src/httpcore2/httpcore2/_models.py
+++ b/src/httpcore2/httpcore2/_models.py
@@ -113,7 +113,7 @@ def include_request_headers(
     url: "URL",
     content: None | bytes | typing.Iterable[bytes] | typing.AsyncIterable[bytes],
 ) -> list[tuple[bytes, bytes]]:
-    headers_set = set(k.lower() for k, v in headers)
+    headers_set = {k.lower() for k, v in headers}
 
     if b"host" not in headers_set:
         default_port = DEFAULT_PORTS.get(url.scheme)
@@ -404,7 +404,7 @@ class Response:
                 "You should use 'await response.aread()' instead."
             )
         if not hasattr(self, "_content"):
-            self._content = b"".join([part for part in self.iter_stream()])
+            self._content = b"".join(list(self.iter_stream()))
         return self._content
 
     def iter_stream(self) -> typing.Iterator[bytes]:

--- a/src/httpx2/httpx2/_main.py
+++ b/src/httpx2/httpx2/_main.py
@@ -180,8 +180,7 @@ def format_certificate(cert: _PeerCertRetDictType) -> str:  # pragma: no cover
             lines.append(f"*   {key}:")
             for item in value:
                 if key in ("subject", "issuer"):
-                    for sub_item in item:
-                        lines.append(f"*     {sub_item[0]}: {sub_item[1]!r}")
+                    lines.extend(f"*     {sub_item[0]}: {sub_item[1]!r}" for sub_item in item)
                 elif isinstance(item, tuple) and len(item) == 2:
                     lines.append(f"*     {item[0]}: {item[1]!r}")
                 else:

--- a/src/httpx2/httpx2/_models.py
+++ b/src/httpx2/httpx2/_models.py
@@ -175,7 +175,7 @@ class Headers(typing.MutableMapping[str, str]):
                     try:
                         key.decode(encoding)
                         value.decode(encoding)
-                    except UnicodeDecodeError:
+                    except UnicodeDecodeError:  # noqa: PERF203
                         break
                 else:
                     # The else block runs if 'break' did not occur, meaning

--- a/src/httpx2/httpx2/_models.py
+++ b/src/httpx2/httpx2/_models.py
@@ -175,7 +175,7 @@ class Headers(typing.MutableMapping[str, str]):
                     try:
                         key.decode(encoding)
                         value.decode(encoding)
-                    except UnicodeDecodeError:  # noqa: PERF203
+                    except UnicodeDecodeError:
                         break
                 else:
                     # The else block runs if 'break' did not occur, meaning

--- a/tests/httpcore2/test_models.py
+++ b/tests/httpcore2/test_models.py
@@ -125,7 +125,7 @@ def test_response_sync_read():
 def test_response_sync_streaming():
     stream = ByteIterator([b"Hello, ", b"world!"])
     response = httpcore2.Response(200, content=stream)
-    content = b"".join([chunk for chunk in response.iter_stream()])
+    content = b"".join(list(response.iter_stream()))
     assert content == b"Hello, world!"
 
     # We streamed the response rather than reading it, so .content is not available.

--- a/tests/httpx2/models/test_headers.py
+++ b/tests/httpx2/models/test_headers.py
@@ -183,8 +183,8 @@ def test_sensitive_headers(header):
     ],
 )
 def test_obfuscate_sensitive_headers(headers, output):
-    as_dict = {k: v for k, v in output}
-    headers_class = httpx2.Headers({k: v for k, v in headers})
+    as_dict = dict(output)
+    headers_class = httpx2.Headers(dict(headers))
     assert repr(headers_class) == f"Headers({as_dict!r})"
 
 

--- a/tests/httpx2/models/test_responses.py
+++ b/tests/httpx2/models/test_responses.py
@@ -669,9 +669,7 @@ async def test_aiter_lines():
         content=b"Hello,\nworld!",
     )
 
-    content = []
-    async for line in response.aiter_lines():
-        content.append(line)
+    content = [line async for line in response.aiter_lines()]
     assert content == ["Hello,", "world!"]
 
 


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX2! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

```diff
 [tool.ruff.lint]
- select = ["E", "F", "W", "I", "B", "PIE"]
+ select = ["B", "C4", "E", "F", "I", "PERF", "PIE", "W"]
```
% `ruff check --statistics`
```
4	C416   	unnecessary-comprehension
2	C401   	unnecessary-generator-set
2	PERF203	try-except-in-loop
2	PERF401	manual-list-comprehension
Found 10 errors.
No fixes available (6 hidden fixes can be enabled with the `--unsafe-fixes` option).
```
https://docs.astral.sh/ruff/rules/#flake8-comprehensions-c4
https://docs.astral.sh/ruff/rules/#perflint-perf

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.

% `ruff rule PERF401`
# manual-list-comprehension (PERF401)

Derived from the **Perflint** linter.

Fix is sometimes available.

## What it does
Checks for `for` loops that can be replaced by a list comprehension.

## Why is this bad?
When creating a transformed list from an existing list using a for-loop,
prefer a list comprehension. List comprehensions are more readable and
more performant.

Using the below as an example, the list comprehension is ~10% faster on
Python 3.11, and ~25% faster on Python 3.10.

Note that, as with all `perflint` rules, this is only intended as a
micro-optimization, and will have a negligible impact on performance in
most cases.

## Example
```python
original = list(range(10000))
filtered = []
for i in original:
    if i % 2:
        filtered.append(i)
```

Use instead:
```python
original = list(range(10000))
filtered = [x for x in original if x % 2]
```

If you're appending to an existing list, use the `extend` method instead:
```python
original = list(range(10000))
filtered.extend(x for x in original if x % 2)
```
