### PR TITLE
Enforce typed defs in httpcore2 tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ ignore_missing_imports = true
 strict = true
 
 [[tool.mypy.overrides]]
-module = "tests.*"
+module = "tests.httpx2.*"
 disallow_untyped_defs = false
 check_untyped_defs = true
 

--- a/tests/httpcore2/_async/test_connection.py
+++ b/tests/httpcore2/_async/test_connection.py
@@ -20,7 +20,7 @@ from httpcore2 import (
 
 
 @pytest.mark.anyio
-async def test_http_connection():
+async def test_http_connection() -> None:
     origin = Origin(b"https", b"example.com", 443)
     network_backend = AsyncMockBackend(
         [
@@ -54,7 +54,7 @@ async def test_http_connection():
 
 
 @pytest.mark.anyio
-async def test_concurrent_requests_not_available_on_http11_connections():
+async def test_concurrent_requests_not_available_on_http11_connections() -> None:
     """
     Attempting to issue a request against an already active HTTP/1.1 connection
     will raise a `ConnectionNotAvailable` exception.
@@ -78,7 +78,7 @@ async def test_concurrent_requests_not_available_on_http11_connections():
 
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 @pytest.mark.anyio
-async def test_write_error_with_response_sent():
+async def test_write_error_with_response_sent() -> None:
     """
     If a server half-closes the connection while the client is sending
     the request, it may still send a response. In this case the client
@@ -129,7 +129,7 @@ async def test_write_error_with_response_sent():
 
 @pytest.mark.anyio
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
-async def test_write_error_without_response_sent():
+async def test_write_error_without_response_sent() -> None:
     """
     If a server fully closes the connection while the client is sending
     the request, then client should raise an error.
@@ -171,7 +171,7 @@ async def test_write_error_without_response_sent():
 
 @pytest.mark.anyio
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
-async def test_http2_connection():
+async def test_http2_connection() -> None:
     origin = Origin(b"https", b"example.com", 443)
     network_backend = AsyncMockBackend(
         [
@@ -200,7 +200,7 @@ async def test_http2_connection():
 
 
 @pytest.mark.anyio
-async def test_request_to_incorrect_origin():
+async def test_request_to_incorrect_origin() -> None:
     """
     A connection can only send requests whichever origin it is connected to.
     """
@@ -270,7 +270,7 @@ class NeedsRetryBackend(AsyncMockBackend):
 
 
 @pytest.mark.anyio
-async def test_connection_retries():
+async def test_connection_retries() -> None:
     origin = Origin(b"https", b"example.com", 443)
     content = [
         b"HTTP/1.1 200 OK\r\n",
@@ -295,7 +295,7 @@ async def test_connection_retries():
 
 
 @pytest.mark.anyio
-async def test_connection_retries_tls():
+async def test_connection_retries_tls() -> None:
     origin = Origin(b"https", b"example.com", 443)
     content = [
         b"HTTP/1.1 200 OK\r\n",
@@ -320,7 +320,7 @@ async def test_connection_retries_tls():
 
 
 @pytest.mark.anyio
-async def test_uds_connections():
+async def test_uds_connections() -> None:
     # We're not actually testing Unix Domain Sockets here, because we're just
     # using a mock backend, but at least we're covering the UDS codepath
     # in `connection.py` which we may as well do.

--- a/tests/httpcore2/_async/test_connection_pool.py
+++ b/tests/httpcore2/_async/test_connection_pool.py
@@ -10,7 +10,7 @@ import httpcore2
 
 
 @pytest.mark.anyio
-async def test_connection_pool_with_keepalive():
+async def test_connection_pool_with_keepalive() -> None:
     """
     By default HTTP/1.1 requests should be returned to the connection pool.
     """
@@ -83,7 +83,7 @@ async def test_connection_pool_with_keepalive():
 
 
 @pytest.mark.anyio
-async def test_connection_pool_with_close():
+async def test_connection_pool_with_close() -> None:
     """
     HTTP/1.1 requests that include a 'Connection: Close' header should
     not be returned to the connection pool.
@@ -112,7 +112,7 @@ async def test_connection_pool_with_close():
 
 
 @pytest.mark.anyio
-async def test_connection_pool_with_http2():
+async def test_connection_pool_with_http2() -> None:
     """
     Test a connection pool with HTTP/2 requests.
     """
@@ -166,7 +166,7 @@ async def test_connection_pool_with_http2():
 
 
 @pytest.mark.anyio
-async def test_connection_pool_with_http2_goaway():
+async def test_connection_pool_with_http2_goaway() -> None:
     """
     Test a connection pool with HTTP/2 requests, that cleanly disconnects
     with a GoAway frame after the first request.
@@ -215,7 +215,7 @@ async def test_connection_pool_with_http2_goaway():
 
 
 @pytest.mark.anyio
-async def test_trace_request():
+async def test_trace_request() -> None:
     """
     The 'trace' request extension allows for a callback function to inspect the
     internal events that occur while sending a request.
@@ -232,7 +232,7 @@ async def test_trace_request():
 
     called = []
 
-    async def trace(name, kwargs):
+    async def trace(name: str, kwargs: dict[str, typing.Any]) -> None:
         called.append(name)
 
     async with httpcore2.AsyncConnectionPool(network_backend=network_backend) as pool:
@@ -257,7 +257,7 @@ async def test_trace_request():
 
 
 @pytest.mark.anyio
-async def test_debug_request(caplog):
+async def test_debug_request(caplog: pytest.LogCaptureFixture) -> None:
     """
     The 'trace' request extension allows for a callback function to inspect the
     internal events that occur while sending a request.
@@ -325,7 +325,7 @@ async def test_debug_request(caplog):
 
 
 @pytest.mark.anyio
-async def test_connection_pool_with_http_exception():
+async def test_connection_pool_with_http_exception() -> None:
     """
     HTTP/1.1 requests that result in an exception during the connection should
     not be returned to the connection pool.
@@ -334,7 +334,7 @@ async def test_connection_pool_with_http_exception():
 
     called = []
 
-    async def trace(name, kwargs):
+    async def trace(name: str, kwargs: dict[str, typing.Any]) -> None:
         called.append(name)
 
     async with httpcore2.AsyncConnectionPool(network_backend=network_backend) as pool:
@@ -362,7 +362,7 @@ async def test_connection_pool_with_http_exception():
 
 
 @pytest.mark.anyio
-async def test_connection_pool_with_connect_exception():
+async def test_connection_pool_with_connect_exception() -> None:
     """
     HTTP/1.1 requests that result in an exception during connection should not
     be returned to the connection pool.
@@ -383,7 +383,7 @@ async def test_connection_pool_with_connect_exception():
 
     called = []
 
-    async def trace(name, kwargs):
+    async def trace(name: str, kwargs: dict[str, typing.Any]) -> None:
         called.append(name)
 
     async with httpcore2.AsyncConnectionPool(network_backend=network_backend) as pool:
@@ -401,7 +401,7 @@ async def test_connection_pool_with_connect_exception():
 
 
 @pytest.mark.anyio
-async def test_connection_pool_with_immediate_expiry():
+async def test_connection_pool_with_immediate_expiry() -> None:
     """
     Connection pools with keepalive_expiry=0.0 should immediately expire
     keep alive connections.
@@ -433,7 +433,7 @@ async def test_connection_pool_with_immediate_expiry():
 
 
 @pytest.mark.anyio
-async def test_connection_pool_with_no_keepalive_connections_allowed():
+async def test_connection_pool_with_no_keepalive_connections_allowed() -> None:
     """
     When 'max_keepalive_connections=0' is used, IDLE connections should not
     be returned to the pool.
@@ -462,7 +462,7 @@ async def test_connection_pool_with_no_keepalive_connections_allowed():
 
 
 @pytest.mark.trio
-async def test_connection_pool_concurrency():
+async def test_connection_pool_concurrency() -> None:
     """
     HTTP/1.1 requests made in concurrency must not ever exceed the maximum number
     of allowable connection in the pool.
@@ -477,14 +477,14 @@ async def test_connection_pool_concurrency():
         ]
     )
 
-    async def fetch(pool, domain, info_list):
+    async def fetch(pool: httpcore2.AsyncConnectionPool, domain: str, info_list: list[list[str]]) -> None:
         async with pool.stream("GET", f"http://{domain}/") as response:
             info = [repr(c) for c in pool.connections]
             info_list.append(info)
             await response.aread()
 
     async with httpcore2.AsyncConnectionPool(max_connections=1, network_backend=network_backend) as pool:
-        info_list: typing.List[str] = []
+        info_list: typing.List[typing.List[str]] = []
         async with concurrency.open_nursery() as nursery:
             for domain in ["a.com", "b.com", "c.com", "d.com", "e.com"]:
                 nursery.start_soon(fetch, pool, domain, info_list)
@@ -505,7 +505,7 @@ async def test_connection_pool_concurrency():
 
 
 @pytest.mark.trio
-async def test_connection_pool_concurrency_same_domain_closing():
+async def test_connection_pool_concurrency_same_domain_closing() -> None:
     """
     HTTP/1.1 requests made in concurrency must not ever exceed the maximum number
     of allowable connection in the pool.
@@ -521,14 +521,14 @@ async def test_connection_pool_concurrency_same_domain_closing():
         ]
     )
 
-    async def fetch(pool, domain, info_list):
+    async def fetch(pool: httpcore2.AsyncConnectionPool, domain: str, info_list: list[list[str]]) -> None:
         async with pool.stream("GET", f"https://{domain}/") as response:
             info = [repr(c) for c in pool.connections]
             info_list.append(info)
             await response.aread()
 
     async with httpcore2.AsyncConnectionPool(max_connections=1, network_backend=network_backend, http2=True) as pool:
-        info_list: typing.List[str] = []
+        info_list: typing.List[typing.List[str]] = []
         async with concurrency.open_nursery() as nursery:
             for domain in ["a.com", "a.com", "a.com", "a.com", "a.com"]:
                 nursery.start_soon(fetch, pool, domain, info_list)
@@ -542,7 +542,7 @@ async def test_connection_pool_concurrency_same_domain_closing():
 
 
 @pytest.mark.trio
-async def test_connection_pool_concurrency_same_domain_keepalive():
+async def test_connection_pool_concurrency_same_domain_keepalive() -> None:
     """
     HTTP/1.1 requests made in concurrency must not ever exceed the maximum number
     of allowable connection in the pool.
@@ -558,14 +558,14 @@ async def test_connection_pool_concurrency_same_domain_keepalive():
         * 5
     )
 
-    async def fetch(pool, domain, info_list):
+    async def fetch(pool: httpcore2.AsyncConnectionPool, domain: str, info_list: list[list[str]]) -> None:
         async with pool.stream("GET", f"https://{domain}/") as response:
             info = [repr(c) for c in pool.connections]
             info_list.append(info)
             await response.aread()
 
     async with httpcore2.AsyncConnectionPool(max_connections=1, network_backend=network_backend, http2=True) as pool:
-        info_list: typing.List[str] = []
+        info_list: typing.List[typing.List[str]] = []
         async with concurrency.open_nursery() as nursery:
             for domain in ["a.com", "a.com", "a.com", "a.com", "a.com"]:
                 nursery.start_soon(fetch, pool, domain, info_list)
@@ -587,7 +587,7 @@ async def test_connection_pool_concurrency_same_domain_keepalive():
 
 
 @pytest.mark.anyio
-async def test_unsupported_protocol():
+async def test_unsupported_protocol() -> None:
     async with httpcore2.AsyncConnectionPool() as pool:
         with pytest.raises(httpcore2.UnsupportedProtocol):
             await pool.request("GET", "ftp://www.example.com/")
@@ -597,7 +597,7 @@ async def test_unsupported_protocol():
 
 
 @pytest.mark.anyio
-async def test_connection_pool_closed_while_request_in_flight():
+async def test_connection_pool_closed_while_request_in_flight() -> None:
     """
     Closing a connection pool while a request/response is still in-flight
     should raise an error.
@@ -624,7 +624,7 @@ async def test_connection_pool_closed_while_request_in_flight():
 
 
 @pytest.mark.anyio
-async def test_connection_pool_timeout():
+async def test_connection_pool_timeout() -> None:
     """
     Ensure that exceeding max_connections can cause a request to timeout.
     """
@@ -649,7 +649,7 @@ async def test_connection_pool_timeout():
 
 
 @pytest.mark.anyio
-async def test_connection_pool_timeout_zero():
+async def test_connection_pool_timeout_zero() -> None:
     """
     A pool timeout of 0 shouldn't raise a PoolTimeout if there's
     no need to wait on a new connection.
@@ -701,7 +701,7 @@ async def test_connection_pool_timeout_zero():
 
 
 @pytest.mark.anyio
-async def test_http11_upgrade_connection():
+async def test_http11_upgrade_connection() -> None:
     """
     HTTP "101 Switching Protocols" indicates an upgraded connection.
 
@@ -723,7 +723,7 @@ async def test_http11_upgrade_connection():
 
     called = []
 
-    async def trace(name, kwargs):
+    async def trace(name: str, kwargs: dict[str, typing.Any]) -> None:
         called.append(name)
 
     async with httpcore2.AsyncConnectionPool(network_backend=network_backend, max_connections=1) as pool:

--- a/tests/httpcore2/_async/test_http11.py
+++ b/tests/httpcore2/_async/test_http11.py
@@ -4,7 +4,7 @@ import httpcore2
 
 
 @pytest.mark.anyio
-async def test_http11_connection():
+async def test_http11_connection() -> None:
     origin = httpcore2.Origin(b"https", b"example.com", 443)
     stream = httpcore2.AsyncMockStream(
         [
@@ -28,7 +28,7 @@ async def test_http11_connection():
 
 
 @pytest.mark.anyio
-async def test_http11_connection_unread_response():
+async def test_http11_connection_unread_response() -> None:
     """
     If the client releases the response without reading it to termination,
     then the connection will not be reusable.
@@ -55,7 +55,7 @@ async def test_http11_connection_unread_response():
 
 
 @pytest.mark.anyio
-async def test_http11_connection_with_remote_protocol_error():
+async def test_http11_connection_with_remote_protocol_error() -> None:
     """
     If a remote protocol error occurs, then no response will be returned,
     and the connection will not be reusable.
@@ -74,7 +74,7 @@ async def test_http11_connection_with_remote_protocol_error():
 
 
 @pytest.mark.anyio
-async def test_http11_connection_with_incomplete_response():
+async def test_http11_connection_with_incomplete_response() -> None:
     """
     We should be gracefully handling the case where the connection ends prematurely.
     """
@@ -100,7 +100,7 @@ async def test_http11_connection_with_incomplete_response():
 
 
 @pytest.mark.anyio
-async def test_http11_connection_with_local_protocol_error():
+async def test_http11_connection_with_local_protocol_error() -> None:
     """
     If a local protocol error occurs, then no response will be returned,
     and the connection will not be reusable.
@@ -129,7 +129,7 @@ async def test_http11_connection_with_local_protocol_error():
 
 
 @pytest.mark.anyio
-async def test_http11_connection_handles_one_active_request():
+async def test_http11_connection_handles_one_active_request() -> None:
     """
     Attempting to send a request while one is already in-flight will raise
     a ConnectionNotAvailable exception.
@@ -151,7 +151,7 @@ async def test_http11_connection_handles_one_active_request():
 
 
 @pytest.mark.anyio
-async def test_http11_connection_attempt_close():
+async def test_http11_connection_attempt_close() -> None:
     """
     A connection can only be closed when it is idle.
     """
@@ -173,7 +173,7 @@ async def test_http11_connection_attempt_close():
 
 
 @pytest.mark.anyio
-async def test_http11_request_to_incorrect_origin():
+async def test_http11_request_to_incorrect_origin() -> None:
     """
     A connection can only send requests to whichever origin it is connected to.
     """
@@ -185,7 +185,7 @@ async def test_http11_request_to_incorrect_origin():
 
 
 @pytest.mark.anyio
-async def test_http11_expect_continue():
+async def test_http11_expect_continue() -> None:
     """
     HTTP "100 Continue" is an interim response.
     We simply ignore it and return the final response.
@@ -216,7 +216,7 @@ async def test_http11_expect_continue():
 
 
 @pytest.mark.anyio
-async def test_http11_upgrade_connection():
+async def test_http11_upgrade_connection() -> None:
     """
     HTTP "101 Switching Protocols" indicates an upgraded connection.
 
@@ -249,7 +249,7 @@ async def test_http11_upgrade_connection():
 
 
 @pytest.mark.anyio
-async def test_http11_upgrade_with_trailing_data():
+async def test_http11_upgrade_with_trailing_data() -> None:
     """
     HTTP "101 Switching Protocols" indicates an upgraded connection.
 
@@ -292,7 +292,7 @@ async def test_http11_upgrade_with_trailing_data():
 
 
 @pytest.mark.anyio
-async def test_http11_early_hints():
+async def test_http11_early_hints() -> None:
     """
     HTTP "103 Early Hints" is an interim response.
     We simply ignore it and return the final response.
@@ -326,7 +326,7 @@ async def test_http11_early_hints():
 
 
 @pytest.mark.anyio
-async def test_http11_header_sub_100kb():
+async def test_http11_header_sub_100kb() -> None:
     """
     A connection should be able to handle a http header size up to 100kB.
     """

--- a/tests/httpcore2/_async/test_http2.py
+++ b/tests/httpcore2/_async/test_http2.py
@@ -6,7 +6,7 @@ import httpcore2
 
 
 @pytest.mark.anyio
-async def test_http2_connection():
+async def test_http2_connection() -> None:
     origin = httpcore2.Origin(b"https", b"example.com", 443)
     stream = httpcore2.AsyncMockStream(
         [
@@ -38,7 +38,7 @@ async def test_http2_connection():
 
 
 @pytest.mark.anyio
-async def test_http2_connection_closed():
+async def test_http2_connection_closed() -> None:
     origin = httpcore2.Origin(b"https", b"example.com", 443)
     stream = httpcore2.AsyncMockStream(
         [
@@ -68,7 +68,7 @@ async def test_http2_connection_closed():
 
 
 @pytest.mark.anyio
-async def test_http2_connection_post_request():
+async def test_http2_connection_post_request() -> None:
     origin = httpcore2.Origin(b"https", b"example.com", 443)
     stream = httpcore2.AsyncMockStream(
         [
@@ -98,7 +98,7 @@ async def test_http2_connection_post_request():
 
 
 @pytest.mark.anyio
-async def test_http2_connection_with_remote_protocol_error():
+async def test_http2_connection_with_remote_protocol_error() -> None:
     """
     If a remote protocol error occurs, then no response will be returned,
     and the connection will not be reusable.
@@ -111,7 +111,7 @@ async def test_http2_connection_with_remote_protocol_error():
 
 
 @pytest.mark.anyio
-async def test_http2_connection_with_rst_stream():
+async def test_http2_connection_with_rst_stream() -> None:
     """
     If a stream reset occurs, then no response will be returned,
     but the connection will remain reusable for other requests.
@@ -155,7 +155,7 @@ async def test_http2_connection_with_rst_stream():
 
 
 @pytest.mark.anyio
-async def test_http2_connection_with_goaway():
+async def test_http2_connection_with_goaway() -> None:
     """
     If a GoAway frame occurs, then no response will be returned,
     and the connection will not be reusable for other requests.
@@ -203,7 +203,7 @@ async def test_http2_connection_with_goaway():
 
 
 @pytest.mark.anyio
-async def test_http2_connection_with_negative_flow_control_window():
+async def test_http2_connection_with_negative_flow_control_window() -> None:
     """A negative stream flow-control window must be awaited, not sent into.
 
     After the 65535-byte window is exhausted, the server reduces INITIAL_WINDOW_SIZE
@@ -241,7 +241,7 @@ async def test_http2_connection_with_negative_flow_control_window():
 
 
 @pytest.mark.anyio
-async def test_http2_connection_with_flow_control():
+async def test_http2_connection_with_flow_control() -> None:
     origin = httpcore2.Origin(b"https", b"example.com", 443)
     stream = httpcore2.AsyncMockStream(
         [
@@ -283,7 +283,7 @@ async def test_http2_connection_with_flow_control():
 
 
 @pytest.mark.anyio
-async def test_http2_connection_attempt_close():
+async def test_http2_connection_attempt_close() -> None:
     """
     A connection can only be closed when it is idle.
     """
@@ -316,7 +316,7 @@ async def test_http2_connection_attempt_close():
 
 
 @pytest.mark.anyio
-async def test_http2_request_to_incorrect_origin():
+async def test_http2_request_to_incorrect_origin() -> None:
     """
     A connection can only send requests to whichever origin it is connected to.
     """
@@ -328,7 +328,7 @@ async def test_http2_request_to_incorrect_origin():
 
 
 @pytest.mark.anyio
-async def test_http2_remote_max_streams_update():
+async def test_http2_remote_max_streams_update() -> None:
     """
     If the remote server updates the maximum concurrent streams value, we should
     be adjusting how many streams we will allow.

--- a/tests/httpcore2/_async/test_http_proxy.py
+++ b/tests/httpcore2/_async/test_http_proxy.py
@@ -18,7 +18,7 @@ from httpcore2 import (
 
 
 @pytest.mark.anyio
-async def test_proxy_forwarding():
+async def test_proxy_forwarding() -> None:
     """
     Send an HTTP request via a proxy.
     """
@@ -61,7 +61,7 @@ async def test_proxy_forwarding():
 
 
 @pytest.mark.anyio
-async def test_proxy_tunneling():
+async def test_proxy_tunneling() -> None:
     """
     Send an HTTPS request via a proxy.
     """
@@ -133,7 +133,7 @@ class HTTP1ThenHTTP2Backend(AsyncMockBackend):
 
 
 @pytest.mark.anyio
-async def test_proxy_tunneling_http2():
+async def test_proxy_tunneling_http2() -> None:
     """
     Send an HTTP/2 request via a proxy.
     """
@@ -184,7 +184,7 @@ async def test_proxy_tunneling_http2():
 
 
 @pytest.mark.anyio
-async def test_proxy_tunneling_with_403():
+async def test_proxy_tunneling_with_403() -> None:
     """
     Send an HTTPS request via a proxy.
     """
@@ -205,7 +205,7 @@ async def test_proxy_tunneling_with_403():
 
 
 @pytest.mark.anyio
-async def test_proxy_tunneling_with_auth():
+async def test_proxy_tunneling_with_auth() -> None:
     """
     Send an authenticated HTTPS request via a proxy.
     """
@@ -234,7 +234,7 @@ async def test_proxy_tunneling_with_auth():
         assert response.content == b"Hello, world!"
 
 
-def test_proxy_headers():
+def test_proxy_headers() -> None:
     proxy = Proxy(
         url="http://localhost:8080/",
         auth=("username", "password"),

--- a/tests/httpcore2/_async/test_integration.py
+++ b/tests/httpcore2/_async/test_integration.py
@@ -1,19 +1,20 @@
 import ssl
 
 import pytest
+from pytest_httpbin.serve import Server
 
 import httpcore2
 
 
 @pytest.mark.anyio
-async def test_request(httpbin):
+async def test_request(httpbin: Server) -> None:
     async with httpcore2.AsyncConnectionPool() as pool:
         response = await pool.request("GET", httpbin.url)
         assert response.status == 200
 
 
 @pytest.mark.anyio
-async def test_ssl_request(httpbin_secure):
+async def test_ssl_request(httpbin_secure: Server) -> None:
     ssl_context = ssl.create_default_context()
     ssl_context.check_hostname = False
     ssl_context.verify_mode = ssl.CERT_NONE
@@ -23,7 +24,7 @@ async def test_ssl_request(httpbin_secure):
 
 
 @pytest.mark.anyio
-async def test_extra_info(httpbin_secure):
+async def test_extra_info(httpbin_secure: Server) -> None:
     ssl_context = ssl.create_default_context()
     ssl_context.check_hostname = False
     ssl_context.verify_mode = ssl.CERT_NONE

--- a/tests/httpcore2/_async/test_socks_proxy.py
+++ b/tests/httpcore2/_async/test_socks_proxy.py
@@ -4,7 +4,7 @@ import httpcore2
 
 
 @pytest.mark.anyio
-async def test_socks5_request():
+async def test_socks5_request() -> None:
     """
     Send an HTTP request via a SOCKS proxy.
     """
@@ -50,7 +50,7 @@ async def test_socks5_request():
 
 
 @pytest.mark.anyio
-async def test_authenticated_socks5_request():
+async def test_authenticated_socks5_request() -> None:
     """
     Send an HTTP request via a SOCKS proxy.
     """
@@ -95,7 +95,7 @@ async def test_authenticated_socks5_request():
 
 
 @pytest.mark.anyio
-async def test_socks5_request_connect_failed():
+async def test_socks5_request_connect_failed() -> None:
     """
     Attempt to send an HTTP request via a SOCKS proxy, resulting in a connect failure.
     """
@@ -122,7 +122,7 @@ async def test_socks5_request_connect_failed():
 
 
 @pytest.mark.anyio
-async def test_socks5_request_failed_to_provide_auth():
+async def test_socks5_request_failed_to_provide_auth() -> None:
     """
     Attempt to send an HTTP request via an authenticated SOCKS proxy,
     without providing authentication credentials.
@@ -149,7 +149,7 @@ async def test_socks5_request_failed_to_provide_auth():
 
 
 @pytest.mark.anyio
-async def test_socks5_request_incorrect_auth():
+async def test_socks5_request_incorrect_auth() -> None:
     """
     Attempt to send an HTTP request via an authenticated SOCKS proxy,
     with incorrect authentication credentials.

--- a/tests/httpcore2/_sync/test_connection.py
+++ b/tests/httpcore2/_sync/test_connection.py
@@ -20,7 +20,7 @@ from httpcore2 import (
 
 
 
-def test_http_connection():
+def test_http_connection() -> None:
     origin = Origin(b"https", b"example.com", 443)
     network_backend = MockBackend(
         [
@@ -54,7 +54,7 @@ def test_http_connection():
 
 
 
-def test_concurrent_requests_not_available_on_http11_connections():
+def test_concurrent_requests_not_available_on_http11_connections() -> None:
     """
     Attempting to issue a request against an already active HTTP/1.1 connection
     will raise a `ConnectionNotAvailable` exception.
@@ -78,7 +78,7 @@ def test_concurrent_requests_not_available_on_http11_connections():
 
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 
-def test_write_error_with_response_sent():
+def test_write_error_with_response_sent() -> None:
     """
     If a server half-closes the connection while the client is sending
     the request, it may still send a response. In this case the client
@@ -129,7 +129,7 @@ def test_write_error_with_response_sent():
 
 
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
-def test_write_error_without_response_sent():
+def test_write_error_without_response_sent() -> None:
     """
     If a server fully closes the connection while the client is sending
     the request, then client should raise an error.
@@ -171,7 +171,7 @@ def test_write_error_without_response_sent():
 
 
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
-def test_http2_connection():
+def test_http2_connection() -> None:
     origin = Origin(b"https", b"example.com", 443)
     network_backend = MockBackend(
         [
@@ -200,7 +200,7 @@ def test_http2_connection():
 
 
 
-def test_request_to_incorrect_origin():
+def test_request_to_incorrect_origin() -> None:
     """
     A connection can only send requests whichever origin it is connected to.
     """
@@ -270,7 +270,7 @@ class NeedsRetryBackend(MockBackend):
 
 
 
-def test_connection_retries():
+def test_connection_retries() -> None:
     origin = Origin(b"https", b"example.com", 443)
     content = [
         b"HTTP/1.1 200 OK\r\n",
@@ -295,7 +295,7 @@ def test_connection_retries():
 
 
 
-def test_connection_retries_tls():
+def test_connection_retries_tls() -> None:
     origin = Origin(b"https", b"example.com", 443)
     content = [
         b"HTTP/1.1 200 OK\r\n",
@@ -320,7 +320,7 @@ def test_connection_retries_tls():
 
 
 
-def test_uds_connections():
+def test_uds_connections() -> None:
     # We're not actually testing Unix Domain Sockets here, because we're just
     # using a mock backend, but at least we're covering the UDS codepath
     # in `connection.py` which we may as well do.

--- a/tests/httpcore2/_sync/test_connection_pool.py
+++ b/tests/httpcore2/_sync/test_connection_pool.py
@@ -10,7 +10,7 @@ import httpcore2
 
 
 
-def test_connection_pool_with_keepalive():
+def test_connection_pool_with_keepalive() -> None:
     """
     By default HTTP/1.1 requests should be returned to the connection pool.
     """
@@ -83,7 +83,7 @@ def test_connection_pool_with_keepalive():
 
 
 
-def test_connection_pool_with_close():
+def test_connection_pool_with_close() -> None:
     """
     HTTP/1.1 requests that include a 'Connection: Close' header should
     not be returned to the connection pool.
@@ -112,7 +112,7 @@ def test_connection_pool_with_close():
 
 
 
-def test_connection_pool_with_http2():
+def test_connection_pool_with_http2() -> None:
     """
     Test a connection pool with HTTP/2 requests.
     """
@@ -166,7 +166,7 @@ def test_connection_pool_with_http2():
 
 
 
-def test_connection_pool_with_http2_goaway():
+def test_connection_pool_with_http2_goaway() -> None:
     """
     Test a connection pool with HTTP/2 requests, that cleanly disconnects
     with a GoAway frame after the first request.
@@ -215,7 +215,7 @@ def test_connection_pool_with_http2_goaway():
 
 
 
-def test_trace_request():
+def test_trace_request() -> None:
     """
     The 'trace' request extension allows for a callback function to inspect the
     internal events that occur while sending a request.
@@ -232,7 +232,7 @@ def test_trace_request():
 
     called = []
 
-    def trace(name, kwargs):
+    def trace(name: str, kwargs: dict[str, typing.Any]) -> None:
         called.append(name)
 
     with httpcore2.ConnectionPool(network_backend=network_backend) as pool:
@@ -257,7 +257,7 @@ def test_trace_request():
 
 
 
-def test_debug_request(caplog):
+def test_debug_request(caplog: pytest.LogCaptureFixture) -> None:
     """
     The 'trace' request extension allows for a callback function to inspect the
     internal events that occur while sending a request.
@@ -325,7 +325,7 @@ def test_debug_request(caplog):
 
 
 
-def test_connection_pool_with_http_exception():
+def test_connection_pool_with_http_exception() -> None:
     """
     HTTP/1.1 requests that result in an exception during the connection should
     not be returned to the connection pool.
@@ -334,7 +334,7 @@ def test_connection_pool_with_http_exception():
 
     called = []
 
-    def trace(name, kwargs):
+    def trace(name: str, kwargs: dict[str, typing.Any]) -> None:
         called.append(name)
 
     with httpcore2.ConnectionPool(network_backend=network_backend) as pool:
@@ -362,7 +362,7 @@ def test_connection_pool_with_http_exception():
 
 
 
-def test_connection_pool_with_connect_exception():
+def test_connection_pool_with_connect_exception() -> None:
     """
     HTTP/1.1 requests that result in an exception during connection should not
     be returned to the connection pool.
@@ -383,7 +383,7 @@ def test_connection_pool_with_connect_exception():
 
     called = []
 
-    def trace(name, kwargs):
+    def trace(name: str, kwargs: dict[str, typing.Any]) -> None:
         called.append(name)
 
     with httpcore2.ConnectionPool(network_backend=network_backend) as pool:
@@ -401,7 +401,7 @@ def test_connection_pool_with_connect_exception():
 
 
 
-def test_connection_pool_with_immediate_expiry():
+def test_connection_pool_with_immediate_expiry() -> None:
     """
     Connection pools with keepalive_expiry=0.0 should immediately expire
     keep alive connections.
@@ -433,7 +433,7 @@ def test_connection_pool_with_immediate_expiry():
 
 
 
-def test_connection_pool_with_no_keepalive_connections_allowed():
+def test_connection_pool_with_no_keepalive_connections_allowed() -> None:
     """
     When 'max_keepalive_connections=0' is used, IDLE connections should not
     be returned to the pool.
@@ -462,7 +462,7 @@ def test_connection_pool_with_no_keepalive_connections_allowed():
 
 
 
-def test_connection_pool_concurrency():
+def test_connection_pool_concurrency() -> None:
     """
     HTTP/1.1 requests made in concurrency must not ever exceed the maximum number
     of allowable connection in the pool.
@@ -477,14 +477,14 @@ def test_connection_pool_concurrency():
         ]
     )
 
-    def fetch(pool, domain, info_list):
+    def fetch(pool: httpcore2.ConnectionPool, domain: str, info_list: list[list[str]]) -> None:
         with pool.stream("GET", f"http://{domain}/") as response:
             info = [repr(c) for c in pool.connections]
             info_list.append(info)
             response.read()
 
     with httpcore2.ConnectionPool(max_connections=1, network_backend=network_backend) as pool:
-        info_list: typing.List[str] = []
+        info_list: typing.List[typing.List[str]] = []
         with concurrency.open_nursery() as nursery:
             for domain in ["a.com", "b.com", "c.com", "d.com", "e.com"]:
                 nursery.start_soon(fetch, pool, domain, info_list)
@@ -505,7 +505,7 @@ def test_connection_pool_concurrency():
 
 
 
-def test_connection_pool_concurrency_same_domain_closing():
+def test_connection_pool_concurrency_same_domain_closing() -> None:
     """
     HTTP/1.1 requests made in concurrency must not ever exceed the maximum number
     of allowable connection in the pool.
@@ -521,14 +521,14 @@ def test_connection_pool_concurrency_same_domain_closing():
         ]
     )
 
-    def fetch(pool, domain, info_list):
+    def fetch(pool: httpcore2.ConnectionPool, domain: str, info_list: list[list[str]]) -> None:
         with pool.stream("GET", f"https://{domain}/") as response:
             info = [repr(c) for c in pool.connections]
             info_list.append(info)
             response.read()
 
     with httpcore2.ConnectionPool(max_connections=1, network_backend=network_backend, http2=True) as pool:
-        info_list: typing.List[str] = []
+        info_list: typing.List[typing.List[str]] = []
         with concurrency.open_nursery() as nursery:
             for domain in ["a.com", "a.com", "a.com", "a.com", "a.com"]:
                 nursery.start_soon(fetch, pool, domain, info_list)
@@ -542,7 +542,7 @@ def test_connection_pool_concurrency_same_domain_closing():
 
 
 
-def test_connection_pool_concurrency_same_domain_keepalive():
+def test_connection_pool_concurrency_same_domain_keepalive() -> None:
     """
     HTTP/1.1 requests made in concurrency must not ever exceed the maximum number
     of allowable connection in the pool.
@@ -558,14 +558,14 @@ def test_connection_pool_concurrency_same_domain_keepalive():
         * 5
     )
 
-    def fetch(pool, domain, info_list):
+    def fetch(pool: httpcore2.ConnectionPool, domain: str, info_list: list[list[str]]) -> None:
         with pool.stream("GET", f"https://{domain}/") as response:
             info = [repr(c) for c in pool.connections]
             info_list.append(info)
             response.read()
 
     with httpcore2.ConnectionPool(max_connections=1, network_backend=network_backend, http2=True) as pool:
-        info_list: typing.List[str] = []
+        info_list: typing.List[typing.List[str]] = []
         with concurrency.open_nursery() as nursery:
             for domain in ["a.com", "a.com", "a.com", "a.com", "a.com"]:
                 nursery.start_soon(fetch, pool, domain, info_list)
@@ -587,7 +587,7 @@ def test_connection_pool_concurrency_same_domain_keepalive():
 
 
 
-def test_unsupported_protocol():
+def test_unsupported_protocol() -> None:
     with httpcore2.ConnectionPool() as pool:
         with pytest.raises(httpcore2.UnsupportedProtocol):
             pool.request("GET", "ftp://www.example.com/")
@@ -597,7 +597,7 @@ def test_unsupported_protocol():
 
 
 
-def test_connection_pool_closed_while_request_in_flight():
+def test_connection_pool_closed_while_request_in_flight() -> None:
     """
     Closing a connection pool while a request/response is still in-flight
     should raise an error.
@@ -624,7 +624,7 @@ def test_connection_pool_closed_while_request_in_flight():
 
 
 
-def test_connection_pool_timeout():
+def test_connection_pool_timeout() -> None:
     """
     Ensure that exceeding max_connections can cause a request to timeout.
     """
@@ -649,7 +649,7 @@ def test_connection_pool_timeout():
 
 
 
-def test_connection_pool_timeout_zero():
+def test_connection_pool_timeout_zero() -> None:
     """
     A pool timeout of 0 shouldn't raise a PoolTimeout if there's
     no need to wait on a new connection.
@@ -701,7 +701,7 @@ def test_connection_pool_timeout_zero():
 
 
 
-def test_http11_upgrade_connection():
+def test_http11_upgrade_connection() -> None:
     """
     HTTP "101 Switching Protocols" indicates an upgraded connection.
 
@@ -723,7 +723,7 @@ def test_http11_upgrade_connection():
 
     called = []
 
-    def trace(name, kwargs):
+    def trace(name: str, kwargs: dict[str, typing.Any]) -> None:
         called.append(name)
 
     with httpcore2.ConnectionPool(network_backend=network_backend, max_connections=1) as pool:

--- a/tests/httpcore2/_sync/test_http11.py
+++ b/tests/httpcore2/_sync/test_http11.py
@@ -4,7 +4,7 @@ import httpcore2
 
 
 
-def test_http11_connection():
+def test_http11_connection() -> None:
     origin = httpcore2.Origin(b"https", b"example.com", 443)
     stream = httpcore2.MockStream(
         [
@@ -28,7 +28,7 @@ def test_http11_connection():
 
 
 
-def test_http11_connection_unread_response():
+def test_http11_connection_unread_response() -> None:
     """
     If the client releases the response without reading it to termination,
     then the connection will not be reusable.
@@ -55,7 +55,7 @@ def test_http11_connection_unread_response():
 
 
 
-def test_http11_connection_with_remote_protocol_error():
+def test_http11_connection_with_remote_protocol_error() -> None:
     """
     If a remote protocol error occurs, then no response will be returned,
     and the connection will not be reusable.
@@ -74,7 +74,7 @@ def test_http11_connection_with_remote_protocol_error():
 
 
 
-def test_http11_connection_with_incomplete_response():
+def test_http11_connection_with_incomplete_response() -> None:
     """
     We should be gracefully handling the case where the connection ends prematurely.
     """
@@ -100,7 +100,7 @@ def test_http11_connection_with_incomplete_response():
 
 
 
-def test_http11_connection_with_local_protocol_error():
+def test_http11_connection_with_local_protocol_error() -> None:
     """
     If a local protocol error occurs, then no response will be returned,
     and the connection will not be reusable.
@@ -129,7 +129,7 @@ def test_http11_connection_with_local_protocol_error():
 
 
 
-def test_http11_connection_handles_one_active_request():
+def test_http11_connection_handles_one_active_request() -> None:
     """
     Attempting to send a request while one is already in-flight will raise
     a ConnectionNotAvailable exception.
@@ -151,7 +151,7 @@ def test_http11_connection_handles_one_active_request():
 
 
 
-def test_http11_connection_attempt_close():
+def test_http11_connection_attempt_close() -> None:
     """
     A connection can only be closed when it is idle.
     """
@@ -173,7 +173,7 @@ def test_http11_connection_attempt_close():
 
 
 
-def test_http11_request_to_incorrect_origin():
+def test_http11_request_to_incorrect_origin() -> None:
     """
     A connection can only send requests to whichever origin it is connected to.
     """
@@ -185,7 +185,7 @@ def test_http11_request_to_incorrect_origin():
 
 
 
-def test_http11_expect_continue():
+def test_http11_expect_continue() -> None:
     """
     HTTP "100 Continue" is an interim response.
     We simply ignore it and return the final response.
@@ -216,7 +216,7 @@ def test_http11_expect_continue():
 
 
 
-def test_http11_upgrade_connection():
+def test_http11_upgrade_connection() -> None:
     """
     HTTP "101 Switching Protocols" indicates an upgraded connection.
 
@@ -249,7 +249,7 @@ def test_http11_upgrade_connection():
 
 
 
-def test_http11_upgrade_with_trailing_data():
+def test_http11_upgrade_with_trailing_data() -> None:
     """
     HTTP "101 Switching Protocols" indicates an upgraded connection.
 
@@ -292,7 +292,7 @@ def test_http11_upgrade_with_trailing_data():
 
 
 
-def test_http11_early_hints():
+def test_http11_early_hints() -> None:
     """
     HTTP "103 Early Hints" is an interim response.
     We simply ignore it and return the final response.
@@ -326,7 +326,7 @@ def test_http11_early_hints():
 
 
 
-def test_http11_header_sub_100kb():
+def test_http11_header_sub_100kb() -> None:
     """
     A connection should be able to handle a http header size up to 100kB.
     """

--- a/tests/httpcore2/_sync/test_http2.py
+++ b/tests/httpcore2/_sync/test_http2.py
@@ -6,7 +6,7 @@ import httpcore2
 
 
 
-def test_http2_connection():
+def test_http2_connection() -> None:
     origin = httpcore2.Origin(b"https", b"example.com", 443)
     stream = httpcore2.MockStream(
         [
@@ -38,7 +38,7 @@ def test_http2_connection():
 
 
 
-def test_http2_connection_closed():
+def test_http2_connection_closed() -> None:
     origin = httpcore2.Origin(b"https", b"example.com", 443)
     stream = httpcore2.MockStream(
         [
@@ -68,7 +68,7 @@ def test_http2_connection_closed():
 
 
 
-def test_http2_connection_post_request():
+def test_http2_connection_post_request() -> None:
     origin = httpcore2.Origin(b"https", b"example.com", 443)
     stream = httpcore2.MockStream(
         [
@@ -98,7 +98,7 @@ def test_http2_connection_post_request():
 
 
 
-def test_http2_connection_with_remote_protocol_error():
+def test_http2_connection_with_remote_protocol_error() -> None:
     """
     If a remote protocol error occurs, then no response will be returned,
     and the connection will not be reusable.
@@ -111,7 +111,7 @@ def test_http2_connection_with_remote_protocol_error():
 
 
 
-def test_http2_connection_with_rst_stream():
+def test_http2_connection_with_rst_stream() -> None:
     """
     If a stream reset occurs, then no response will be returned,
     but the connection will remain reusable for other requests.
@@ -155,7 +155,7 @@ def test_http2_connection_with_rst_stream():
 
 
 
-def test_http2_connection_with_goaway():
+def test_http2_connection_with_goaway() -> None:
     """
     If a GoAway frame occurs, then no response will be returned,
     and the connection will not be reusable for other requests.
@@ -203,7 +203,7 @@ def test_http2_connection_with_goaway():
 
 
 
-def test_http2_connection_with_negative_flow_control_window():
+def test_http2_connection_with_negative_flow_control_window() -> None:
     """A negative stream flow-control window must be awaited, not sent into.
 
     After the 65535-byte window is exhausted, the server reduces INITIAL_WINDOW_SIZE
@@ -241,7 +241,7 @@ def test_http2_connection_with_negative_flow_control_window():
 
 
 
-def test_http2_connection_with_flow_control():
+def test_http2_connection_with_flow_control() -> None:
     origin = httpcore2.Origin(b"https", b"example.com", 443)
     stream = httpcore2.MockStream(
         [
@@ -283,7 +283,7 @@ def test_http2_connection_with_flow_control():
 
 
 
-def test_http2_connection_attempt_close():
+def test_http2_connection_attempt_close() -> None:
     """
     A connection can only be closed when it is idle.
     """
@@ -316,7 +316,7 @@ def test_http2_connection_attempt_close():
 
 
 
-def test_http2_request_to_incorrect_origin():
+def test_http2_request_to_incorrect_origin() -> None:
     """
     A connection can only send requests to whichever origin it is connected to.
     """
@@ -328,7 +328,7 @@ def test_http2_request_to_incorrect_origin():
 
 
 
-def test_http2_remote_max_streams_update():
+def test_http2_remote_max_streams_update() -> None:
     """
     If the remote server updates the maximum concurrent streams value, we should
     be adjusting how many streams we will allow.

--- a/tests/httpcore2/_sync/test_http_proxy.py
+++ b/tests/httpcore2/_sync/test_http_proxy.py
@@ -18,7 +18,7 @@ from httpcore2 import (
 
 
 
-def test_proxy_forwarding():
+def test_proxy_forwarding() -> None:
     """
     Send an HTTP request via a proxy.
     """
@@ -61,7 +61,7 @@ def test_proxy_forwarding():
 
 
 
-def test_proxy_tunneling():
+def test_proxy_tunneling() -> None:
     """
     Send an HTTPS request via a proxy.
     """
@@ -133,7 +133,7 @@ class HTTP1ThenHTTP2Backend(MockBackend):
 
 
 
-def test_proxy_tunneling_http2():
+def test_proxy_tunneling_http2() -> None:
     """
     Send an HTTP/2 request via a proxy.
     """
@@ -184,7 +184,7 @@ def test_proxy_tunneling_http2():
 
 
 
-def test_proxy_tunneling_with_403():
+def test_proxy_tunneling_with_403() -> None:
     """
     Send an HTTPS request via a proxy.
     """
@@ -205,7 +205,7 @@ def test_proxy_tunneling_with_403():
 
 
 
-def test_proxy_tunneling_with_auth():
+def test_proxy_tunneling_with_auth() -> None:
     """
     Send an authenticated HTTPS request via a proxy.
     """
@@ -234,7 +234,7 @@ def test_proxy_tunneling_with_auth():
         assert response.content == b"Hello, world!"
 
 
-def test_proxy_headers():
+def test_proxy_headers() -> None:
     proxy = Proxy(
         url="http://localhost:8080/",
         auth=("username", "password"),

--- a/tests/httpcore2/_sync/test_integration.py
+++ b/tests/httpcore2/_sync/test_integration.py
@@ -1,19 +1,20 @@
 import ssl
 
 import pytest
+from pytest_httpbin.serve import Server
 
 import httpcore2
 
 
 
-def test_request(httpbin):
+def test_request(httpbin: Server) -> None:
     with httpcore2.ConnectionPool() as pool:
         response = pool.request("GET", httpbin.url)
         assert response.status == 200
 
 
 
-def test_ssl_request(httpbin_secure):
+def test_ssl_request(httpbin_secure: Server) -> None:
     ssl_context = ssl.create_default_context()
     ssl_context.check_hostname = False
     ssl_context.verify_mode = ssl.CERT_NONE
@@ -23,7 +24,7 @@ def test_ssl_request(httpbin_secure):
 
 
 
-def test_extra_info(httpbin_secure):
+def test_extra_info(httpbin_secure: Server) -> None:
     ssl_context = ssl.create_default_context()
     ssl_context.check_hostname = False
     ssl_context.verify_mode = ssl.CERT_NONE

--- a/tests/httpcore2/_sync/test_socks_proxy.py
+++ b/tests/httpcore2/_sync/test_socks_proxy.py
@@ -4,7 +4,7 @@ import httpcore2
 
 
 
-def test_socks5_request():
+def test_socks5_request() -> None:
     """
     Send an HTTP request via a SOCKS proxy.
     """
@@ -50,7 +50,7 @@ def test_socks5_request():
 
 
 
-def test_authenticated_socks5_request():
+def test_authenticated_socks5_request() -> None:
     """
     Send an HTTP request via a SOCKS proxy.
     """
@@ -95,7 +95,7 @@ def test_authenticated_socks5_request():
 
 
 
-def test_socks5_request_connect_failed():
+def test_socks5_request_connect_failed() -> None:
     """
     Attempt to send an HTTP request via a SOCKS proxy, resulting in a connect failure.
     """
@@ -122,7 +122,7 @@ def test_socks5_request_connect_failed():
 
 
 
-def test_socks5_request_failed_to_provide_auth():
+def test_socks5_request_failed_to_provide_auth() -> None:
     """
     Attempt to send an HTTP request via an authenticated SOCKS proxy,
     without providing authentication credentials.
@@ -149,7 +149,7 @@ def test_socks5_request_failed_to_provide_auth():
 
 
 
-def test_socks5_request_incorrect_auth():
+def test_socks5_request_incorrect_auth() -> None:
     """
     Attempt to send an HTTP request via an authenticated SOCKS proxy,
     with incorrect authentication credentials.

--- a/tests/httpcore2/benchmark/client.py
+++ b/tests/httpcore2/benchmark/client.py
@@ -29,7 +29,7 @@ def duration(start: float) -> int:
 
 
 @contextmanager
-def profile():
+def profile() -> Iterator[None]:
     if not PROFILE:
         yield
         return

--- a/tests/httpcore2/benchmark/server.py
+++ b/tests/httpcore2/benchmark/server.py
@@ -1,4 +1,6 @@
 import asyncio
+from collections.abc import Awaitable, Callable
+from typing import Any
 
 import uvicorn
 
@@ -7,7 +9,11 @@ RESP = b"a" * 2000
 SLEEP = 0.01
 
 
-async def app(scope, receive, send):
+async def app(
+    scope: dict[str, Any],
+    receive: Callable[[], Awaitable[dict[str, Any]]],
+    send: Callable[[dict[str, Any]], Awaitable[None]],
+) -> None:
     assert scope["type"] == "http"
     assert scope["path"] == "/req"
     assert not (await receive()).get("more_body", False)

--- a/tests/httpcore2/test_api.py
+++ b/tests/httpcore2/test_api.py
@@ -1,19 +1,21 @@
 import json
 
+from pytest_httpbin.serve import Server
+
 import httpcore2
 
 
-def test_request(httpbin):
+def test_request(httpbin: Server) -> None:
     response = httpcore2.request("GET", httpbin.url)
     assert response.status == 200
 
 
-def test_stream(httpbin):
+def test_stream(httpbin: Server) -> None:
     with httpcore2.stream("GET", httpbin.url) as response:
         assert response.status == 200
 
 
-def test_request_with_content(httpbin):
+def test_request_with_content(httpbin: Server) -> None:
     url = f"{httpbin.url}/post"
     response = httpcore2.request("POST", url, content=b'{"hello":"world"}')
     assert response.status == 200

--- a/tests/httpcore2/test_cancellations.py
+++ b/tests/httpcore2/test_cancellations.py
@@ -50,7 +50,7 @@ class SlowReadStream(httpcore2.AsyncNetworkStream):
     def __init__(self, buffer: typing.List[bytes]):
         self._buffer = buffer
 
-    async def write(self, buffer, timeout=None):
+    async def write(self, buffer: bytes, timeout: typing.Optional[float] = None) -> None:
         pass
 
     async def read(self, max_bytes: int, timeout: typing.Optional[float] = None) -> bytes:
@@ -58,7 +58,7 @@ class SlowReadStream(httpcore2.AsyncNetworkStream):
             await anyio.sleep(999)
         return self._buffer.pop(0)
 
-    async def aclose(self):
+    async def aclose(self) -> None:
         await anyio.sleep(0)
 
 
@@ -90,7 +90,7 @@ class SlowReadBackend(httpcore2.AsyncNetworkBackend):
 
 
 @pytest.mark.anyio
-async def test_connection_pool_timeout_during_request():
+async def test_connection_pool_timeout_during_request() -> None:
     """
     An async timeout when writing an HTTP/1.1 response on the connection pool
     should leave the pool in a consistent state.
@@ -106,7 +106,7 @@ async def test_connection_pool_timeout_during_request():
 
 
 @pytest.mark.anyio
-async def test_connection_pool_timeout_during_response():
+async def test_connection_pool_timeout_during_response() -> None:
     """
     An async timeout when reading an HTTP/1.1 response on the connection pool
     should leave the pool in a consistent state.
@@ -130,7 +130,7 @@ async def test_connection_pool_timeout_during_response():
 
 
 @pytest.mark.anyio
-async def test_h11_timeout_during_request():
+async def test_h11_timeout_during_request() -> None:
     """
     An async timeout on an HTTP/1.1 during the request writing
     should leave the connection in a neatly closed state.
@@ -144,7 +144,7 @@ async def test_h11_timeout_during_request():
 
 
 @pytest.mark.anyio
-async def test_h11_timeout_during_response():
+async def test_h11_timeout_during_response() -> None:
     """
     An async timeout on an HTTP/1.1 during the response reading
     should leave the connection in a neatly closed state.
@@ -166,7 +166,7 @@ async def test_h11_timeout_during_response():
 
 
 @pytest.mark.anyio
-async def test_h2_timeout_during_handshake():
+async def test_h2_timeout_during_handshake() -> None:
     """
     An async timeout on an HTTP/2 during the initial handshake
     should leave the connection in a neatly closed state.
@@ -180,7 +180,7 @@ async def test_h2_timeout_during_handshake():
 
 
 @pytest.mark.anyio
-async def test_h2_timeout_during_request():
+async def test_h2_timeout_during_request() -> None:
     """
     An async timeout on an HTTP/2 during a request
     should leave the connection in a neatly idle state.
@@ -200,7 +200,7 @@ async def test_h2_timeout_during_request():
 
 
 @pytest.mark.anyio
-async def test_h2_timeout_during_response():
+async def test_h2_timeout_during_response() -> None:
     """
     An async timeout on an HTTP/2 during the response reading
     should leave the connection in a neatly idle state.

--- a/tests/httpcore2/test_models.py
+++ b/tests/httpcore2/test_models.py
@@ -7,25 +7,25 @@ import httpcore2
 # URL
 
 
-def test_url():
+def test_url() -> None:
     url = httpcore2.URL("https://www.example.com/")
     assert url == httpcore2.URL(scheme="https", host="www.example.com", port=None, target="/")
     assert bytes(url) == b"https://www.example.com/"
 
 
-def test_url_with_port():
+def test_url_with_port() -> None:
     url = httpcore2.URL("https://www.example.com:443/")
     assert url == httpcore2.URL(scheme="https", host="www.example.com", port=443, target="/")
     assert bytes(url) == b"https://www.example.com:443/"
 
 
-def test_url_with_invalid_argument():
+def test_url_with_invalid_argument() -> None:
     with pytest.raises(TypeError) as exc_info:
         httpcore2.URL(123)  # type: ignore
     assert str(exc_info.value) == "url must be bytes or str, but got int."
 
 
-def test_url_cannot_include_unicode_strings():
+def test_url_cannot_include_unicode_strings() -> None:
     """
     URLs instantiated with strings outside of the plain ASCII range are disallowed,
     but the explicit style allows for these ambiguous cases to be precisely expressed.
@@ -37,7 +37,7 @@ def test_url_cannot_include_unicode_strings():
     httpcore2.URL(scheme=b"https", host=b"www.example.com", target="/☺".encode("utf-8"))
 
 
-def test_url_origin_socks5():
+def test_url_origin_socks5() -> None:
     url = httpcore2.URL("socks5://127.0.0.1")
     origin = url.origin
     assert origin == httpcore2.Origin(scheme=b"socks5", host=b"127.0.0.1", port=1080)
@@ -52,7 +52,7 @@ def test_url_origin_socks5():
 # Request
 
 
-def test_request():
+def test_request() -> None:
     request = httpcore2.Request("GET", "https://www.example.com/")
     assert request.method == b"GET"
     assert request.url == httpcore2.URL("https://www.example.com/")
@@ -63,7 +63,7 @@ def test_request():
     assert repr(request.stream) == "<ByteStream [0 bytes]>"
 
 
-def test_request_with_target_extension():
+def test_request_with_target_extension() -> None:
     extensions = {"target": b"/another_path"}
     request = httpcore2.Request("GET", "https://www.example.com/path", extensions=extensions)
     assert request.url.target == b"/another_path"
@@ -73,19 +73,19 @@ def test_request_with_target_extension():
     assert request.url.target == b"/unescaped|path"
 
 
-def test_request_with_invalid_method():
+def test_request_with_invalid_method() -> None:
     with pytest.raises(TypeError) as exc_info:
         httpcore2.Request(123, "https://www.example.com/")  # type: ignore
     assert str(exc_info.value) == "method must be bytes or str, but got int."
 
 
-def test_request_with_invalid_url():
+def test_request_with_invalid_url() -> None:
     with pytest.raises(TypeError) as exc_info:
         httpcore2.Request("GET", 123)  # type: ignore
     assert str(exc_info.value) == "url must be a URL, bytes, or str, but got int."
 
 
-def test_request_with_invalid_headers():
+def test_request_with_invalid_headers() -> None:
     with pytest.raises(TypeError) as exc_info:
         httpcore2.Request("GET", "https://www.example.com/", headers=123)  # type: ignore
     assert str(exc_info.value) == "headers must be a mapping or sequence of two-tuples, but got int."
@@ -94,7 +94,7 @@ def test_request_with_invalid_headers():
 # Response
 
 
-def test_response():
+def test_response() -> None:
     response = httpcore2.Response(200)
     assert response.status == 200
     assert response.headers == []
@@ -115,14 +115,14 @@ class ByteIterator:
             yield chunk
 
 
-def test_response_sync_read():
+def test_response_sync_read() -> None:
     stream = ByteIterator([b"Hello, ", b"world!"])
     response = httpcore2.Response(200, content=stream)
     assert response.read() == b"Hello, world!"
     assert response.content == b"Hello, world!"
 
 
-def test_response_sync_streaming():
+def test_response_sync_streaming() -> None:
     stream = ByteIterator([b"Hello, ", b"world!"])
     response = httpcore2.Response(200, content=stream)
     content = b"".join(list(response.iter_stream()))
@@ -151,7 +151,7 @@ class AsyncByteIterator:
 
 
 @pytest.mark.trio
-async def test_response_async_read():
+async def test_response_async_read() -> None:
     stream = AsyncByteIterator([b"Hello, ", b"world!"])
     response = httpcore2.Response(200, content=stream)
     assert await response.aread() == b"Hello, world!"
@@ -159,7 +159,7 @@ async def test_response_async_read():
 
 
 @pytest.mark.trio
-async def test_response_async_streaming():
+async def test_response_async_streaming() -> None:
     stream = AsyncByteIterator([b"Hello, ", b"world!"])
     response = httpcore2.Response(200, content=stream)
     content = b"".join([chunk async for chunk in response.aiter_stream()])


### PR DESCRIPTION
Narrows the `disallow_untyped_defs = false` mypy override from `tests.*` to `tests.httpx2.*`, so `tests.httpcore2.*` is now held to the same strict typing as the source. Annotates the 171 functions this flagged with parameter and return types (most just needed `-> None`; trace callbacks, `fetch` helpers, fixtures, and the ASGI `app` needed parameter types too).

mypy, ruff check/format, and the unasync `--check` all pass.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.