### PR TITLE
fix: clean up garbage connections on cancellation in AsyncConnectionPool

### DIFF
--- a/src/httpcore2/httpcore2/_async/connection.py
+++ b/src/httpcore2/httpcore2/_async/connection.py
@@ -156,6 +156,9 @@ class AsyncHTTPConnection(AsyncConnectionInterface):
             async with Trace("close", logger, None, {}):
                 await self._connection.aclose()
 
+    def is_connected(self) -> bool:
+        return self._connection is not None and self._connection.is_connected()
+
     def is_available(self) -> bool:
         if self._connection is None:
             # If HTTP/2 support is enabled, and the resulting connection could

--- a/src/httpcore2/httpcore2/_async/connection_pool.py
+++ b/src/httpcore2/httpcore2/_async/connection_pool.py
@@ -264,10 +264,19 @@ class AsyncConnectionPool(AsyncRequestInterface):
         closing_connections: list[AsyncConnectionInterface] = []
         retained_connections: list[AsyncConnectionInterface] = []
 
+        # Connections currently referenced by an active request (including
+        # connections that are in the process of being established).
+        request_connections = {r.connection for r in self._requests}
+
         # First we handle cleaning up any connections that are closed
         # or have expired their keep-alive, in a single pass.
         for connection in self._connections:
             if connection.is_closed():
+                continue
+            elif not (connection.is_connected() or connection in request_connections):
+                # Garbage: a NEW-state connection whose request was cancelled
+                # before the TCP handshake completed.  Drop it without closing
+                # (there is no socket to close yet).
                 continue
             elif connection.has_expired():
                 closing_connections.append(connection)

--- a/src/httpcore2/httpcore2/_async/http11.py
+++ b/src/httpcore2/httpcore2/_async/http11.py
@@ -246,6 +246,9 @@ class AsyncHTTP11Connection(AsyncConnectionInterface):
     def can_handle_request(self, origin: Origin) -> bool:
         return origin == self._origin
 
+    def is_connected(self) -> bool:
+        return not self.is_closed()
+
     def is_available(self) -> bool:
         # Note that HTTP/1.1 connections in the "NEW" state are not treated as
         # being "available". The control flow which created the connection will

--- a/src/httpcore2/httpcore2/_async/http2.py
+++ b/src/httpcore2/httpcore2/_async/http2.py
@@ -477,6 +477,9 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
     def can_handle_request(self, origin: Origin) -> bool:
         return origin == self._origin
 
+    def is_connected(self) -> bool:
+        return not self.is_closed()
+
     def is_available(self) -> bool:
         return (
             self._state != HTTPConnectionState.CLOSED

--- a/src/httpcore2/httpcore2/_async/http_proxy.py
+++ b/src/httpcore2/httpcore2/_async/http_proxy.py
@@ -204,6 +204,9 @@ class AsyncForwardHTTPConnection(AsyncConnectionInterface):
     def info(self) -> str:
         return self._connection.info()
 
+    def is_connected(self) -> bool:
+        return self._connection.is_connected()
+
     def is_available(self) -> bool:
         return self._connection.is_available()
 
@@ -329,6 +332,9 @@ class AsyncTunnelHTTPConnection(AsyncConnectionInterface):
 
     def info(self) -> str:
         return self._connection.info()
+
+    def is_connected(self) -> bool:
+        return self._connection.is_connected()
 
     def is_available(self) -> bool:
         return self._connection.is_available()

--- a/src/httpcore2/httpcore2/_async/interfaces.py
+++ b/src/httpcore2/httpcore2/_async/interfaces.py
@@ -95,6 +95,18 @@ class AsyncConnectionInterface(AsyncRequestInterface):
     def can_handle_request(self, origin: Origin) -> bool:
         raise NotImplementedError()  # pragma: no cover
 
+    def is_connected(self) -> bool:
+        """
+        Return `True` if the connection is open (the underlying socket has been
+        established).  A connection in the NEW state (just created but not yet
+        connected) returns `False`.
+
+        Note: for some implementations ``is_connected() != not is_closed()``.
+        The default implementation returns ``not self.is_closed()``, which is
+        correct for connections that are never in the NEW (pre-TCP) state.
+        """
+        return not self.is_closed()  # pragma: nocover
+
     def is_available(self) -> bool:
         """
         Return `True` if the connection is currently able to accept an

--- a/src/httpcore2/httpcore2/_async/interfaces.py
+++ b/src/httpcore2/httpcore2/_async/interfaces.py
@@ -101,11 +101,11 @@ class AsyncConnectionInterface(AsyncRequestInterface):
         established).  A connection in the NEW state (just created but not yet
         connected) returns `False`.
 
-        Note: for some implementations ``is_connected() != not is_closed()``.
-        The default implementation returns ``not self.is_closed()``, which is
+        Note: for some implementations `is_connected() != not is_closed()`.
+        The default implementation returns `not self.is_closed()`, which is
         correct for connections that are never in the NEW (pre-TCP) state.
         """
-        return not self.is_closed()  # pragma: nocover
+        return not self.is_closed()  # pragma: no cover
 
     def is_available(self) -> bool:
         """

--- a/src/httpcore2/httpcore2/_async/socks_proxy.py
+++ b/src/httpcore2/httpcore2/_async/socks_proxy.py
@@ -283,6 +283,9 @@ class AsyncSocks5Connection(AsyncConnectionInterface):
         if self._connection is not None:
             await self._connection.aclose()
 
+    def is_connected(self) -> bool:
+        return self._connection is not None and self._connection.is_connected()
+
     def is_available(self) -> bool:
         if self._connection is None:  # pragma: no cover
             # If HTTP/2 support is enabled, and the resulting connection could

--- a/src/httpcore2/httpcore2/_sync/connection.py
+++ b/src/httpcore2/httpcore2/_sync/connection.py
@@ -156,6 +156,9 @@ class HTTPConnection(ConnectionInterface):
             with Trace("close", logger, None, {}):
                 self._connection.close()
 
+    def is_connected(self) -> bool:
+        return self._connection is not None and self._connection.is_connected()
+
     def is_available(self) -> bool:
         if self._connection is None:
             # If HTTP/2 support is enabled, and the resulting connection could

--- a/src/httpcore2/httpcore2/_sync/connection_pool.py
+++ b/src/httpcore2/httpcore2/_sync/connection_pool.py
@@ -264,10 +264,19 @@ class ConnectionPool(RequestInterface):
         closing_connections: list[ConnectionInterface] = []
         retained_connections: list[ConnectionInterface] = []
 
+        # Connections currently referenced by an active request (including
+        # connections that are in the process of being established).
+        request_connections = {r.connection for r in self._requests}
+
         # First we handle cleaning up any connections that are closed
         # or have expired their keep-alive, in a single pass.
         for connection in self._connections:
             if connection.is_closed():
+                continue
+            elif not (connection.is_connected() or connection in request_connections):
+                # Garbage: a NEW-state connection whose request was cancelled
+                # before the TCP handshake completed.  Drop it without closing
+                # (there is no socket to close yet).
                 continue
             elif connection.has_expired():
                 closing_connections.append(connection)

--- a/src/httpcore2/httpcore2/_sync/http11.py
+++ b/src/httpcore2/httpcore2/_sync/http11.py
@@ -246,6 +246,9 @@ class HTTP11Connection(ConnectionInterface):
     def can_handle_request(self, origin: Origin) -> bool:
         return origin == self._origin
 
+    def is_connected(self) -> bool:
+        return not self.is_closed()
+
     def is_available(self) -> bool:
         # Note that HTTP/1.1 connections in the "NEW" state are not treated as
         # being "available". The control flow which created the connection will

--- a/src/httpcore2/httpcore2/_sync/http2.py
+++ b/src/httpcore2/httpcore2/_sync/http2.py
@@ -477,6 +477,9 @@ class HTTP2Connection(ConnectionInterface):
     def can_handle_request(self, origin: Origin) -> bool:
         return origin == self._origin
 
+    def is_connected(self) -> bool:
+        return not self.is_closed()
+
     def is_available(self) -> bool:
         return (
             self._state != HTTPConnectionState.CLOSED

--- a/src/httpcore2/httpcore2/_sync/http_proxy.py
+++ b/src/httpcore2/httpcore2/_sync/http_proxy.py
@@ -204,6 +204,9 @@ class ForwardHTTPConnection(ConnectionInterface):
     def info(self) -> str:
         return self._connection.info()
 
+    def is_connected(self) -> bool:
+        return self._connection.is_connected()
+
     def is_available(self) -> bool:
         return self._connection.is_available()
 
@@ -329,6 +332,9 @@ class TunnelHTTPConnection(ConnectionInterface):
 
     def info(self) -> str:
         return self._connection.info()
+
+    def is_connected(self) -> bool:
+        return self._connection.is_connected()
 
     def is_available(self) -> bool:
         return self._connection.is_available()

--- a/src/httpcore2/httpcore2/_sync/interfaces.py
+++ b/src/httpcore2/httpcore2/_sync/interfaces.py
@@ -101,11 +101,11 @@ class ConnectionInterface(RequestInterface):
         established).  A connection in the NEW state (just created but not yet
         connected) returns `False`.
 
-        Note: for some implementations ``is_connected() != not is_closed()``.
-        The default implementation returns ``not self.is_closed()``, which is
+        Note: for some implementations `is_connected() != not is_closed()`.
+        The default implementation returns `not self.is_closed()`, which is
         correct for connections that are never in the NEW (pre-TCP) state.
         """
-        return not self.is_closed()  # pragma: nocover
+        return not self.is_closed()  # pragma: no cover
 
     def is_available(self) -> bool:
         """

--- a/src/httpcore2/httpcore2/_sync/interfaces.py
+++ b/src/httpcore2/httpcore2/_sync/interfaces.py
@@ -95,6 +95,18 @@ class ConnectionInterface(RequestInterface):
     def can_handle_request(self, origin: Origin) -> bool:
         raise NotImplementedError()  # pragma: no cover
 
+    def is_connected(self) -> bool:
+        """
+        Return `True` if the connection is open (the underlying socket has been
+        established).  A connection in the NEW state (just created but not yet
+        connected) returns `False`.
+
+        Note: for some implementations ``is_connected() != not is_closed()``.
+        The default implementation returns ``not self.is_closed()``, which is
+        correct for connections that are never in the NEW (pre-TCP) state.
+        """
+        return not self.is_closed()  # pragma: nocover
+
     def is_available(self) -> bool:
         """
         Return `True` if the connection is currently able to accept an

--- a/src/httpcore2/httpcore2/_sync/socks_proxy.py
+++ b/src/httpcore2/httpcore2/_sync/socks_proxy.py
@@ -283,6 +283,9 @@ class Socks5Connection(ConnectionInterface):
         if self._connection is not None:
             self._connection.close()
 
+    def is_connected(self) -> bool:
+        return self._connection is not None and self._connection.is_connected()
+
     def is_available(self) -> bool:
         if self._connection is None:  # pragma: no cover
             # If HTTP/2 support is enabled, and the resulting connection could

--- a/tests/httpcore2/_async/test_connection.py
+++ b/tests/httpcore2/_async/test_connection.py
@@ -37,6 +37,7 @@ async def test_http_connection() -> None:
         assert not conn.is_closed()
         assert not conn.is_available()
         assert not conn.has_expired()
+        assert not conn.is_connected()
         assert repr(conn) == "<AsyncHTTPConnection [CONNECTING]>"
 
         async with conn.stream("GET", "https://example.com/") as response:
@@ -50,6 +51,7 @@ async def test_http_connection() -> None:
         assert not conn.is_closed()
         assert conn.is_available()
         assert not conn.has_expired()
+        assert conn.is_connected()
         assert repr(conn) == "<AsyncHTTPConnection ['https://example.com:443', HTTP/1.1, IDLE, Request Count: 1]>"
 
 

--- a/tests/httpcore2/_async/test_http11.py
+++ b/tests/httpcore2/_async/test_http11.py
@@ -24,6 +24,7 @@ async def test_http11_connection() -> None:
         assert not conn.is_closed()
         assert conn.is_available()
         assert not conn.has_expired()
+        assert conn.is_connected()
         assert repr(conn) == "<AsyncHTTP11Connection ['https://example.com:443', IDLE, Request Count: 1]>"
 
 

--- a/tests/httpcore2/_async/test_http2.py
+++ b/tests/httpcore2/_async/test_http2.py
@@ -33,6 +33,7 @@ async def test_http2_connection() -> None:
         assert conn.is_available()
         assert not conn.is_closed()
         assert not conn.has_expired()
+        assert conn.is_connected()
         assert conn.info() == "'https://example.com:443', HTTP/2, IDLE, Request Count: 1"
         assert repr(conn) == "<AsyncHTTP2Connection ['https://example.com:443', IDLE, Request Count: 1]>"
 

--- a/tests/httpcore2/_sync/test_connection.py
+++ b/tests/httpcore2/_sync/test_connection.py
@@ -37,6 +37,7 @@ def test_http_connection() -> None:
         assert not conn.is_closed()
         assert not conn.is_available()
         assert not conn.has_expired()
+        assert not conn.is_connected()
         assert repr(conn) == "<HTTPConnection [CONNECTING]>"
 
         with conn.stream("GET", "https://example.com/") as response:
@@ -50,6 +51,7 @@ def test_http_connection() -> None:
         assert not conn.is_closed()
         assert conn.is_available()
         assert not conn.has_expired()
+        assert conn.is_connected()
         assert repr(conn) == "<HTTPConnection ['https://example.com:443', HTTP/1.1, IDLE, Request Count: 1]>"
 
 

--- a/tests/httpcore2/_sync/test_http11.py
+++ b/tests/httpcore2/_sync/test_http11.py
@@ -24,6 +24,7 @@ def test_http11_connection() -> None:
         assert not conn.is_closed()
         assert conn.is_available()
         assert not conn.has_expired()
+        assert conn.is_connected()
         assert repr(conn) == "<HTTP11Connection ['https://example.com:443', IDLE, Request Count: 1]>"
 
 

--- a/tests/httpcore2/_sync/test_http2.py
+++ b/tests/httpcore2/_sync/test_http2.py
@@ -33,6 +33,7 @@ def test_http2_connection() -> None:
         assert conn.is_available()
         assert not conn.is_closed()
         assert not conn.has_expired()
+        assert conn.is_connected()
         assert conn.info() == "'https://example.com:443', HTTP/2, IDLE, Request Count: 1"
         assert repr(conn) == "<HTTP2Connection ['https://example.com:443', IDLE, Request Count: 1]>"
 

--- a/tests/httpcore2/test_cancellations.py
+++ b/tests/httpcore2/test_cancellations.py
@@ -1,4 +1,5 @@
 import typing
+from unittest.mock import patch
 
 import anyio
 import hpack
@@ -127,6 +128,29 @@ async def test_connection_pool_timeout_during_response() -> None:
         with anyio.move_on_after(0.01):
             await pool.request("GET", "http://example.com")
         assert not pool.connections
+
+
+@pytest.mark.anyio
+async def test_connection_pool_cancellation_during_waiting_for_connection() -> None:
+    """
+    A cancellation while a request is waiting for a connection should leave
+    the pool in a consistent state.
+
+    In this case, that means the new (not-yet-connected) connection is
+    discarded and no longer remains in the pool.
+    """
+
+    async def wait_for_connection(self: typing.Any, *args: typing.Any, **kwargs: typing.Any) -> None:
+        await anyio.sleep(999)
+
+    with patch(
+        "httpcore2._async.connection_pool.AsyncPoolRequest.wait_for_connection",
+        new=wait_for_connection,
+    ):
+        async with httpcore2.AsyncConnectionPool() as pool:
+            with anyio.move_on_after(0.01):
+                await pool.request("GET", "http://example.com")
+            assert not pool.connections
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

- Fixes the `AsyncConnectionPool` poisoning bug reported in #982: an `asyncio.CancelledError` (or any cancel scope timeout) during connection establishment leaves a NEW-state connection in `self._connections` that is neither closed nor connected, eventually exhausting `max_connections` and surfacing as `PoolTimeout` on every subsequent request.
- Adds `is_connected()` to `(Async)ConnectionInterface`, overridden on the concrete connection classes and proxy wrappers so a connection in the pre-TCP NEW state reports `False`.
- Teaches `_assign_requests_to_connections()` to recognise such *garbage* connections (not connected AND no live pool request references them) and silently drop them from the pool.

Ported from internal commit https://codeberg.org/httpxyz/httpcorexyz/commit/a7500e4 on the `httpcorexyz` fork

## Reproduction (from #982)

```python
import asyncio
import httpcore2 as httpcore

async def main():
    async with httpcore.AsyncConnectionPool(max_connections=1) as pool:
        tasks = [asyncio.create_task(pool.request("GET", f"http://localhost:8888/{i}")) for i in range(2)]
        await asyncio.sleep(0)
        for task in tasks:
            task.cancel()
        await asyncio.gather(*tasks, return_exceptions=True)

        print(pool)
        # Before: <AsyncConnectionPool [Requests: 0 active, 0 queued | Connections: 1 active, 0 idle]>
        # After:  <AsyncConnectionPool [Requests: 0 active, 0 queued | Connections: 0 active, 0 idle]>
        await pool.request("GET", "http://localhost:8888/", extensions={"timeout": {"pool": 1}})
        # Before: httpcore2.PoolTimeout
        # After:  proceeds normally (or surfaces a genuine ConnectError/ConnectTimeout)
```

## Test plan

- [x] `scripts/check` — ruff format/check + mypy clean
- [x] `scripts/test` — full suite passes (1651 passed, 1 skipped) on both asyncio and trio backends
- [x] `scripts/coverage` — 100% coverage maintained
- [x] New `test_connection_pool_cancellation_during_waiting_for_connection` verifies the pool is empty after cancellation in the connection-wait phase, on both asyncio and trio
- [x] Manually re-ran the reproduction from #982 against the patched pool — pool stays empty and the follow-up request no longer hangs on a `PoolTimeout`

Closes #982.

🤖 Generated with [Claude Code](https://claude.com/claude-code)