### PR TITLE
Pylint and set upper limits on code complexity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,15 +49,27 @@ line-length = 120
 exclude = ["src/httpcore2/httpcore2/_sync", "tests/httpcore2/_sync"]
 
 [tool.ruff.lint]
-select = ["B", "C4", "E", "F", "I", "PERF", "PIE", "W"]
-ignore = ["B904", "B028", "C401", "PERF203"]
+select = ["B", "C4", "C90", "E", "F", "I", "PERF", "PIE", "PL", "W"]
+ignore = ["B904", "B028", "C401", "PERF203", "PLC0415", "PLW1641"]
 
 [tool.ruff.lint.isort]
 combine-as-imports = true
 known-first-party = ["httpx2", "httpcore2"]
 
+[tool.ruff.lint.mccabe]
+max-complexity = 22  # Default is 10
+
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F403", "F405"]
+"scripts/unasync.py" = ["PLW2901"]
+"src/httpx2/httpx2/_models.py" = ["PLW2901"]
+
+[tool.ruff.lint.pylint]
+allow-magic-value-types = ["bytes", "int", "str"]
+max-args = 19  # Default is 5
+max-branches = 23  # Default is 12
+max-statements = 63  # Default is 50
+max-returns = 19  # Default is 6
 
 [tool.mypy]
 ignore_missing_imports = true

--- a/scripts/unasync.py
+++ b/scripts/unasync.py
@@ -97,7 +97,7 @@ def main():
 
         print("These patterns were not used:")
         pprint(unused_subs)
-        exit(1)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/src/httpx2/httpx2/_decoders.py
+++ b/src/httpx2/httpx2/_decoders.py
@@ -40,7 +40,7 @@ if typing.TYPE_CHECKING:
         ZstdDecompressor = functools.partial(_ZstdDecompressor().decompressobj)
 
     _zstandard_installed: bool = True
-else:  # pragma: no cover
+else:  # pragma: no cover # noqa: PLR5501
     if sys.version_info >= (3, 14):
         from compression.zstd import ZstdDecompressor, ZstdError
 

--- a/src/httpx2/httpx2/_transports/default.py
+++ b/src/httpx2/httpx2/_transports/default.py
@@ -94,7 +94,7 @@ def _load_httpcore_exceptions() -> dict[type[Exception], type[httpx2.HTTPError]]
 
 @contextlib.contextmanager
 def map_httpcore_exceptions() -> typing.Iterator[None]:
-    global HTTPCORE_EXC_MAP
+    global HTTPCORE_EXC_MAP  # noqa: PLW0603
     if len(HTTPCORE_EXC_MAP) == 0:
         HTTPCORE_EXC_MAP = _load_httpcore_exceptions()
     try:

--- a/src/httpx2/httpx2/_utils.py
+++ b/src/httpx2/httpx2/_utils.py
@@ -222,7 +222,7 @@ class URLPattern:
 
 def is_ipv4_hostname(hostname: str) -> bool:
     try:
-        ipaddress.IPv4Address(hostname.split("/")[0])
+        ipaddress.IPv4Address(hostname.split("/", maxsplit=1)[0])
     except Exception:
         return False
     return True
@@ -230,7 +230,7 @@ def is_ipv4_hostname(hostname: str) -> bool:
 
 def is_ipv6_hostname(hostname: str) -> bool:
     try:
-        ipaddress.IPv6Address(hostname.split("/")[0])
+        ipaddress.IPv6Address(hostname.split("/", maxsplit=1)[0])
     except Exception:
         return False
     return True


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX2! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

Add pylint and add upper limits on code complexity.  Ruff rules C90 and PLR091x enable the setting of upper limits on code complexity. If a contributor wants to raise these limits, that can lead to useful discussion in code reviews about why complexity needs to rise, and maintainability needs to go down.
* https://docs.astral.sh/ruff/rules/#mccabe-c90
    * https://en.wikipedia.org/wiki/Cyclomatic_complexity
* https://docs.astral.sh/ruff/rules/#pylint-pl

<!-- Write a small summary about what is happening here. -->

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.

% `ruff rule PLC0207`
# missing-maxsplit-arg (PLC0207)

Derived from the **Pylint** linter.

Fix is always available.

## What it does
Checks for access to the first or last element of `str.split()` or `str.rsplit()` without a
`maxsplit=1` argument.

## Why is this bad?
Calling `str.split()` or `str.rsplit()` without passing `maxsplit=1` splits on every delimiter in the
string. When accessing only the first or last element of the result, it
would be more efficient to split only once.

## Example
```python
url = "www.example.com"
prefix = url.split(".")[0]
```

Use instead:
```python
url = "www.example.com"
prefix = url.split(".", maxsplit=1)[0]
```

To access the last element, use `str.rsplit()` instead of `str.split()`:
```python
url = "www.example.com"
suffix = url.rsplit(".", maxsplit=1)[-1]
```

## Fix Safety
This rule's fix is marked as unsafe for `split()`/`rsplit()` calls that contain `*args` or
`**kwargs` arguments, as adding a `maxsplit` argument to such a call may lead to duplicate
arguments.
