### PR TITLE
Enforce typed defs in httpx2 tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,11 +63,6 @@ known-first-party = ["httpx2", "httpcore2"]
 ignore_missing_imports = true
 strict = true
 
-[[tool.mypy.overrides]]
-module = "tests.httpx2.*"
-disallow_untyped_defs = false
-check_untyped_defs = true
-
 [tool.pytest.ini_options]
 addopts = "-rxXs --import-mode=importlib"
 testpaths = ["tests"]

--- a/tests/httpx2/client/test_async_client.py
+++ b/tests/httpx2/client/test_async_client.py
@@ -7,9 +7,12 @@ import pytest
 
 import httpx2
 
+if typing.TYPE_CHECKING:  # pragma: no cover
+    from conftest import TestServer
+
 
 @pytest.mark.anyio
-async def test_get(server):
+async def test_get(server: TestServer) -> None:
     url = server.url
     async with httpx2.AsyncClient(http2=True) as client:
         response = await client.get(url)
@@ -30,14 +33,14 @@ async def test_get(server):
     ],
 )
 @pytest.mark.anyio
-async def test_get_invalid_url(server, url):
+async def test_get_invalid_url(server: TestServer, url: str) -> None:
     async with httpx2.AsyncClient() as client:
         with pytest.raises((httpx2.UnsupportedProtocol, httpx2.LocalProtocolError)):
             await client.get(url)
 
 
 @pytest.mark.anyio
-async def test_build_request(server):
+async def test_build_request(server: TestServer) -> None:
     url = server.url.copy_with(path="/echo_headers")
     headers = {"Custom-header": "value"}
     async with httpx2.AsyncClient() as client:
@@ -52,7 +55,7 @@ async def test_build_request(server):
 
 
 @pytest.mark.anyio
-async def test_post(server):
+async def test_post(server: TestServer) -> None:
     url = server.url
     async with httpx2.AsyncClient() as client:
         response = await client.post(url, content=b"Hello, world!")
@@ -60,7 +63,7 @@ async def test_post(server):
 
 
 @pytest.mark.anyio
-async def test_post_json(server):
+async def test_post_json(server: TestServer) -> None:
     url = server.url
     async with httpx2.AsyncClient() as client:
         response = await client.post(url, json={"text": "Hello, world!"})
@@ -68,7 +71,7 @@ async def test_post_json(server):
 
 
 @pytest.mark.anyio
-async def test_stream_response(server):
+async def test_stream_response(server: TestServer) -> None:
     async with httpx2.AsyncClient() as client:
         async with client.stream("GET", server.url) as response:
             body = await response.aread()
@@ -79,7 +82,7 @@ async def test_stream_response(server):
 
 
 @pytest.mark.anyio
-async def test_access_content_stream_response(server):
+async def test_access_content_stream_response(server: TestServer) -> None:
     async with httpx2.AsyncClient() as client:
         async with client.stream("GET", server.url) as response:
             pass
@@ -90,7 +93,7 @@ async def test_access_content_stream_response(server):
 
 
 @pytest.mark.anyio
-async def test_stream_request(server):
+async def test_stream_request(server: TestServer) -> None:
     async def hello_world() -> typing.AsyncIterator[bytes]:
         yield b"Hello, "
         yield b"world!"
@@ -101,7 +104,7 @@ async def test_stream_request(server):
 
 
 @pytest.mark.anyio
-async def test_cannot_stream_sync_request(server):
+async def test_cannot_stream_sync_request(server: TestServer) -> None:
     def hello_world() -> typing.Iterator[bytes]:  # pragma: no cover
         yield b"Hello, "
         yield b"world!"
@@ -112,7 +115,7 @@ async def test_cannot_stream_sync_request(server):
 
 
 @pytest.mark.anyio
-async def test_raise_for_status(server):
+async def test_raise_for_status(server: TestServer) -> None:
     async with httpx2.AsyncClient() as client:
         for status_code in (200, 400, 404, 500, 505):
             response = await client.request("GET", server.url.copy_with(path=f"/status/{status_code}"))
@@ -126,7 +129,7 @@ async def test_raise_for_status(server):
 
 
 @pytest.mark.anyio
-async def test_options(server):
+async def test_options(server: TestServer) -> None:
     async with httpx2.AsyncClient() as client:
         response = await client.options(server.url)
     assert response.status_code == 200
@@ -134,7 +137,7 @@ async def test_options(server):
 
 
 @pytest.mark.anyio
-async def test_head(server):
+async def test_head(server: TestServer) -> None:
     async with httpx2.AsyncClient() as client:
         response = await client.head(server.url)
     assert response.status_code == 200
@@ -142,21 +145,21 @@ async def test_head(server):
 
 
 @pytest.mark.anyio
-async def test_put(server):
+async def test_put(server: TestServer) -> None:
     async with httpx2.AsyncClient() as client:
         response = await client.put(server.url, content=b"Hello, world!")
     assert response.status_code == 200
 
 
 @pytest.mark.anyio
-async def test_patch(server):
+async def test_patch(server: TestServer) -> None:
     async with httpx2.AsyncClient() as client:
         response = await client.patch(server.url, content=b"Hello, world!")
     assert response.status_code == 200
 
 
 @pytest.mark.anyio
-async def test_delete(server):
+async def test_delete(server: TestServer) -> None:
     async with httpx2.AsyncClient() as client:
         response = await client.delete(server.url)
     assert response.status_code == 200
@@ -164,7 +167,7 @@ async def test_delete(server):
 
 
 @pytest.mark.anyio
-async def test_100_continue(server):
+async def test_100_continue(server: TestServer) -> None:
     headers = {"Expect": "100-continue"}
     content = b"Echo request body"
 
@@ -176,23 +179,24 @@ async def test_100_continue(server):
 
 
 @pytest.mark.anyio
-async def test_context_managed_transport():
+async def test_context_managed_transport() -> None:
     class Transport(httpx2.AsyncBaseTransport):
         def __init__(self) -> None:
             self.events: list[str] = []
 
-        async def aclose(self):
+        async def aclose(self) -> None:
             # The base implementation of httpx2.AsyncBaseTransport just
             # calls into `.aclose`, so simple transport cases can just override
             # this method for any cleanup, where more complex cases
             # might want to additionally override `__aenter__`/`__aexit__`.
             self.events.append("transport.aclose")
 
-        async def __aenter__(self):
+        async def __aenter__(self) -> Transport:
             await super().__aenter__()
             self.events.append("transport.__aenter__")
+            return self
 
-        async def __aexit__(self, *args):
+        async def __aexit__(self, *args: typing.Any) -> None:
             await super().__aexit__(*args)
             self.events.append("transport.__aexit__")
 
@@ -208,24 +212,25 @@ async def test_context_managed_transport():
 
 
 @pytest.mark.anyio
-async def test_context_managed_transport_and_mount():
+async def test_context_managed_transport_and_mount() -> None:
     class Transport(httpx2.AsyncBaseTransport):
         def __init__(self, name: str) -> None:
             self.name: str = name
             self.events: list[str] = []
 
-        async def aclose(self):
+        async def aclose(self) -> None:
             # The base implementation of httpx2.AsyncBaseTransport just
             # calls into `.aclose`, so simple transport cases can just override
             # this method for any cleanup, where more complex cases
             # might want to additionally override `__aenter__`/`__aexit__`.
             self.events.append(f"{self.name}.aclose")
 
-        async def __aenter__(self):
+        async def __aenter__(self) -> Transport:
             await super().__aenter__()
             self.events.append(f"{self.name}.__aenter__")
+            return self
 
-        async def __aexit__(self, *args):
+        async def __aexit__(self, *args: typing.Any) -> None:
             await super().__aexit__(*args)
             self.events.append(f"{self.name}.__aexit__")
 
@@ -246,12 +251,12 @@ async def test_context_managed_transport_and_mount():
     ]
 
 
-def hello_world(request):
+def hello_world(request: httpx2.Request) -> httpx2.Response:
     return httpx2.Response(200, text="Hello, world!")
 
 
 @pytest.mark.anyio
-async def test_client_closed_state_using_implicit_open():
+async def test_client_closed_state_using_implicit_open() -> None:
     client = httpx2.AsyncClient(transport=httpx2.MockTransport(hello_world))
 
     assert not client.is_closed
@@ -272,7 +277,7 @@ async def test_client_closed_state_using_implicit_open():
 
 
 @pytest.mark.anyio
-async def test_client_closed_state_using_with_block():
+async def test_client_closed_state_using_with_block() -> None:
     transport = httpx2.MockTransport(hello_world)
     async with httpx2.AsyncClient(transport=transport) as client:
         assert not client.is_closed
@@ -294,7 +299,7 @@ def mounted(request: httpx2.Request) -> httpx2.Response:
 
 
 @pytest.mark.anyio
-async def test_mounted_transport():
+async def test_mounted_transport() -> None:
     transport = httpx2.MockTransport(unmounted)
     mounts = {"custom://": httpx2.MockTransport(mounted)}
 
@@ -309,7 +314,7 @@ async def test_mounted_transport():
 
 
 @pytest.mark.anyio
-async def test_async_mock_transport():
+async def test_async_mock_transport() -> None:
     async def hello_world(request: httpx2.Request) -> httpx2.Response:
         return httpx2.Response(200, text="Hello, world!")
 
@@ -322,7 +327,7 @@ async def test_async_mock_transport():
 
 
 @pytest.mark.anyio
-async def test_cancellation_during_stream():
+async def test_cancellation_during_stream() -> None:
     """
     If any BaseException is raised during streaming the response, then the
     stream should be closed.
@@ -338,7 +343,7 @@ async def test_cancellation_during_stream():
     """
     stream_was_closed = False
 
-    def response_with_cancel_during_stream(request):
+    def response_with_cancel_during_stream(request: httpx2.Request) -> httpx2.Response:
         class CancelledStream(httpx2.AsyncByteStream):
             async def __aiter__(self) -> typing.AsyncIterator[bytes]:
                 yield b"Hello"
@@ -360,7 +365,7 @@ async def test_cancellation_during_stream():
 
 
 @pytest.mark.anyio
-async def test_server_extensions(server):
+async def test_server_extensions(server: TestServer) -> None:
     url = server.url
     async with httpx2.AsyncClient(http2=True) as client:
         response = await client.get(url)

--- a/tests/httpx2/client/test_async_client.py
+++ b/tests/httpx2/client/test_async_client.py
@@ -7,7 +7,7 @@ import pytest
 
 import httpx2
 
-if typing.TYPE_CHECKING:  # pragma: no cover
+if typing.TYPE_CHECKING:
     from conftest import TestServer
 
 

--- a/tests/httpx2/client/test_auth.py
+++ b/tests/httpx2/client/test_auth.py
@@ -659,7 +659,7 @@ class ConsumeBodyTransport(httpx2.MockTransport):
 
 
 @pytest.mark.anyio
-async def test_digest_auth_unavailable_streaming_body():
+async def test_digest_auth_unavailable_streaming_body() -> None:
     url = "https://example.org/"
     auth = httpx2.DigestAuth(username="user", password="password123")
     app = DigestApp()

--- a/tests/httpx2/client/test_client.py
+++ b/tests/httpx2/client/test_client.py
@@ -8,7 +8,7 @@ import pytest
 
 import httpx2
 
-if typing.TYPE_CHECKING:  # pragma: no cover
+if typing.TYPE_CHECKING:
     from conftest import TestServer
 
 

--- a/tests/httpx2/client/test_client.py
+++ b/tests/httpx2/client/test_client.py
@@ -8,12 +8,15 @@ import pytest
 
 import httpx2
 
+if typing.TYPE_CHECKING:  # pragma: no cover
+    from conftest import TestServer
 
-def autodetect(content):
+
+def autodetect(content: bytes) -> str | None:
     return chardet.detect(content).get("encoding")
 
 
-def test_get(server):
+def test_get(server: TestServer) -> None:
     url = server.url
     with httpx2.Client(http2=True) as http:
         response = http.get(url)
@@ -38,13 +41,13 @@ def test_get(server):
         pytest.param("http://", id="no-host"),
     ],
 )
-def test_get_invalid_url(server, url):
+def test_get_invalid_url(server: TestServer, url: str) -> None:
     with httpx2.Client() as client:
         with pytest.raises((httpx2.UnsupportedProtocol, httpx2.LocalProtocolError)):
             client.get(url)
 
 
-def test_build_request(server):
+def test_build_request(server: TestServer) -> None:
     url = server.url.copy_with(path="/echo_headers")
     headers = {"Custom-header": "value"}
 
@@ -59,7 +62,7 @@ def test_build_request(server):
     assert response.json()["Custom-header"] == "value"
 
 
-def test_build_post_request(server):
+def test_build_post_request(server: TestServer) -> None:
     url = server.url.copy_with(path="/echo_headers")
     headers = {"Custom-header": "value"}
 
@@ -75,21 +78,21 @@ def test_build_post_request(server):
     assert response.json()["Custom-header"] == "value"
 
 
-def test_post(server):
+def test_post(server: TestServer) -> None:
     with httpx2.Client() as client:
         response = client.post(server.url, content=b"Hello, world!")
     assert response.status_code == 200
     assert response.reason_phrase == "OK"
 
 
-def test_post_json(server):
+def test_post_json(server: TestServer) -> None:
     with httpx2.Client() as client:
         response = client.post(server.url, json={"text": "Hello, world!"})
     assert response.status_code == 200
     assert response.reason_phrase == "OK"
 
 
-def test_stream_response(server):
+def test_stream_response(server: TestServer) -> None:
     with httpx2.Client() as client:
         with client.stream("GET", server.url) as response:
             content = response.read()
@@ -97,7 +100,7 @@ def test_stream_response(server):
     assert content == b"Hello, world!"
 
 
-def test_stream_iterator(server):
+def test_stream_iterator(server: TestServer) -> None:
     body = b""
 
     with httpx2.Client() as client:
@@ -109,7 +112,7 @@ def test_stream_iterator(server):
     assert body == b"Hello, world!"
 
 
-def test_raw_iterator(server):
+def test_raw_iterator(server: TestServer) -> None:
     body = b""
 
     with httpx2.Client() as client:
@@ -121,7 +124,7 @@ def test_raw_iterator(server):
     assert body == b"Hello, world!"
 
 
-def test_cannot_stream_async_request(server):
+def test_cannot_stream_async_request(server: TestServer) -> None:
     async def hello_world() -> typing.AsyncIterator[bytes]:  # pragma: no cover
         yield b"Hello, "
         yield b"world!"
@@ -131,7 +134,7 @@ def test_cannot_stream_async_request(server):
             client.post(server.url, content=hello_world())
 
 
-def test_raise_for_status(server):
+def test_raise_for_status(server: TestServer) -> None:
     with httpx2.Client() as client:
         for status_code in (200, 400, 404, 500, 505):
             response = client.request("GET", server.url.copy_with(path=f"/status/{status_code}"))
@@ -144,42 +147,42 @@ def test_raise_for_status(server):
                 assert response.raise_for_status() is response
 
 
-def test_options(server):
+def test_options(server: TestServer) -> None:
     with httpx2.Client() as client:
         response = client.options(server.url)
     assert response.status_code == 200
     assert response.reason_phrase == "OK"
 
 
-def test_head(server):
+def test_head(server: TestServer) -> None:
     with httpx2.Client() as client:
         response = client.head(server.url)
     assert response.status_code == 200
     assert response.reason_phrase == "OK"
 
 
-def test_put(server):
+def test_put(server: TestServer) -> None:
     with httpx2.Client() as client:
         response = client.put(server.url, content=b"Hello, world!")
     assert response.status_code == 200
     assert response.reason_phrase == "OK"
 
 
-def test_patch(server):
+def test_patch(server: TestServer) -> None:
     with httpx2.Client() as client:
         response = client.patch(server.url, content=b"Hello, world!")
     assert response.status_code == 200
     assert response.reason_phrase == "OK"
 
 
-def test_delete(server):
+def test_delete(server: TestServer) -> None:
     with httpx2.Client() as client:
         response = client.delete(server.url)
     assert response.status_code == 200
     assert response.reason_phrase == "OK"
 
 
-def test_base_url(server):
+def test_base_url(server: TestServer) -> None:
     base_url = server.url
     with httpx2.Client(base_url=base_url) as client:
         response = client.get("/")
@@ -187,37 +190,37 @@ def test_base_url(server):
     assert response.url == base_url
 
 
-def test_merge_absolute_url():
+def test_merge_absolute_url() -> None:
     client = httpx2.Client(base_url="https://www.example.com/")
     request = client.build_request("GET", "http://www.example.com/")
     assert request.url == "http://www.example.com/"
 
 
-def test_merge_relative_url():
+def test_merge_relative_url() -> None:
     client = httpx2.Client(base_url="https://www.example.com/")
     request = client.build_request("GET", "/testing/123")
     assert request.url == "https://www.example.com/testing/123"
 
 
-def test_merge_relative_url_with_path():
+def test_merge_relative_url_with_path() -> None:
     client = httpx2.Client(base_url="https://www.example.com/some/path")
     request = client.build_request("GET", "/testing/123")
     assert request.url == "https://www.example.com/some/path/testing/123"
 
 
-def test_merge_relative_url_with_dotted_path():
+def test_merge_relative_url_with_dotted_path() -> None:
     client = httpx2.Client(base_url="https://www.example.com/some/path")
     request = client.build_request("GET", "../testing/123")
     assert request.url == "https://www.example.com/some/testing/123"
 
 
-def test_merge_relative_url_with_path_including_colon():
+def test_merge_relative_url_with_path_including_colon() -> None:
     client = httpx2.Client(base_url="https://www.example.com/some/path")
     request = client.build_request("GET", "/testing:123")
     assert request.url == "https://www.example.com/some/path/testing:123"
 
 
-def test_merge_relative_url_with_encoded_slashes():
+def test_merge_relative_url_with_encoded_slashes() -> None:
     client = httpx2.Client(base_url="https://www.example.com/")
     request = client.build_request("GET", "/testing%2F123")
     assert request.url == "https://www.example.com/testing%2F123"
@@ -227,23 +230,24 @@ def test_merge_relative_url_with_encoded_slashes():
     assert request.url == "https://www.example.com/base%2Fpath/testing"
 
 
-def test_context_managed_transport():
+def test_context_managed_transport() -> None:
     class Transport(httpx2.BaseTransport):
         def __init__(self) -> None:
             self.events: list[str] = []
 
-        def close(self):
+        def close(self) -> None:
             # The base implementation of httpx2.BaseTransport just
             # calls into `.close`, so simple transport cases can just override
             # this method for any cleanup, where more complex cases
             # might want to additionally override `__enter__`/`__exit__`.
             self.events.append("transport.close")
 
-        def __enter__(self):
+        def __enter__(self) -> Transport:
             super().__enter__()
             self.events.append("transport.__enter__")
+            return self
 
-        def __exit__(self, *args):
+        def __exit__(self, *args: typing.Any) -> None:
             super().__exit__(*args)
             self.events.append("transport.__exit__")
 
@@ -258,24 +262,25 @@ def test_context_managed_transport():
     ]
 
 
-def test_context_managed_transport_and_mount():
+def test_context_managed_transport_and_mount() -> None:
     class Transport(httpx2.BaseTransport):
         def __init__(self, name: str) -> None:
             self.name: str = name
             self.events: list[str] = []
 
-        def close(self):
+        def close(self) -> None:
             # The base implementation of httpx2.BaseTransport just
             # calls into `.close`, so simple transport cases can just override
             # this method for any cleanup, where more complex cases
             # might want to additionally override `__enter__`/`__exit__`.
             self.events.append(f"{self.name}.close")
 
-        def __enter__(self):
+        def __enter__(self) -> Transport:
             super().__enter__()
             self.events.append(f"{self.name}.__enter__")
+            return self
 
-        def __exit__(self, *args):
+        def __exit__(self, *args: typing.Any) -> None:
             super().__exit__(*args)
             self.events.append(f"{self.name}.__exit__")
 
@@ -296,11 +301,11 @@ def test_context_managed_transport_and_mount():
     ]
 
 
-def hello_world(request):
+def hello_world(request: httpx2.Request) -> httpx2.Response:
     return httpx2.Response(200, text="Hello, world!")
 
 
-def test_client_closed_state_using_implicit_open():
+def test_client_closed_state_using_implicit_open() -> None:
     client = httpx2.Client(transport=httpx2.MockTransport(hello_world))
 
     assert not client.is_closed
@@ -321,7 +326,7 @@ def test_client_closed_state_using_implicit_open():
             pass  # pragma: no cover
 
 
-def test_client_closed_state_using_with_block():
+def test_client_closed_state_using_with_block() -> None:
     with httpx2.Client(transport=httpx2.MockTransport(hello_world)) as client:
         assert not client.is_closed
         client.get("http://example.com")
@@ -336,7 +341,7 @@ def echo_raw_headers(request: httpx2.Request) -> httpx2.Response:
     return httpx2.Response(200, json=data)
 
 
-def test_raw_client_header():
+def test_raw_client_header() -> None:
     """
     Set a header in the Client.
     """
@@ -367,7 +372,7 @@ def mounted(request: httpx2.Request) -> httpx2.Response:
     return httpx2.Response(200, json=data)
 
 
-def test_mounted_transport():
+def test_mounted_transport() -> None:
     transport = httpx2.MockTransport(unmounted)
     mounts = {"custom://": httpx2.MockTransport(mounted)}
 
@@ -382,7 +387,7 @@ def test_mounted_transport():
     assert response.json() == {"app": "mounted"}
 
 
-def test_all_mounted_transport():
+def test_all_mounted_transport() -> None:
     mounts = {"all://": httpx2.MockTransport(mounted)}
 
     client = httpx2.Client(mounts=mounts)
@@ -392,7 +397,7 @@ def test_all_mounted_transport():
     assert response.json() == {"app": "mounted"}
 
 
-def test_server_extensions(server):
+def test_server_extensions(server: TestServer) -> None:
     url = server.url.copy_with(path="/http_version_2")
     with httpx2.Client(http2=True) as client:
         response = client.get(url)
@@ -400,7 +405,7 @@ def test_server_extensions(server):
     assert response.extensions["http_version"] == b"HTTP/1.1"
 
 
-def test_client_decode_text_using_autodetect():
+def test_client_decode_text_using_autodetect() -> None:
     # Ensure that a 'default_encoding=autodetect' on the response allows for
     # encoding autodetection to be used when no "Content-Type: text/plain; charset=..."
     # info is present.
@@ -414,7 +419,7 @@ def test_client_decode_text_using_autodetect():
         "plus complète le fond du génie français."
     )
 
-    def cp1252_but_no_content_type(request):
+    def cp1252_but_no_content_type(request: httpx2.Request) -> httpx2.Response:
         content = text.encode("ISO-8859-1")
         return httpx2.Response(200, content=content)
 
@@ -428,7 +433,7 @@ def test_client_decode_text_using_autodetect():
         assert response.text == text
 
 
-def test_client_decode_text_using_explicit_encoding():
+def test_client_decode_text_using_explicit_encoding() -> None:
     # Ensure that a 'default_encoding="..."' on the response is used for text decoding
     # when no "Content-Type: text/plain; charset=..."" info is present.
     #
@@ -441,7 +446,7 @@ def test_client_decode_text_using_explicit_encoding():
         "plus complète le fond du génie français."
     )
 
-    def cp1252_but_no_content_type(request):
+    def cp1252_but_no_content_type(request: httpx2.Request) -> httpx2.Response:
         content = text.encode("ISO-8859-1")
         return httpx2.Response(200, content=content)
 

--- a/tests/httpx2/client/test_event_hooks.py
+++ b/tests/httpx2/client/test_event_hooks.py
@@ -1,6 +1,13 @@
+from __future__ import annotations
+
+import typing
+
 import pytest
 
 import httpx2
+
+if typing.TYPE_CHECKING:  # pragma: no cover
+    from conftest import TestServer
 
 
 def app(request: httpx2.Request) -> httpx2.Response:
@@ -13,16 +20,19 @@ def app(request: httpx2.Request) -> httpx2.Response:
     return httpx2.Response(200, headers={"server": "testserver"})
 
 
-def test_event_hooks():
+def test_event_hooks() -> None:
     events = []
 
-    def on_request(request):
+    def on_request(request: httpx2.Request) -> None:
         events.append({"event": "request", "headers": dict(request.headers)})
 
-    def on_response(response):
+    def on_response(response: httpx2.Response) -> None:
         events.append({"event": "response", "headers": dict(response.headers)})
 
-    event_hooks = {"request": [on_request], "response": [on_response]}
+    event_hooks: dict[str, list[typing.Callable[..., typing.Any]]] = {
+        "request": [on_request],
+        "response": [on_response],
+    }
 
     with httpx2.Client(event_hooks=event_hooks, transport=httpx2.MockTransport(app)) as http:
         http.get("http://127.0.0.1:8000/", auth=("username", "password"))
@@ -46,8 +56,8 @@ def test_event_hooks():
     ]
 
 
-def test_event_hooks_raising_exception(server):
-    def raise_on_4xx_5xx(response):
+def test_event_hooks_raising_exception(server: TestServer) -> None:
+    def raise_on_4xx_5xx(response: httpx2.Response) -> None:
         response.raise_for_status()
 
     event_hooks = {"response": [raise_on_4xx_5xx]}
@@ -60,16 +70,19 @@ def test_event_hooks_raising_exception(server):
 
 
 @pytest.mark.anyio
-async def test_async_event_hooks():
+async def test_async_event_hooks() -> None:
     events = []
 
-    async def on_request(request):
+    async def on_request(request: httpx2.Request) -> None:
         events.append({"event": "request", "headers": dict(request.headers)})
 
-    async def on_response(response):
+    async def on_response(response: httpx2.Response) -> None:
         events.append({"event": "response", "headers": dict(response.headers)})
 
-    event_hooks = {"request": [on_request], "response": [on_response]}
+    event_hooks: dict[str, list[typing.Callable[..., typing.Any]]] = {
+        "request": [on_request],
+        "response": [on_response],
+    }
 
     async with httpx2.AsyncClient(event_hooks=event_hooks, transport=httpx2.MockTransport(app)) as http:
         await http.get("http://127.0.0.1:8000/", auth=("username", "password"))
@@ -94,8 +107,8 @@ async def test_async_event_hooks():
 
 
 @pytest.mark.anyio
-async def test_async_event_hooks_raising_exception():
-    async def raise_on_4xx_5xx(response):
+async def test_async_event_hooks_raising_exception() -> None:
+    async def raise_on_4xx_5xx(response: httpx2.Response) -> None:
         response.raise_for_status()
 
     event_hooks = {"response": [raise_on_4xx_5xx]}
@@ -107,20 +120,23 @@ async def test_async_event_hooks_raising_exception():
             assert exc.response.is_closed
 
 
-def test_event_hooks_with_redirect():
+def test_event_hooks_with_redirect() -> None:
     """
     A redirect request should trigger additional 'request' and 'response' event hooks.
     """
 
     events = []
 
-    def on_request(request):
+    def on_request(request: httpx2.Request) -> None:
         events.append({"event": "request", "headers": dict(request.headers)})
 
-    def on_response(response):
+    def on_response(response: httpx2.Response) -> None:
         events.append({"event": "response", "headers": dict(response.headers)})
 
-    event_hooks = {"request": [on_request], "response": [on_response]}
+    event_hooks: dict[str, list[typing.Callable[..., typing.Any]]] = {
+        "request": [on_request],
+        "response": [on_response],
+    }
 
     with httpx2.Client(
         event_hooks=event_hooks,
@@ -164,20 +180,23 @@ def test_event_hooks_with_redirect():
 
 
 @pytest.mark.anyio
-async def test_async_event_hooks_with_redirect():
+async def test_async_event_hooks_with_redirect() -> None:
     """
     A redirect request should trigger additional 'request' and 'response' event hooks.
     """
 
     events = []
 
-    async def on_request(request):
+    async def on_request(request: httpx2.Request) -> None:
         events.append({"event": "request", "headers": dict(request.headers)})
 
-    async def on_response(response):
+    async def on_response(response: httpx2.Response) -> None:
         events.append({"event": "response", "headers": dict(response.headers)})
 
-    event_hooks = {"request": [on_request], "response": [on_response]}
+    event_hooks: dict[str, list[typing.Callable[..., typing.Any]]] = {
+        "request": [on_request],
+        "response": [on_response],
+    }
 
     async with httpx2.AsyncClient(
         event_hooks=event_hooks,

--- a/tests/httpx2/client/test_event_hooks.py
+++ b/tests/httpx2/client/test_event_hooks.py
@@ -6,7 +6,7 @@ import pytest
 
 import httpx2
 
-if typing.TYPE_CHECKING:  # pragma: no cover
+if typing.TYPE_CHECKING:
     from conftest import TestServer
 
 

--- a/tests/httpx2/client/test_headers.py
+++ b/tests/httpx2/client/test_headers.py
@@ -20,7 +20,7 @@ def echo_repeated_headers_items(request: httpx2.Request) -> httpx2.Response:
     return httpx2.Response(200, json=data)
 
 
-def test_client_header():
+def test_client_header() -> None:
     """
     Set a header in the Client.
     """
@@ -44,7 +44,7 @@ def test_client_header():
     }
 
 
-def test_header_merge():
+def test_header_merge() -> None:
     url = "http://example.org/echo_headers"
     client_headers = {"User-Agent": "python-myclient/0.2.1"}
     request_headers = {"X-Auth-Token": "FooBarBazToken"}
@@ -64,7 +64,7 @@ def test_header_merge():
     }
 
 
-def test_header_merge_conflicting_headers():
+def test_header_merge_conflicting_headers() -> None:
     url = "http://example.org/echo_headers"
     client_headers = {"X-Auth-Token": "FooBar"}
     request_headers = {"X-Auth-Token": "BazToken"}
@@ -84,7 +84,7 @@ def test_header_merge_conflicting_headers():
     }
 
 
-def test_header_update():
+def test_header_update() -> None:
     url = "http://example.org/echo_headers"
     client = httpx2.Client(transport=httpx2.MockTransport(echo_headers))
     first_response = client.get(url)
@@ -115,7 +115,7 @@ def test_header_update():
     }
 
 
-def test_header_repeated_items():
+def test_header_repeated_items() -> None:
     url = "http://example.org/echo_headers"
     client = httpx2.Client(transport=httpx2.MockTransport(echo_repeated_headers_items))
     response = client.get(url, headers=[("x-header", "1"), ("x-header", "2,3")])
@@ -128,7 +128,7 @@ def test_header_repeated_items():
     assert ["x-header", ["1", "2", "3"]] in [[k, [subv.lstrip() for subv in v.split(",")]] for k, v in echoed_headers]
 
 
-def test_header_repeated_multi_items():
+def test_header_repeated_multi_items() -> None:
     url = "http://example.org/echo_headers"
     client = httpx2.Client(transport=httpx2.MockTransport(echo_repeated_headers_multi_items))
     response = client.get(url, headers=[("x-header", "1"), ("x-header", "2,3")])
@@ -140,7 +140,7 @@ def test_header_repeated_multi_items():
     assert ["x-header", "2,3"] in echoed_headers
 
 
-def test_remove_default_header():
+def test_remove_default_header() -> None:
     """
     Remove a default header from the Client.
     """
@@ -162,13 +162,13 @@ def test_remove_default_header():
     }
 
 
-def test_header_does_not_exist():
+def test_header_does_not_exist() -> None:
     headers = httpx2.Headers({"foo": "bar"})
     with pytest.raises(KeyError):
         del headers["baz"]
 
 
-def test_header_with_incorrect_value():
+def test_header_with_incorrect_value() -> None:
     with pytest.raises(
         TypeError,
         match=f"Header value must be str or bytes, not {type(None)}",
@@ -176,7 +176,7 @@ def test_header_with_incorrect_value():
         httpx2.Headers({"foo": None})  # type: ignore
 
 
-def test_host_with_auth_and_port_in_url():
+def test_host_with_auth_and_port_in_url() -> None:
     """
     The Host header should only include the hostname, or hostname:port
     (for non-default ports only). Any userinfo or default port should not
@@ -200,7 +200,7 @@ def test_host_with_auth_and_port_in_url():
     }
 
 
-def test_host_with_non_default_port_in_url():
+def test_host_with_non_default_port_in_url() -> None:
     """
     If the URL includes a non-default port, then it should be included in
     the Host header.
@@ -223,12 +223,12 @@ def test_host_with_non_default_port_in_url():
     }
 
 
-def test_request_auto_headers():
+def test_request_auto_headers() -> None:
     request = httpx2.Request("GET", "https://www.example.org/")
     assert "host" in request.headers
 
 
-def test_same_origin():
+def test_same_origin() -> None:
     origin = httpx2.URL("https://example.com")
     request = httpx2.Request("GET", "HTTPS://EXAMPLE.COM:443")
 
@@ -238,7 +238,7 @@ def test_same_origin():
     assert headers["Host"] == request.url.netloc.decode("ascii")
 
 
-def test_not_same_origin():
+def test_not_same_origin() -> None:
     origin = httpx2.URL("https://example.com")
     request = httpx2.Request("GET", "HTTP://EXAMPLE.COM:80")
 
@@ -248,7 +248,7 @@ def test_not_same_origin():
     assert headers["Host"] == origin.netloc.decode("ascii")
 
 
-def test_is_https_redirect():
+def test_is_https_redirect() -> None:
     url = httpx2.URL("https://example.com")
     request = httpx2.Request("GET", "http://example.com", headers={"Authorization": "empty"})
 
@@ -258,7 +258,7 @@ def test_is_https_redirect():
     assert "Authorization" in headers
 
 
-def test_is_not_https_redirect():
+def test_is_not_https_redirect() -> None:
     url = httpx2.URL("https://www.example.com")
     request = httpx2.Request("GET", "http://example.com", headers={"Authorization": "empty"})
 
@@ -268,7 +268,7 @@ def test_is_not_https_redirect():
     assert "Authorization" not in headers
 
 
-def test_is_not_https_redirect_if_not_default_ports():
+def test_is_not_https_redirect_if_not_default_ports() -> None:
     url = httpx2.URL("https://example.com:1337")
     request = httpx2.Request("GET", "http://example.com:9999", headers={"Authorization": "empty"})
 

--- a/tests/httpx2/client/test_properties.py
+++ b/tests/httpx2/client/test_properties.py
@@ -1,35 +1,37 @@
+from __future__ import annotations
+
 import httpx2
 
 
-def test_client_base_url():
+def test_client_base_url() -> None:
     client = httpx2.Client()
     client.base_url = "https://www.example.org/"
     assert isinstance(client.base_url, httpx2.URL)
     assert client.base_url == "https://www.example.org/"
 
 
-def test_client_base_url_without_trailing_slash():
+def test_client_base_url_without_trailing_slash() -> None:
     client = httpx2.Client()
     client.base_url = "https://www.example.org/path"
     assert isinstance(client.base_url, httpx2.URL)
     assert client.base_url == "https://www.example.org/path/"
 
 
-def test_client_base_url_with_trailing_slash():
+def test_client_base_url_with_trailing_slash() -> None:
     client = httpx2.Client()
     client.base_url = "https://www.example.org/path/"
     assert isinstance(client.base_url, httpx2.URL)
     assert client.base_url == "https://www.example.org/path/"
 
 
-def test_client_headers():
+def test_client_headers() -> None:
     client = httpx2.Client()
     client.headers = {"a": "b"}
     assert isinstance(client.headers, httpx2.Headers)
     assert client.headers["A"] == "b"
 
 
-def test_client_cookies():
+def test_client_cookies() -> None:
     client = httpx2.Client()
     client.cookies = {"a": "b"}
     assert isinstance(client.cookies, httpx2.Cookies)
@@ -38,7 +40,7 @@ def test_client_cookies():
     assert mycookies[0].name == "a" and mycookies[0].value == "b"
 
 
-def test_client_timeout():
+def test_client_timeout() -> None:
     expected_timeout = 12.0
     client = httpx2.Client()
 
@@ -51,8 +53,8 @@ def test_client_timeout():
     assert client.timeout.pool == expected_timeout
 
 
-def test_client_event_hooks():
-    def on_request(request):
+def test_client_event_hooks() -> None:
+    def on_request(request: httpx2.Request) -> None:
         pass  # pragma: no cover
 
     client = httpx2.Client()
@@ -60,7 +62,7 @@ def test_client_event_hooks():
     assert client.event_hooks == {"request": [on_request], "response": []}
 
 
-def test_client_trust_env():
+def test_client_trust_env() -> None:
     client = httpx2.Client()
     assert client.trust_env
 

--- a/tests/httpx2/client/test_proxies.py
+++ b/tests/httpx2/client/test_proxies.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+import typing
+
 import pytest
 
 import httpcore2
@@ -13,7 +17,7 @@ def url_to_origin(url: str) -> httpcore2.URL:
     return httpcore2.URL(scheme=u.raw_scheme, host=u.raw_host, port=u.port, target="/")
 
 
-def test_socks_proxy():
+def test_socks_proxy() -> None:
     url = httpx2.URL("http://www.example.com")
 
     for proxy in ("socks5://localhost/", "socks5h://localhost/"):
@@ -85,7 +89,7 @@ PROXY_URL = "http://[::1]"
         ),
     ],
 )
-def test_transport_for_request(url, proxies, expected):
+def test_transport_for_request(url: str, proxies: dict[str, str], expected: str | None) -> None:
     mounts = {key: httpx2.HTTPTransport(proxy=value) for key, value in proxies.items()}
     client = httpx2.Client(mounts=mounts)
 
@@ -101,7 +105,7 @@ def test_transport_for_request(url, proxies, expected):
 
 @pytest.mark.anyio
 @pytest.mark.network
-async def test_async_proxy_close():
+async def test_async_proxy_close() -> None:
     try:
         transport = httpx2.AsyncHTTPTransport(proxy=PROXY_URL)
         client = httpx2.AsyncClient(mounts={"https://": transport})
@@ -111,7 +115,7 @@ async def test_async_proxy_close():
 
 
 @pytest.mark.network
-def test_sync_proxy_close():
+def test_sync_proxy_close() -> None:
     try:
         transport = httpx2.HTTPTransport(proxy=PROXY_URL)
         client = httpx2.Client(mounts={"https://": transport})
@@ -120,7 +124,7 @@ def test_sync_proxy_close():
         client.close()
 
 
-def test_unsupported_proxy_scheme():
+def test_unsupported_proxy_scheme() -> None:
     with pytest.raises(ValueError):
         httpx2.Client(proxy="ftp://127.0.0.1")
 
@@ -223,7 +227,13 @@ def test_unsupported_proxy_scheme():
     ],
 )
 @pytest.mark.parametrize("client_class", [httpx2.Client, httpx2.AsyncClient])
-def test_proxies_environ(monkeypatch, client_class, url, env, expected):
+def test_proxies_environ(
+    monkeypatch: pytest.MonkeyPatch,
+    client_class: type[typing.Any],
+    url: str,
+    env: dict[str, str],
+    expected: str | None,
+) -> None:
     for name, value in env.items():
         monkeypatch.setenv(name, value)
 
@@ -247,7 +257,7 @@ def test_proxies_environ(monkeypatch, client_class, url, env, expected):
         ({"all://": "http://127.0.0.1"}, True),
     ],
 )
-def test_for_deprecated_proxy_params(proxies, is_valid):
+def test_for_deprecated_proxy_params(proxies: dict[str, str], is_valid: bool) -> None:
     mounts = {key: httpx2.HTTPTransport(proxy=value) for key, value in proxies.items()}
 
     if not is_valid:
@@ -257,7 +267,7 @@ def test_for_deprecated_proxy_params(proxies, is_valid):
         httpx2.Client(mounts=mounts)
 
 
-def test_proxy_with_mounts():
+def test_proxy_with_mounts() -> None:
     proxy_transport = httpx2.HTTPTransport(proxy="http://127.0.0.1")
     client = httpx2.Client(mounts={"http://": proxy_transport})
 

--- a/tests/httpx2/client/test_queryparams.py
+++ b/tests/httpx2/client/test_queryparams.py
@@ -5,13 +5,13 @@ def hello_world(request: httpx2.Request) -> httpx2.Response:
     return httpx2.Response(200, text="Hello, world")
 
 
-def test_client_queryparams():
+def test_client_queryparams() -> None:
     client = httpx2.Client(params={"a": "b"})
     assert isinstance(client.params, httpx2.QueryParams)
     assert client.params["a"] == "b"
 
 
-def test_client_queryparams_string():
+def test_client_queryparams_string() -> None:
     client = httpx2.Client(params="a=b")
     assert isinstance(client.params, httpx2.QueryParams)
     assert client.params["a"] == "b"
@@ -22,7 +22,7 @@ def test_client_queryparams_string():
     assert client.params["a"] == "b"
 
 
-def test_client_queryparams_echo():
+def test_client_queryparams_echo() -> None:
     url = "http://example.org/echo_queryparams"
     client_queryparams = "first=str"
     request_queryparams = {"second": "dict"}

--- a/tests/httpx2/client/test_redirects.py
+++ b/tests/httpx2/client/test_redirects.py
@@ -114,7 +114,7 @@ def redirects(request: httpx2.Request) -> httpx2.Response:
     return httpx2.Response(200, html="<html><body>Hello, world!</body></html>")
 
 
-def test_redirect_301():
+def test_redirect_301() -> None:
     client = httpx2.Client(transport=httpx2.MockTransport(redirects))
     response = client.post("https://example.org/redirect_301", follow_redirects=True)
     assert response.status_code == httpx2.codes.OK
@@ -122,7 +122,7 @@ def test_redirect_301():
     assert len(response.history) == 1
 
 
-def test_redirect_302():
+def test_redirect_302() -> None:
     client = httpx2.Client(transport=httpx2.MockTransport(redirects))
     response = client.post("https://example.org/redirect_302", follow_redirects=True)
     assert response.status_code == httpx2.codes.OK
@@ -130,7 +130,7 @@ def test_redirect_302():
     assert len(response.history) == 1
 
 
-def test_redirect_303():
+def test_redirect_303() -> None:
     client = httpx2.Client(transport=httpx2.MockTransport(redirects))
     response = client.get("https://example.org/redirect_303", follow_redirects=True)
     assert response.status_code == httpx2.codes.OK
@@ -138,7 +138,7 @@ def test_redirect_303():
     assert len(response.history) == 1
 
 
-def test_next_request():
+def test_next_request() -> None:
     client = httpx2.Client(transport=httpx2.MockTransport(redirects))
     request = client.build_request("POST", "https://example.org/redirect_303")
     response = client.send(request, follow_redirects=False)
@@ -153,7 +153,7 @@ def test_next_request():
 
 
 @pytest.mark.anyio
-async def test_async_next_request():
+async def test_async_next_request() -> None:
     async with httpx2.AsyncClient(transport=httpx2.MockTransport(redirects)) as client:
         request = client.build_request("POST", "https://example.org/redirect_303")
         response = await client.send(request, follow_redirects=False)
@@ -167,7 +167,7 @@ async def test_async_next_request():
         assert response.next_request is None
 
 
-def test_head_redirect():
+def test_head_redirect() -> None:
     """
     Contrary to Requests, redirects remain enabled by default for HEAD requests.
     """
@@ -180,7 +180,7 @@ def test_head_redirect():
     assert response.text == ""
 
 
-def test_relative_redirect():
+def test_relative_redirect() -> None:
     client = httpx2.Client(transport=httpx2.MockTransport(redirects))
     response = client.get("https://example.org/relative_redirect", follow_redirects=True)
     assert response.status_code == httpx2.codes.OK
@@ -188,7 +188,7 @@ def test_relative_redirect():
     assert len(response.history) == 1
 
 
-def test_malformed_redirect():
+def test_malformed_redirect() -> None:
     # https://github.com/encode/httpx/issues/771
     client = httpx2.Client(transport=httpx2.MockTransport(redirects))
     response = client.get("http://example.org/malformed_redirect", follow_redirects=True)
@@ -197,13 +197,13 @@ def test_malformed_redirect():
     assert len(response.history) == 1
 
 
-def test_invalid_redirect():
+def test_invalid_redirect() -> None:
     client = httpx2.Client(transport=httpx2.MockTransport(redirects))
     with pytest.raises(httpx2.RemoteProtocolError):
         client.get("http://example.org/invalid_redirect", follow_redirects=True)
 
 
-def test_no_scheme_redirect():
+def test_no_scheme_redirect() -> None:
     client = httpx2.Client(transport=httpx2.MockTransport(redirects))
     response = client.get("https://example.org/no_scheme_redirect", follow_redirects=True)
     assert response.status_code == httpx2.codes.OK
@@ -211,7 +211,7 @@ def test_no_scheme_redirect():
     assert len(response.history) == 1
 
 
-def test_fragment_redirect():
+def test_fragment_redirect() -> None:
     client = httpx2.Client(transport=httpx2.MockTransport(redirects))
     response = client.get("https://example.org/relative_redirect#fragment", follow_redirects=True)
     assert response.status_code == httpx2.codes.OK
@@ -219,7 +219,7 @@ def test_fragment_redirect():
     assert len(response.history) == 1
 
 
-def test_multiple_redirects():
+def test_multiple_redirects() -> None:
     client = httpx2.Client(transport=httpx2.MockTransport(redirects))
     response = client.get("https://example.org/multiple_redirects?count=20", follow_redirects=True)
     assert response.status_code == httpx2.codes.OK
@@ -232,25 +232,25 @@ def test_multiple_redirects():
 
 
 @pytest.mark.anyio
-async def test_async_too_many_redirects():
+async def test_async_too_many_redirects() -> None:
     async with httpx2.AsyncClient(transport=httpx2.MockTransport(redirects)) as client:
         with pytest.raises(httpx2.TooManyRedirects):
             await client.get("https://example.org/multiple_redirects?count=21", follow_redirects=True)
 
 
-def test_sync_too_many_redirects():
+def test_sync_too_many_redirects() -> None:
     client = httpx2.Client(transport=httpx2.MockTransport(redirects))
     with pytest.raises(httpx2.TooManyRedirects):
         client.get("https://example.org/multiple_redirects?count=21", follow_redirects=True)
 
 
-def test_redirect_loop():
+def test_redirect_loop() -> None:
     client = httpx2.Client(transport=httpx2.MockTransport(redirects))
     with pytest.raises(httpx2.TooManyRedirects):
         client.get("https://example.org/redirect_loop", follow_redirects=True)
 
 
-def test_cross_domain_redirect_with_auth_header():
+def test_cross_domain_redirect_with_auth_header() -> None:
     client = httpx2.Client(transport=httpx2.MockTransport(redirects))
     url = "https://example.com/cross_domain"
     headers = {"Authorization": "abc"}
@@ -259,7 +259,7 @@ def test_cross_domain_redirect_with_auth_header():
     assert "authorization" not in response.json()["headers"]
 
 
-def test_cross_domain_https_redirect_with_auth_header():
+def test_cross_domain_https_redirect_with_auth_header() -> None:
     client = httpx2.Client(transport=httpx2.MockTransport(redirects))
     url = "http://example.com/cross_domain"
     headers = {"Authorization": "abc"}
@@ -268,7 +268,7 @@ def test_cross_domain_https_redirect_with_auth_header():
     assert "authorization" not in response.json()["headers"]
 
 
-def test_cross_domain_redirect_with_auth():
+def test_cross_domain_redirect_with_auth() -> None:
     client = httpx2.Client(transport=httpx2.MockTransport(redirects))
     url = "https://example.com/cross_domain"
     response = client.get(url, auth=("user", "pass"), follow_redirects=True)
@@ -276,7 +276,7 @@ def test_cross_domain_redirect_with_auth():
     assert "authorization" not in response.json()["headers"]
 
 
-def test_same_domain_redirect():
+def test_same_domain_redirect() -> None:
     client = httpx2.Client(transport=httpx2.MockTransport(redirects))
     url = "https://example.org/cross_domain"
     headers = {"Authorization": "abc"}
@@ -285,7 +285,7 @@ def test_same_domain_redirect():
     assert response.json()["headers"]["authorization"] == "abc"
 
 
-def test_same_domain_https_redirect_with_auth_header():
+def test_same_domain_https_redirect_with_auth_header() -> None:
     client = httpx2.Client(transport=httpx2.MockTransport(redirects))
     url = "http://example.org/cross_domain"
     headers = {"Authorization": "abc"}
@@ -294,7 +294,7 @@ def test_same_domain_https_redirect_with_auth_header():
     assert response.json()["headers"]["authorization"] == "abc"
 
 
-def test_body_redirect():
+def test_body_redirect() -> None:
     """
     A 308 redirect should preserve the request body.
     """
@@ -307,7 +307,7 @@ def test_body_redirect():
     assert "content-length" in response.json()["headers"]
 
 
-def test_no_body_redirect():
+def test_no_body_redirect() -> None:
     """
     A 303 redirect should remove the request body.
     """
@@ -320,7 +320,7 @@ def test_no_body_redirect():
     assert "content-length" not in response.json()["headers"]
 
 
-def test_can_stream_if_no_redirect():
+def test_can_stream_if_no_redirect() -> None:
     client = httpx2.Client(transport=httpx2.MockTransport(redirects))
     url = "https://example.org/redirect_301"
     with client.stream("GET", url, follow_redirects=False) as response:
@@ -336,7 +336,7 @@ class ConsumeBodyTransport(httpx2.MockTransport):
         return self.handler(request)  # type: ignore[return-value]
 
 
-def test_cannot_redirect_streaming_body():
+def test_cannot_redirect_streaming_body() -> None:
     client = httpx2.Client(transport=ConsumeBodyTransport(redirects))
     url = "https://example.org/redirect_body"
 
@@ -347,7 +347,7 @@ def test_cannot_redirect_streaming_body():
         client.post(url, content=streaming_body(), follow_redirects=True)
 
 
-def test_cross_subdomain_redirect():
+def test_cross_subdomain_redirect() -> None:
     client = httpx2.Client(transport=httpx2.MockTransport(redirects))
     url = "https://example.com/cross_subdomain"
     response = client.get(url, follow_redirects=True)
@@ -381,7 +381,7 @@ def cookie_sessions(request: httpx2.Request) -> httpx2.Response:
         return httpx2.Response(status_code, headers=headers)
 
 
-def test_redirect_cookie_behavior():
+def test_redirect_cookie_behavior() -> None:
     client = httpx2.Client(transport=httpx2.MockTransport(cookie_sessions), follow_redirects=True)
 
     # The client is not logged in.
@@ -410,7 +410,7 @@ def test_redirect_cookie_behavior():
     assert response.text == "Not logged in"
 
 
-def test_redirect_custom_scheme():
+def test_redirect_custom_scheme() -> None:
     client = httpx2.Client(transport=httpx2.MockTransport(redirects))
     with pytest.raises(httpx2.UnsupportedProtocol) as e:
         client.post("https://example.org/redirect_custom_scheme", follow_redirects=True)
@@ -418,7 +418,7 @@ def test_redirect_custom_scheme():
 
 
 @pytest.mark.anyio
-async def test_async_invalid_redirect():
+async def test_async_invalid_redirect() -> None:
     async with httpx2.AsyncClient(transport=httpx2.MockTransport(redirects)) as client:
         with pytest.raises(httpx2.RemoteProtocolError):
             await client.get("http://example.org/invalid_redirect", follow_redirects=True)

--- a/tests/httpx2/conftest.py
+++ b/tests/httpx2/conftest.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import os
+import socket
 import threading
 import time
 import typing
@@ -32,7 +33,7 @@ ENVIRONMENT_VARIABLES = {
 
 
 @pytest.fixture(scope="function", autouse=True)
-def clean_environ():
+def clean_environ() -> typing.Iterator[None]:
     """Keeps os.environ clean for every test without having to mock os.environ"""
     original_environ = os.environ.copy()
     os.environ.clear()
@@ -176,29 +177,29 @@ async def redirect_301(scope: Scope, receive: Receive, send: Send) -> None:
 
 
 @pytest.fixture(scope="session")
-def cert_authority():
+def cert_authority() -> trustme.CA:
     return trustme.CA()
 
 
 @pytest.fixture(scope="session")
-def localhost_cert(cert_authority):
+def localhost_cert(cert_authority: trustme.CA) -> trustme.LeafCert:
     return cert_authority.issue_cert("localhost")
 
 
 @pytest.fixture(scope="session")
-def cert_pem_file(localhost_cert):
+def cert_pem_file(localhost_cert: trustme.LeafCert) -> typing.Iterator[str]:
     with localhost_cert.cert_chain_pems[0].tempfile() as tmp:
         yield tmp
 
 
 @pytest.fixture(scope="session")
-def cert_private_key_file(localhost_cert):
+def cert_private_key_file(localhost_cert: trustme.LeafCert) -> typing.Iterator[str]:
     with localhost_cert.private_key_pem.tempfile() as tmp:
         yield tmp
 
 
 @pytest.fixture(scope="session")
-def cert_encrypted_private_key_file(localhost_cert):
+def cert_encrypted_private_key_file(localhost_cert: trustme.LeafCert) -> typing.Iterator[str]:
     # Deserialize the private key and then reserialize with a password
     private_key = load_pem_private_key(localhost_cert.private_key_pem.bytes(), password=None, backend=default_backend())
     encrypted_private_key_pem = trustme.Blob(
@@ -223,7 +224,7 @@ class TestServer(Server):
         # because it can only be done in the main thread.
         pass  # pragma: nocover
 
-    async def serve(self, sockets=None):
+    async def serve(self, sockets: list[socket.socket] | None = None) -> None:
         self.restart_requested = asyncio.Event()
 
         loop = asyncio.get_running_loop()

--- a/tests/httpx2/models/test_cookies.py
+++ b/tests/httpx2/models/test_cookies.py
@@ -5,7 +5,7 @@ import pytest
 import httpx2
 
 
-def test_cookies():
+def test_cookies() -> None:
     cookies = httpx2.Cookies({"name": "value"})
     assert cookies["name"] == "value"
     assert "name" in cookies
@@ -20,7 +20,7 @@ def test_cookies():
     assert bool(cookies) is False
 
 
-def test_cookies_update():
+def test_cookies_update() -> None:
     cookies = httpx2.Cookies()
     more_cookies = httpx2.Cookies()
     more_cookies.set("name", "value", domain="example.com")
@@ -30,7 +30,7 @@ def test_cookies_update():
     assert cookies.get("name", domain="example.com") == "value"
 
 
-def test_cookies_with_domain():
+def test_cookies_with_domain() -> None:
     cookies = httpx2.Cookies()
     cookies.set("name", "value", domain="example.com")
     cookies.set("name", "value", domain="example.org")
@@ -42,7 +42,7 @@ def test_cookies_with_domain():
     assert len(cookies) == 1
 
 
-def test_cookies_with_domain_and_path():
+def test_cookies_with_domain_and_path() -> None:
     cookies = httpx2.Cookies()
     cookies.set("name", "value", domain="example.com", path="/subpath/1")
     cookies.set("name", "value", domain="example.com", path="/subpath/2")
@@ -52,7 +52,7 @@ def test_cookies_with_domain_and_path():
     assert len(cookies) == 0
 
 
-def test_multiple_set_cookie():
+def test_multiple_set_cookie() -> None:
     jar = http.cookiejar.CookieJar()
     headers = [
         (
@@ -76,7 +76,7 @@ def test_multiple_set_cookie():
     assert len(cookies) == 2
 
 
-def test_cookies_can_be_a_list_of_tuples():
+def test_cookies_can_be_a_list_of_tuples() -> None:
     cookies_val = [("name1", "val1"), ("name2", "val2")]
 
     cookies = httpx2.Cookies(cookies_val)
@@ -86,7 +86,7 @@ def test_cookies_can_be_a_list_of_tuples():
         assert cookies[k] == v
 
 
-def test_cookies_repr():
+def test_cookies_repr() -> None:
     cookies = httpx2.Cookies()
     cookies.set(name="foo", value="bar", domain="http://blah.com")
     cookies.set(name="fizz", value="buzz", domain="http://hello.com")

--- a/tests/httpx2/models/test_headers.py
+++ b/tests/httpx2/models/test_headers.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import pytest
 
 import httpx2
 
 
-def test_headers():
+def test_headers() -> None:
     h = httpx2.Headers([("a", "123"), ("a", "456"), ("b", "789")])
     assert "a" in h
     assert "A" in h
@@ -34,7 +36,7 @@ def test_headers():
     assert repr(h) == "Headers({'a': '123', 'b': '789'})"
 
 
-def test_header_mutations():
+def test_header_mutations() -> None:
     h = httpx2.Headers()
     assert dict(h) == {}
     h["a"] = "1"
@@ -50,44 +52,44 @@ def test_header_mutations():
     assert h.raw == [(b"b", b"4")]
 
 
-def test_copy_headers_method():
+def test_copy_headers_method() -> None:
     headers = httpx2.Headers({"custom": "example"})
     headers_copy = headers.copy()
     assert headers == headers_copy
     assert headers is not headers_copy
 
 
-def test_copy_headers_init():
+def test_copy_headers_init() -> None:
     headers = httpx2.Headers({"custom": "example"})
     headers_copy = httpx2.Headers(headers)
     assert headers == headers_copy
 
 
-def test_headers_insert_retains_ordering():
+def test_headers_insert_retains_ordering() -> None:
     headers = httpx2.Headers({"a": "a", "b": "b", "c": "c"})
     headers["b"] = "123"
     assert list(headers.values()) == ["a", "123", "c"]
 
 
-def test_headers_insert_appends_if_new():
+def test_headers_insert_appends_if_new() -> None:
     headers = httpx2.Headers({"a": "a", "b": "b", "c": "c"})
     headers["d"] = "123"
     assert list(headers.values()) == ["a", "b", "c", "123"]
 
 
-def test_headers_insert_removes_all_existing():
+def test_headers_insert_removes_all_existing() -> None:
     headers = httpx2.Headers([("a", "123"), ("a", "456")])
     headers["a"] = "789"
     assert dict(headers) == {"a": "789"}
 
 
-def test_headers_delete_removes_all_existing():
+def test_headers_delete_removes_all_existing() -> None:
     headers = httpx2.Headers([("a", "123"), ("a", "456")])
     del headers["a"]
     assert dict(headers) == {}
 
 
-def test_headers_dict_repr():
+def test_headers_dict_repr() -> None:
     """
     Headers should display with a dict repr by default.
     """
@@ -95,7 +97,7 @@ def test_headers_dict_repr():
     assert repr(headers) == "Headers({'custom': 'example'})"
 
 
-def test_headers_encoding_in_repr():
+def test_headers_encoding_in_repr() -> None:
     """
     Headers should display an encoding in the repr if required.
     """
@@ -103,7 +105,7 @@ def test_headers_encoding_in_repr():
     assert repr(headers) == "Headers({'custom': 'example ☃'}, encoding='utf-8')"
 
 
-def test_headers_list_repr():
+def test_headers_list_repr() -> None:
     """
     Headers should display with a list repr if they include multiple identical keys.
     """
@@ -111,7 +113,7 @@ def test_headers_list_repr():
     assert repr(headers) == "Headers([('custom', 'example 1'), ('custom', 'example 2')])"
 
 
-def test_headers_decode_ascii():
+def test_headers_decode_ascii() -> None:
     """
     Headers should decode as ascii by default.
     """
@@ -121,7 +123,7 @@ def test_headers_decode_ascii():
     assert headers.encoding == "ascii"
 
 
-def test_headers_decode_utf_8():
+def test_headers_decode_utf_8() -> None:
     """
     Headers containing non-ascii codepoints should default to decoding as utf-8.
     """
@@ -131,7 +133,7 @@ def test_headers_decode_utf_8():
     assert headers.encoding == "utf-8"
 
 
-def test_headers_decode_iso_8859_1():
+def test_headers_decode_iso_8859_1() -> None:
     """
     Headers containing non-UTF-8 codepoints should default to decoding as iso-8859-1.
     """
@@ -141,7 +143,7 @@ def test_headers_decode_iso_8859_1():
     assert headers.encoding == "iso-8859-1"
 
 
-def test_headers_decode_explicit_encoding():
+def test_headers_decode_explicit_encoding() -> None:
     """
     An explicit encoding may be set on headers in order to force a
     particular decoding.
@@ -153,7 +155,7 @@ def test_headers_decode_explicit_encoding():
     assert headers.encoding == "iso-8859-1"
 
 
-def test_multiple_headers():
+def test_multiple_headers() -> None:
     """
     `Headers.get_list` should support both split_commas=False and split_commas=True.
     """
@@ -165,7 +167,7 @@ def test_multiple_headers():
 
 
 @pytest.mark.parametrize("header", ["authorization", "proxy-authorization"])
-def test_sensitive_headers(header):
+def test_sensitive_headers(header: str) -> None:
     """
     Some headers should be obfuscated because they contain sensitive data.
     """
@@ -182,7 +184,7 @@ def test_sensitive_headers(header):
         ([("proxy-authorization", "s3kr3t")], [("proxy-authorization", "[secure]")]),
     ],
 )
-def test_obfuscate_sensitive_headers(headers, output):
+def test_obfuscate_sensitive_headers(headers: list[tuple[str, str]], output: list[tuple[str, str]]) -> None:
     as_dict = dict(output)
     headers_class = httpx2.Headers(dict(headers))
     assert repr(headers_class) == f"Headers({as_dict!r})"
@@ -207,11 +209,11 @@ def test_obfuscate_sensitive_headers(headers, output):
         ("", []),
     ),
 )
-def test_parse_header_links(value, expected):
+def test_parse_header_links(value: str, expected: list[dict[str, str]]) -> None:
     all_links = httpx2.Response(200, headers={"link": value}).links.values()
     assert all(link in all_links for link in expected)
 
 
-def test_parse_header_links_no_link():
+def test_parse_header_links_no_link() -> None:
     all_links = httpx2.Response(200).links
     assert all_links == {}

--- a/tests/httpx2/models/test_queryparams.py
+++ b/tests/httpx2/models/test_queryparams.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+import typing
+
 import pytest
 
 import httpx2
@@ -13,7 +17,7 @@ import httpx2
         (("a", "123"), ("a", "456"), ("b", "789")),
     ],
 )
-def test_queryparams(source):
+def test_queryparams(source: typing.Any) -> None:
     q = httpx2.QueryParams(source)
     assert "a" in q
     assert "A" not in q
@@ -42,7 +46,7 @@ def test_queryparams(source):
     assert httpx2.QueryParams(q) == q
 
 
-def test_queryparam_types():
+def test_queryparam_types() -> None:
     q = httpx2.QueryParams(None)
     assert str(q) == ""
 
@@ -68,7 +72,7 @@ def test_queryparam_types():
     assert str(q) == "a=1&a=2"
 
 
-def test_empty_query_params():
+def test_empty_query_params() -> None:
     q = httpx2.QueryParams({"a": ""})
     assert str(q) == "a="
 
@@ -79,37 +83,37 @@ def test_empty_query_params():
     assert str(q) == "a="
 
 
-def test_queryparam_update_is_hard_deprecated():
+def test_queryparam_update_is_hard_deprecated() -> None:
     q = httpx2.QueryParams("a=123")
     with pytest.raises(RuntimeError):
         q.update({"a": "456"})
 
 
-def test_queryparam_setter_is_hard_deprecated():
+def test_queryparam_setter_is_hard_deprecated() -> None:
     q = httpx2.QueryParams("a=123")
     with pytest.raises(RuntimeError):
         q["a"] = "456"
 
 
-def test_queryparam_set():
+def test_queryparam_set() -> None:
     q = httpx2.QueryParams("a=123")
     q = q.set("a", "456")
     assert q == httpx2.QueryParams("a=456")
 
 
-def test_queryparam_add():
+def test_queryparam_add() -> None:
     q = httpx2.QueryParams("a=123")
     q = q.add("a", "456")
     assert q == httpx2.QueryParams("a=123&a=456")
 
 
-def test_queryparam_remove():
+def test_queryparam_remove() -> None:
     q = httpx2.QueryParams("a=123")
     q = q.remove("a")
     assert q == httpx2.QueryParams("")
 
 
-def test_queryparam_merge():
+def test_queryparam_merge() -> None:
     q = httpx2.QueryParams("a=123")
     q = q.merge({"b": "456"})
     assert q == httpx2.QueryParams("a=123&b=456")
@@ -117,7 +121,7 @@ def test_queryparam_merge():
     assert q == httpx2.QueryParams("a=000&b=456&c=789")
 
 
-def test_queryparams_are_hashable():
+def test_queryparams_are_hashable() -> None:
     params = (
         httpx2.QueryParams("a=123"),
         httpx2.QueryParams({"a": 123}),

--- a/tests/httpx2/models/test_requests.py
+++ b/tests/httpx2/models/test_requests.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pickle
 import typing
 
@@ -6,31 +8,31 @@ import pytest
 import httpx2
 
 
-def test_request_repr():
+def test_request_repr() -> None:
     request = httpx2.Request("GET", "http://example.org")
     assert repr(request) == "<Request('GET', 'http://example.org')>"
 
 
-def test_no_content():
+def test_no_content() -> None:
     request = httpx2.Request("GET", "http://example.org")
     assert "Content-Length" not in request.headers
 
 
-def test_content_length_header():
+def test_content_length_header() -> None:
     request = httpx2.Request("POST", "http://example.org", content=b"test 123")
     assert request.headers["Content-Length"] == "8"
 
 
-def test_iterable_content():
+def test_iterable_content() -> None:
     class Content:
-        def __iter__(self):
+        def __iter__(self) -> typing.Iterator[bytes]:
             yield b"test 123"  # pragma: no cover
 
     request = httpx2.Request("POST", "http://example.org", content=Content())
     assert request.headers == {"Host": "example.org", "Transfer-Encoding": "chunked"}
 
 
-def test_generator_with_transfer_encoding_header():
+def test_generator_with_transfer_encoding_header() -> None:
     def content() -> typing.Iterator[bytes]:
         yield b"test 123"  # pragma: no cover
 
@@ -38,7 +40,7 @@ def test_generator_with_transfer_encoding_header():
     assert request.headers == {"Host": "example.org", "Transfer-Encoding": "chunked"}
 
 
-def test_generator_with_content_length_header():
+def test_generator_with_content_length_header() -> None:
     def content() -> typing.Iterator[bytes]:
         yield b"test 123"  # pragma: no cover
 
@@ -47,7 +49,7 @@ def test_generator_with_content_length_header():
     assert request.headers == {"Host": "example.org", "Content-Length": "8"}
 
 
-def test_url_encoded_data():
+def test_url_encoded_data() -> None:
     request = httpx2.Request("POST", "http://example.org", data={"test": "123"})
     request.read()
 
@@ -55,7 +57,7 @@ def test_url_encoded_data():
     assert request.content == b"test=123"
 
 
-def test_json_encoded_data():
+def test_json_encoded_data() -> None:
     request = httpx2.Request("POST", "http://example.org", json={"test": 123})
     request.read()
 
@@ -63,7 +65,7 @@ def test_json_encoded_data():
     assert request.content == b'{"test":123}'
 
 
-def test_headers():
+def test_headers() -> None:
     request = httpx2.Request("POST", "http://example.org", json={"test": 123})
 
     assert request.headers == {
@@ -73,7 +75,7 @@ def test_headers():
     }
 
 
-def test_read_and_stream_data():
+def test_read_and_stream_data() -> None:
     # Ensure a request may still be streamed if it has been read.
     # Needed for cases such as authentication classes that read the request body.
     request = httpx2.Request("POST", "http://example.org", json={"test": 123})
@@ -85,7 +87,7 @@ def test_read_and_stream_data():
 
 
 @pytest.mark.anyio
-async def test_aread_and_stream_data():
+async def test_aread_and_stream_data() -> None:
     # Ensure a request may still be streamed if it has been read.
     # Needed for cases such as authentication classes that read the request body.
     request = httpx2.Request("POST", "http://example.org", json={"test": 123})
@@ -96,7 +98,7 @@ async def test_aread_and_stream_data():
     assert content == request.content
 
 
-def test_cannot_access_streaming_content_without_read():
+def test_cannot_access_streaming_content_without_read() -> None:
     # Ensure that streaming requests
     def streaming_body() -> typing.Iterator[bytes]:  # pragma: no cover
         yield b""
@@ -106,7 +108,7 @@ def test_cannot_access_streaming_content_without_read():
         request.content  # noqa: B018
 
 
-def test_transfer_encoding_header():
+def test_transfer_encoding_header() -> None:
     async def streaming_body(data: bytes) -> typing.AsyncIterator[bytes]:
         yield data  # pragma: no cover
 
@@ -117,7 +119,7 @@ def test_transfer_encoding_header():
     assert request.headers["Transfer-Encoding"] == "chunked"
 
 
-def test_ignore_transfer_encoding_header_if_content_length_exists():
+def test_ignore_transfer_encoding_header_if_content_length_exists() -> None:
     """
     `Transfer-Encoding` should be ignored if `Content-Length` has been set explicitly.
     See https://github.com/encode/httpx/issues/1168
@@ -134,21 +136,21 @@ def test_ignore_transfer_encoding_header_if_content_length_exists():
     assert request.headers["Content-Length"] == "4"
 
 
-def test_override_host_header():
+def test_override_host_header() -> None:
     headers = {"host": "1.2.3.4:80"}
 
     request = httpx2.Request("GET", "http://example.org", headers=headers)
     assert request.headers["Host"] == "1.2.3.4:80"
 
 
-def test_override_accept_encoding_header():
+def test_override_accept_encoding_header() -> None:
     headers = {"Accept-Encoding": "identity"}
 
     request = httpx2.Request("GET", "http://example.org", headers=headers)
     assert request.headers["Accept-Encoding"] == "identity"
 
 
-def test_override_content_length_header():
+def test_override_content_length_header() -> None:
     async def streaming_body(data: bytes) -> typing.AsyncIterator[bytes]:
         yield data  # pragma: no cover
 
@@ -159,7 +161,7 @@ def test_override_content_length_header():
     assert request.headers["Content-Length"] == "8"
 
 
-def test_url():
+def test_url() -> None:
     url = "http://example.org"
     request = httpx2.Request("GET", url)
     assert request.url.scheme == "http"
@@ -175,7 +177,7 @@ def test_url():
     assert request.url.raw_path == b"/abc?foo=bar"
 
 
-def test_request_picklable():
+def test_request_picklable() -> None:
     request = httpx2.Request("POST", "http://example.org", json={"test": 123})
     pickle_request = pickle.loads(pickle.dumps(request))
     assert pickle_request.method == "POST"
@@ -191,7 +193,7 @@ def test_request_picklable():
 
 
 @pytest.mark.anyio
-async def test_request_async_streaming_content_picklable():
+async def test_request_async_streaming_content_picklable() -> None:
     async def streaming_body(data: bytes) -> typing.AsyncIterator[bytes]:
         yield data
 
@@ -209,7 +211,7 @@ async def test_request_async_streaming_content_picklable():
     assert pickle_request.content == b"test 123"
 
 
-def test_request_generator_content_picklable():
+def test_request_generator_content_picklable() -> None:
     def content() -> typing.Iterator[bytes]:
         yield b"test 123"  # pragma: no cover
 
@@ -226,7 +228,7 @@ def test_request_generator_content_picklable():
     assert pickle_request.content == b"test 123"
 
 
-def test_request_params():
+def test_request_params() -> None:
     request = httpx2.Request("GET", "http://example.com", params={})
     assert str(request.url) == "http://example.com"
 

--- a/tests/httpx2/models/test_responses.py
+++ b/tests/httpx2/models/test_responses.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import pickle
 import typing
@@ -9,7 +11,7 @@ import httpx2
 
 
 class StreamingBody:
-    def __iter__(self):
+    def __iter__(self) -> typing.Iterator[bytes]:
         yield b"Hello, "
         yield b"world!"
 
@@ -24,11 +26,11 @@ async def async_streaming_body() -> typing.AsyncIterator[bytes]:
     yield b"world!"
 
 
-def autodetect(content):
+def autodetect(content: bytes) -> str | None:
     return chardet.detect(content).get("encoding")
 
 
-def test_response():
+def test_response() -> None:
     response = httpx2.Response(
         200,
         content=b"Hello, world!",
@@ -43,7 +45,7 @@ def test_response():
     assert not response.is_error
 
 
-def test_response_content():
+def test_response_content() -> None:
     response = httpx2.Response(200, content="Hello, world!")
 
     assert response.status_code == 200
@@ -52,7 +54,7 @@ def test_response_content():
     assert response.headers == {"Content-Length": "13"}
 
 
-def test_response_text():
+def test_response_text() -> None:
     response = httpx2.Response(200, text="Hello, world!")
 
     assert response.status_code == 200
@@ -64,7 +66,7 @@ def test_response_text():
     }
 
 
-def test_response_html():
+def test_response_html() -> None:
     response = httpx2.Response(200, html="<html><body>Hello, world!</html></body>")
 
     assert response.status_code == 200
@@ -76,7 +78,7 @@ def test_response_html():
     }
 
 
-def test_response_json():
+def test_response_json() -> None:
     response = httpx2.Response(200, json={"hello": "world"})
 
     assert response.status_code == 200
@@ -88,7 +90,7 @@ def test_response_json():
     }
 
 
-def test_raise_for_status():
+def test_raise_for_status() -> None:
     request = httpx2.Request("GET", "https://example.org")
 
     # 2xx status codes are not an error.
@@ -146,7 +148,7 @@ def test_raise_for_status():
         response.raise_for_status()
 
 
-def test_response_repr():
+def test_response_repr() -> None:
     response = httpx2.Response(
         200,
         content=b"Hello, world!",
@@ -154,7 +156,7 @@ def test_response_repr():
     assert repr(response) == "<Response [200 OK]>"
 
 
-def test_response_content_type_encoding():
+def test_response_content_type_encoding() -> None:
     """
     Use the charset encoding in the Content-Type header if possible.
     """
@@ -169,7 +171,7 @@ def test_response_content_type_encoding():
     assert response.encoding == "latin-1"
 
 
-def test_response_default_to_utf8_encoding():
+def test_response_default_to_utf8_encoding() -> None:
     """
     Default to utf-8 encoding if there is no Content-Type header.
     """
@@ -182,7 +184,7 @@ def test_response_default_to_utf8_encoding():
     assert response.encoding == "utf-8"
 
 
-def test_response_fallback_to_utf8_encoding():
+def test_response_fallback_to_utf8_encoding() -> None:
     """
     Fallback to utf-8 if we get an invalid charset in the Content-Type header.
     """
@@ -197,7 +199,7 @@ def test_response_fallback_to_utf8_encoding():
     assert response.encoding == "utf-8"
 
 
-def test_response_no_charset_with_ascii_content():
+def test_response_no_charset_with_ascii_content() -> None:
     """
     A response with ascii encoded content should decode correctly,
     even with no charset specified.
@@ -214,7 +216,7 @@ def test_response_no_charset_with_ascii_content():
     assert response.text == "Hello, world!"
 
 
-def test_response_no_charset_with_utf8_content():
+def test_response_no_charset_with_utf8_content() -> None:
     """
     A response with UTF-8 encoded content should decode correctly,
     even with no charset specified.
@@ -230,7 +232,7 @@ def test_response_no_charset_with_utf8_content():
     assert response.encoding == "utf-8"
 
 
-def test_response_no_charset_with_iso_8859_1_content():
+def test_response_no_charset_with_iso_8859_1_content() -> None:
     """
     A response with ISO 8859-1 encoded content should decode correctly,
     even with no charset specified, if autodetect is enabled.
@@ -242,7 +244,7 @@ def test_response_no_charset_with_iso_8859_1_content():
     assert response.charset_encoding is None
 
 
-def test_response_no_charset_with_cp_1252_content():
+def test_response_no_charset_with_cp_1252_content() -> None:
     """
     A response with Windows 1252 encoded content should decode correctly,
     even with no charset specified, if autodetect is enabled.
@@ -254,7 +256,7 @@ def test_response_no_charset_with_cp_1252_content():
     assert response.charset_encoding is None
 
 
-def test_response_non_text_encoding():
+def test_response_non_text_encoding() -> None:
     """
     Default to attempting utf-8 encoding for non-text content-type headers.
     """
@@ -268,7 +270,7 @@ def test_response_non_text_encoding():
     assert response.encoding == "utf-8"
 
 
-def test_response_set_explicit_encoding():
+def test_response_set_explicit_encoding() -> None:
     headers = {"Content-Type": "text-plain; charset=utf-8"}  # Deliberately incorrect charset
     response = httpx2.Response(
         200,
@@ -280,7 +282,7 @@ def test_response_set_explicit_encoding():
     assert response.encoding == "latin-1"
 
 
-def test_response_force_encoding():
+def test_response_force_encoding() -> None:
     response = httpx2.Response(
         200,
         content="Snowman: ☃".encode("utf-8"),
@@ -292,7 +294,7 @@ def test_response_force_encoding():
     assert response.encoding == "iso-8859-1"
 
 
-def test_response_force_encoding_after_text_accessed():
+def test_response_force_encoding_after_text_accessed() -> None:
     response = httpx2.Response(
         200,
         content=b"Hello, world!",
@@ -309,7 +311,7 @@ def test_response_force_encoding_after_text_accessed():
         response.encoding = "iso-8859-1"
 
 
-def test_read():
+def test_read() -> None:
     response = httpx2.Response(
         200,
         content=b"Hello, world!",
@@ -327,7 +329,7 @@ def test_read():
     assert response.is_closed
 
 
-def test_empty_read():
+def test_empty_read() -> None:
     response = httpx2.Response(200)
 
     assert response.status_code == 200
@@ -343,7 +345,7 @@ def test_empty_read():
 
 
 @pytest.mark.anyio
-async def test_aread():
+async def test_aread() -> None:
     response = httpx2.Response(
         200,
         content=b"Hello, world!",
@@ -362,7 +364,7 @@ async def test_aread():
 
 
 @pytest.mark.anyio
-async def test_empty_aread():
+async def test_empty_aread() -> None:
     response = httpx2.Response(200)
 
     assert response.status_code == 200
@@ -377,7 +379,7 @@ async def test_empty_aread():
     assert response.is_closed
 
 
-def test_iter_raw():
+def test_iter_raw() -> None:
     response = httpx2.Response(
         200,
         content=streaming_body(),
@@ -389,7 +391,7 @@ def test_iter_raw():
     assert raw == b"Hello, world!"
 
 
-def test_iter_raw_with_chunksize():
+def test_iter_raw_with_chunksize() -> None:
     response = httpx2.Response(200, content=streaming_body())
     parts = list(response.iter_raw(chunk_size=5))
     assert parts == [b"Hello", b", wor", b"ld!"]
@@ -407,7 +409,7 @@ def test_iter_raw_with_chunksize():
     assert parts == [b"Hello, world!"]
 
 
-def test_iter_raw_doesnt_return_empty_chunks():
+def test_iter_raw_doesnt_return_empty_chunks() -> None:
     def streaming_body_with_empty_chunks() -> typing.Iterator[bytes]:
         yield b"Hello, "
         yield b""
@@ -420,7 +422,7 @@ def test_iter_raw_doesnt_return_empty_chunks():
     assert parts == [b"Hello, ", b"world!"]
 
 
-def test_iter_raw_on_iterable():
+def test_iter_raw_on_iterable() -> None:
     response = httpx2.Response(
         200,
         content=StreamingBody(),
@@ -432,7 +434,7 @@ def test_iter_raw_on_iterable():
     assert raw == b"Hello, world!"
 
 
-def test_iter_raw_on_async():
+def test_iter_raw_on_async() -> None:
     response = httpx2.Response(
         200,
         content=async_streaming_body(),
@@ -442,7 +444,7 @@ def test_iter_raw_on_async():
         list(response.iter_raw())
 
 
-def test_close_on_async():
+def test_close_on_async() -> None:
     response = httpx2.Response(
         200,
         content=async_streaming_body(),
@@ -452,7 +454,7 @@ def test_close_on_async():
         response.close()
 
 
-def test_iter_raw_increments_updates_counter():
+def test_iter_raw_increments_updates_counter() -> None:
     response = httpx2.Response(200, content=streaming_body())
 
     num_downloaded = response.num_bytes_downloaded
@@ -462,7 +464,7 @@ def test_iter_raw_increments_updates_counter():
 
 
 @pytest.mark.anyio
-async def test_aiter_raw():
+async def test_aiter_raw() -> None:
     response = httpx2.Response(200, content=async_streaming_body())
 
     raw = b""
@@ -472,7 +474,7 @@ async def test_aiter_raw():
 
 
 @pytest.mark.anyio
-async def test_aiter_raw_with_chunksize():
+async def test_aiter_raw_with_chunksize() -> None:
     response = httpx2.Response(200, content=async_streaming_body())
 
     parts = [part async for part in response.aiter_raw(chunk_size=5)]
@@ -490,7 +492,7 @@ async def test_aiter_raw_with_chunksize():
 
 
 @pytest.mark.anyio
-async def test_aiter_raw_on_sync():
+async def test_aiter_raw_on_sync() -> None:
     response = httpx2.Response(
         200,
         content=streaming_body(),
@@ -501,7 +503,7 @@ async def test_aiter_raw_on_sync():
 
 
 @pytest.mark.anyio
-async def test_aclose_on_sync():
+async def test_aclose_on_sync() -> None:
     response = httpx2.Response(
         200,
         content=streaming_body(),
@@ -512,7 +514,7 @@ async def test_aclose_on_sync():
 
 
 @pytest.mark.anyio
-async def test_aiter_raw_increments_updates_counter():
+async def test_aiter_raw_increments_updates_counter() -> None:
     response = httpx2.Response(200, content=async_streaming_body())
 
     num_downloaded = response.num_bytes_downloaded
@@ -521,7 +523,7 @@ async def test_aiter_raw_increments_updates_counter():
         num_downloaded = response.num_bytes_downloaded
 
 
-def test_iter_bytes():
+def test_iter_bytes() -> None:
     response = httpx2.Response(200, content=b"Hello, world!")
 
     content = b""
@@ -530,7 +532,7 @@ def test_iter_bytes():
     assert content == b"Hello, world!"
 
 
-def test_iter_bytes_with_chunk_size():
+def test_iter_bytes_with_chunk_size() -> None:
     response = httpx2.Response(200, content=streaming_body())
     parts = list(response.iter_bytes(chunk_size=5))
     assert parts == [b"Hello", b", wor", b"ld!"]
@@ -544,13 +546,13 @@ def test_iter_bytes_with_chunk_size():
     assert parts == [b"Hello, world!"]
 
 
-def test_iter_bytes_with_empty_response():
+def test_iter_bytes_with_empty_response() -> None:
     response = httpx2.Response(200, content=b"")
     parts = list(response.iter_bytes())
     assert parts == []
 
 
-def test_iter_bytes_doesnt_return_empty_chunks():
+def test_iter_bytes_doesnt_return_empty_chunks() -> None:
     def streaming_body_with_empty_chunks() -> typing.Iterator[bytes]:
         yield b"Hello, "
         yield b""
@@ -564,7 +566,7 @@ def test_iter_bytes_doesnt_return_empty_chunks():
 
 
 @pytest.mark.anyio
-async def test_aiter_bytes():
+async def test_aiter_bytes() -> None:
     response = httpx2.Response(
         200,
         content=b"Hello, world!",
@@ -577,7 +579,7 @@ async def test_aiter_bytes():
 
 
 @pytest.mark.anyio
-async def test_aiter_bytes_with_chunk_size():
+async def test_aiter_bytes_with_chunk_size() -> None:
     response = httpx2.Response(200, content=async_streaming_body())
     parts = [part async for part in response.aiter_bytes(chunk_size=5)]
     assert parts == [b"Hello", b", wor", b"ld!"]
@@ -591,7 +593,7 @@ async def test_aiter_bytes_with_chunk_size():
     assert parts == [b"Hello, world!"]
 
 
-def test_iter_text():
+def test_iter_text() -> None:
     response = httpx2.Response(
         200,
         content=b"Hello, world!",
@@ -603,7 +605,7 @@ def test_iter_text():
     assert content == "Hello, world!"
 
 
-def test_iter_text_with_chunk_size():
+def test_iter_text_with_chunk_size() -> None:
     response = httpx2.Response(200, content=b"Hello, world!")
     parts = list(response.iter_text(chunk_size=5))
     assert parts == ["Hello", ", wor", "ld!"]
@@ -626,7 +628,7 @@ def test_iter_text_with_chunk_size():
 
 
 @pytest.mark.anyio
-async def test_aiter_text():
+async def test_aiter_text() -> None:
     response = httpx2.Response(
         200,
         content=b"Hello, world!",
@@ -639,7 +641,7 @@ async def test_aiter_text():
 
 
 @pytest.mark.anyio
-async def test_aiter_text_with_chunk_size():
+async def test_aiter_text_with_chunk_size() -> None:
     response = httpx2.Response(200, content=b"Hello, world!")
     parts = [part async for part in response.aiter_text(chunk_size=5)]
     assert parts == ["Hello", ", wor", "ld!"]
@@ -653,7 +655,7 @@ async def test_aiter_text_with_chunk_size():
     assert parts == ["Hello, world!"]
 
 
-def test_iter_lines():
+def test_iter_lines() -> None:
     response = httpx2.Response(
         200,
         content=b"Hello,\nworld!",
@@ -663,7 +665,7 @@ def test_iter_lines():
 
 
 @pytest.mark.anyio
-async def test_aiter_lines():
+async def test_aiter_lines() -> None:
     response = httpx2.Response(
         200,
         content=b"Hello,\nworld!",
@@ -673,7 +675,7 @@ async def test_aiter_lines():
     assert content == ["Hello,", "world!"]
 
 
-def test_sync_streaming_response():
+def test_sync_streaming_response() -> None:
     response = httpx2.Response(
         200,
         content=streaming_body(),
@@ -690,7 +692,7 @@ def test_sync_streaming_response():
 
 
 @pytest.mark.anyio
-async def test_async_streaming_response():
+async def test_async_streaming_response() -> None:
     response = httpx2.Response(
         200,
         content=async_streaming_body(),
@@ -706,7 +708,7 @@ async def test_async_streaming_response():
     assert response.is_closed
 
 
-def test_cannot_read_after_stream_consumed():
+def test_cannot_read_after_stream_consumed() -> None:
     response = httpx2.Response(
         200,
         content=streaming_body(),
@@ -721,7 +723,7 @@ def test_cannot_read_after_stream_consumed():
 
 
 @pytest.mark.anyio
-async def test_cannot_aread_after_stream_consumed():
+async def test_cannot_aread_after_stream_consumed() -> None:
     response = httpx2.Response(
         200,
         content=async_streaming_body(),
@@ -735,7 +737,7 @@ async def test_cannot_aread_after_stream_consumed():
         await response.aread()
 
 
-def test_cannot_read_after_response_closed():
+def test_cannot_read_after_response_closed() -> None:
     response = httpx2.Response(
         200,
         content=streaming_body(),
@@ -747,7 +749,7 @@ def test_cannot_read_after_response_closed():
 
 
 @pytest.mark.anyio
-async def test_cannot_aread_after_response_closed():
+async def test_cannot_aread_after_response_closed() -> None:
     response = httpx2.Response(
         200,
         content=async_streaming_body(),
@@ -759,7 +761,7 @@ async def test_cannot_aread_after_response_closed():
 
 
 @pytest.mark.anyio
-async def test_elapsed_not_available_until_closed():
+async def test_elapsed_not_available_until_closed() -> None:
     response = httpx2.Response(
         200,
         content=async_streaming_body(),
@@ -769,7 +771,7 @@ async def test_elapsed_not_available_until_closed():
         response.elapsed  # noqa: B018
 
 
-def test_unknown_status_code():
+def test_unknown_status_code() -> None:
     response = httpx2.Response(
         600,
     )
@@ -778,7 +780,7 @@ def test_unknown_status_code():
     assert response.text == ""
 
 
-def test_json_with_specified_encoding():
+def test_json_with_specified_encoding() -> None:
     data = {"greeting": "hello", "recipient": "world"}
     content = json.dumps(data).encode("utf-16")
     headers = {"Content-Type": "application/json, charset=utf-16"}
@@ -790,7 +792,7 @@ def test_json_with_specified_encoding():
     assert response.json() == data
 
 
-def test_json_with_options():
+def test_json_with_options() -> None:
     data = {"greeting": "hello", "recipient": "world", "amount": 1}
     content = json.dumps(data).encode("utf-16")
     headers = {"Content-Type": "application/json, charset=utf-16"}
@@ -815,7 +817,7 @@ def test_json_with_options():
         "utf-32-le",
     ],
 )
-def test_json_without_specified_charset(encoding):
+def test_json_without_specified_charset(encoding: str) -> None:
     data = {"greeting": "hello", "recipient": "world"}
     content = json.dumps(data).encode(encoding)
     headers = {"Content-Type": "application/json"}
@@ -840,7 +842,7 @@ def test_json_without_specified_charset(encoding):
         "utf-32-le",
     ],
 )
-def test_json_with_specified_charset(encoding):
+def test_json_with_specified_charset(encoding: str) -> None:
     data = {"greeting": "hello", "recipient": "world"}
     content = json.dumps(data).encode(encoding)
     headers = {"Content-Type": f"application/json; charset={encoding}"}
@@ -868,7 +870,7 @@ def test_json_with_specified_charset(encoding):
         ),
     ],
 )
-def test_link_headers(headers, expected):
+def test_link_headers(headers: dict[str, str], expected: dict[str, dict[str, str]]) -> None:
     response = httpx2.Response(
         200,
         content=None,
@@ -878,7 +880,7 @@ def test_link_headers(headers, expected):
 
 
 @pytest.mark.parametrize("header_value", (b"deflate", b"gzip", b"br"))
-def test_decode_error_with_request(header_value):
+def test_decode_error_with_request(header_value: bytes) -> None:
     headers = [(b"Content-Encoding", header_value)]
     broken_compressed_body = b"xxxxxxxxxxxxxx"
     with pytest.raises(httpx2.DecodingError):
@@ -898,14 +900,14 @@ def test_decode_error_with_request(header_value):
 
 
 @pytest.mark.parametrize("header_value", (b"deflate", b"gzip", b"br"))
-def test_value_error_without_request(header_value):
+def test_value_error_without_request(header_value: bytes) -> None:
     headers = [(b"Content-Encoding", header_value)]
     broken_compressed_body = b"xxxxxxxxxxxxxx"
     with pytest.raises(httpx2.DecodingError):
         httpx2.Response(200, headers=headers, content=broken_compressed_body)
 
 
-def test_response_with_unset_request():
+def test_response_with_unset_request() -> None:
     response = httpx2.Response(200, content=b"Hello, world!")
 
     assert response.status_code == 200
@@ -914,7 +916,7 @@ def test_response_with_unset_request():
     assert not response.is_error
 
 
-def test_set_request_after_init():
+def test_set_request_after_init() -> None:
     response = httpx2.Response(200, content=b"Hello, world!")
 
     response.request = httpx2.Request("GET", "https://www.example.org")
@@ -923,14 +925,14 @@ def test_set_request_after_init():
     assert response.request.url == "https://www.example.org"
 
 
-def test_cannot_access_unset_request():
+def test_cannot_access_unset_request() -> None:
     response = httpx2.Response(200, content=b"Hello, world!")
 
     with pytest.raises(RuntimeError):
         response.request  # noqa: B018
 
 
-def test_generator_with_transfer_encoding_header():
+def test_generator_with_transfer_encoding_header() -> None:
     def content() -> typing.Iterator[bytes]:
         yield b"test 123"  # pragma: no cover
 
@@ -938,7 +940,7 @@ def test_generator_with_transfer_encoding_header():
     assert response.headers == {"Transfer-Encoding": "chunked"}
 
 
-def test_generator_with_content_length_header():
+def test_generator_with_content_length_header() -> None:
     def content() -> typing.Iterator[bytes]:
         yield b"test 123"  # pragma: no cover
 
@@ -947,7 +949,7 @@ def test_generator_with_content_length_header():
     assert response.headers == {"Content-Length": "8"}
 
 
-def test_response_picklable():
+def test_response_picklable() -> None:
     response = httpx2.Response(
         200,
         content=b"Hello, world!",
@@ -966,7 +968,7 @@ def test_response_picklable():
 
 
 @pytest.mark.anyio
-async def test_response_async_streaming_picklable():
+async def test_response_async_streaming_picklable() -> None:
     response = httpx2.Response(200, content=async_streaming_body())
     pickle_response = pickle.loads(pickle.dumps(response))
     with pytest.raises(httpx2.ResponseNotRead):
@@ -985,7 +987,7 @@ async def test_response_async_streaming_picklable():
     assert pickle_response.num_bytes_downloaded == 13
 
 
-def test_response_decode_text_using_autodetect():
+def test_response_decode_text_using_autodetect() -> None:
     # Ensure that a 'default_encoding="autodetect"' on the response allows for
     # encoding autodetection to be used when no "Content-Type: text/plain; charset=..."
     # info is present.
@@ -1010,7 +1012,7 @@ def test_response_decode_text_using_autodetect():
     assert response.text == text
 
 
-def test_response_decode_text_using_explicit_encoding():
+def test_response_decode_text_using_explicit_encoding() -> None:
     # Ensure that a 'default_encoding="..."' on the response is used for text decoding
     # when no "Content-Type: text/plain; charset=..."" info is present.
     #

--- a/tests/httpx2/models/test_url.py
+++ b/tests/httpx2/models/test_url.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 import httpx2
@@ -5,7 +7,7 @@ import httpx2
 # Tests for `httpx2.URL` instantiation and property accessors.
 
 
-def test_basic_url():
+def test_basic_url() -> None:
     url = httpx2.URL("https://www.example.com/")
 
     assert url.scheme == "https"
@@ -21,7 +23,7 @@ def test_basic_url():
     assert repr(url) == "URL('https://www.example.com/')"
 
 
-def test_complete_url():
+def test_complete_url() -> None:
     url = httpx2.URL("https://example.org:123/path/to/somewhere?abc=123#anchor")
     assert url.scheme == "https"
     assert url.host == "example.org"
@@ -35,7 +37,7 @@ def test_complete_url():
     assert repr(url) == "URL('https://example.org:123/path/to/somewhere?abc=123#anchor')"
 
 
-def test_url_with_empty_query():
+def test_url_with_empty_query() -> None:
     """
     URLs with and without a trailing `?` but an empty query component
     should preserve the information on the raw path.
@@ -51,14 +53,14 @@ def test_url_with_empty_query():
     assert url.raw_path == b"/path?"
 
 
-def test_url_no_scheme():
+def test_url_no_scheme() -> None:
     url = httpx2.URL("://example.com")
     assert url.scheme == ""
     assert url.host == "example.com"
     assert url.path == "/"
 
 
-def test_url_no_authority():
+def test_url_no_authority() -> None:
     url = httpx2.URL("http://")
     assert url.scheme == "http"
     assert url.host == ""
@@ -130,15 +132,15 @@ def test_url_no_authority():
         ),
     ],
 )
-def test_path_query_fragment(url, raw_path, path, query, fragment):
-    url = httpx2.URL(url)
-    assert url.raw_path == raw_path
-    assert url.path == path
-    assert url.query == query
-    assert url.fragment == fragment
+def test_path_query_fragment(url: str, raw_path: bytes, path: str, query: bytes, fragment: str) -> None:
+    parsed = httpx2.URL(url)
+    assert parsed.raw_path == raw_path
+    assert parsed.path == path
+    assert parsed.query == query
+    assert parsed.fragment == fragment
 
 
-def test_url_query_encoding():
+def test_url_query_encoding() -> None:
     url = httpx2.URL("https://www.example.com/?a=b c&d=e/f")
     assert url.raw_path == b"/?a=b%20c&d=e/f"
 
@@ -149,7 +151,7 @@ def test_url_query_encoding():
     assert url.raw_path == b"/?a=b+c&d=e%2Ff"
 
 
-def test_url_params():
+def test_url_params() -> None:
     url = httpx2.URL("https://example.org:123/path/to/somewhere", params={"a": "123"})
     assert str(url) == "https://example.org:123/path/to/somewhere?a=123"
     assert url.params == httpx2.QueryParams({"a": "123"})
@@ -200,32 +202,32 @@ def test_url_params():
         ),
     ],
 )
-def test_url_username_and_password(url, userinfo, username, password):
-    url = httpx2.URL(url)
-    assert url.userinfo == userinfo
-    assert url.username == username
-    assert url.password == password
+def test_url_username_and_password(url: str, userinfo: bytes, username: str, password: str) -> None:
+    parsed = httpx2.URL(url)
+    assert parsed.userinfo == userinfo
+    assert parsed.username == username
+    assert parsed.password == password
 
 
 # Tests for different host types
 
 
-def test_url_valid_host():
+def test_url_valid_host() -> None:
     url = httpx2.URL("https://example.com/")
     assert url.host == "example.com"
 
 
-def test_url_normalized_host():
+def test_url_normalized_host() -> None:
     url = httpx2.URL("https://EXAMPLE.com/")
     assert url.host == "example.com"
 
 
-def test_url_percent_escape_host():
+def test_url_percent_escape_host() -> None:
     url = httpx2.URL("https://exam le.com/")
     assert url.host == "exam%20le.com"
 
 
-def test_url_ipv4_like_host():
+def test_url_ipv4_like_host() -> None:
     """rare host names used to quality as IPv4"""
     url = httpx2.URL("https://023b76x43144/")
     assert url.host == "023b76x43144"
@@ -234,18 +236,18 @@ def test_url_ipv4_like_host():
 # Tests for different port types
 
 
-def test_url_valid_port():
+def test_url_valid_port() -> None:
     url = httpx2.URL("https://example.com:123/")
     assert url.port == 123
 
 
-def test_url_normalized_port():
+def test_url_normalized_port() -> None:
     # If the port matches the scheme default it is normalized to None.
     url = httpx2.URL("https://example.com:443/")
     assert url.port is None
 
 
-def test_url_invalid_port():
+def test_url_invalid_port() -> None:
     with pytest.raises(httpx2.InvalidURL) as exc:
         httpx2.URL("https://example.com:abc/")
     assert str(exc.value) == "Invalid port: 'abc'"
@@ -254,22 +256,22 @@ def test_url_invalid_port():
 # Tests for path handling
 
 
-def test_url_normalized_path():
+def test_url_normalized_path() -> None:
     url = httpx2.URL("https://example.com/abc/def/../ghi/./jkl")
     assert url.path == "/abc/ghi/jkl"
 
 
-def test_url_escaped_path():
+def test_url_escaped_path() -> None:
     url = httpx2.URL("https://example.com/ /🌟/")
     assert url.raw_path == b"/%20/%F0%9F%8C%9F/"
 
 
-def test_url_leading_dot_prefix_on_absolute_url():
+def test_url_leading_dot_prefix_on_absolute_url() -> None:
     url = httpx2.URL("https://example.com/../abc")
     assert url.path == "/abc"
 
 
-def test_url_leading_dot_prefix_on_relative_url():
+def test_url_leading_dot_prefix_on_relative_url() -> None:
     url = httpx2.URL("../abc")
     assert url.path == "../abc"
 
@@ -279,20 +281,20 @@ def test_url_leading_dot_prefix_on_relative_url():
 # Percent-encoding in `params={}` should match browser form behavior.
 
 
-def test_param_with_space():
+def test_param_with_space() -> None:
     # Params passed as form key-value pairs should be form escaped,
     # Including the special case of "+" for space separators.
     url = httpx2.URL("http://webservice", params={"u": "with spaces"})
     assert str(url) == "http://webservice?u=with+spaces"
 
 
-def test_param_requires_encoding():
+def test_param_requires_encoding() -> None:
     # Params passed as form key-value pairs should be escaped.
     url = httpx2.URL("http://webservice", params={"u": "%"})
     assert str(url) == "http://webservice?u=%25"
 
 
-def test_param_with_percent_encoded():
+def test_param_with_percent_encoded() -> None:
     # Params passed as form key-value pairs should always be escaped,
     # even if they include a valid escape sequence.
     # We want to match browser form behaviour here.
@@ -300,7 +302,7 @@ def test_param_with_percent_encoded():
     assert str(url) == "http://webservice?u=with%2520spaces"
 
 
-def test_param_with_existing_escape_requires_encoding():
+def test_param_with_existing_escape_requires_encoding() -> None:
     # Params passed as form key-value pairs should always be escaped,
     # even if they include a valid escape sequence.
     # We want to match browser form behaviour here.
@@ -313,19 +315,19 @@ def test_param_with_existing_escape_requires_encoding():
 # Percent-encoding in `url={}` should match browser URL bar behavior.
 
 
-def test_query_with_existing_percent_encoding():
+def test_query_with_existing_percent_encoding() -> None:
     # Valid percent encoded sequences should not be double encoded.
     url = httpx2.URL("http://webservice?u=phrase%20with%20spaces")
     assert str(url) == "http://webservice?u=phrase%20with%20spaces"
 
 
-def test_query_requiring_percent_encoding():
+def test_query_requiring_percent_encoding() -> None:
     # Characters that require percent encoding should be encoded.
     url = httpx2.URL("http://webservice?u=phrase with spaces")
     assert str(url) == "http://webservice?u=phrase%20with%20spaces"
 
 
-def test_query_with_mixed_percent_encoding():
+def test_query_with_mixed_percent_encoding() -> None:
     # When a mix of encoded and unencoded characters are present,
     # characters that require percent encoding should be encoded,
     # while existing sequences should not be double encoded.
@@ -336,7 +338,7 @@ def test_query_with_mixed_percent_encoding():
 # Tests for invalid URLs
 
 
-def test_url_invalid_hostname():
+def test_url_invalid_hostname() -> None:
     """
     Ensure that invalid URLs raise an `httpx2.InvalidURL` exception.
     """
@@ -344,25 +346,25 @@ def test_url_invalid_hostname():
         httpx2.URL("https://😇/")
 
 
-def test_url_excessively_long_url():
+def test_url_excessively_long_url() -> None:
     with pytest.raises(httpx2.InvalidURL) as exc:
         httpx2.URL("https://www.example.com/" + "x" * 100_000)
     assert str(exc.value) == "URL too long"
 
 
-def test_url_excessively_long_component():
+def test_url_excessively_long_component() -> None:
     with pytest.raises(httpx2.InvalidURL) as exc:
         httpx2.URL("https://www.example.com", path="/" + "x" * 100_000)
     assert str(exc.value) == "URL component 'path' too long"
 
 
-def test_url_non_printing_character_in_url():
+def test_url_non_printing_character_in_url() -> None:
     with pytest.raises(httpx2.InvalidURL) as exc:
         httpx2.URL("https://www.example.com/\n")
     assert str(exc.value) == ("Invalid non-printable ASCII character in URL, '\\n' at position 24.")
 
 
-def test_url_non_printing_character_in_component():
+def test_url_non_printing_character_in_component() -> None:
     with pytest.raises(httpx2.InvalidURL) as exc:
         httpx2.URL("https://www.example.com", path="/\n")
     assert str(exc.value) == ("Invalid non-printable ASCII character in URL path component, '\\n' at position 1.")
@@ -371,7 +373,7 @@ def test_url_non_printing_character_in_component():
 # Test for url components
 
 
-def test_url_with_components():
+def test_url_with_components() -> None:
     url = httpx2.URL(scheme="https", host="www.example.com", path="/")
 
     assert url.scheme == "https"
@@ -385,19 +387,19 @@ def test_url_with_components():
     assert str(url) == "https://www.example.com/"
 
 
-def test_urlparse_with_invalid_component():
+def test_urlparse_with_invalid_component() -> None:
     with pytest.raises(TypeError) as exc:
         httpx2.URL(scheme="https", host="www.example.com", incorrect="/")
     assert str(exc.value) == "'incorrect' is an invalid keyword argument for URL()"
 
 
-def test_urlparse_with_invalid_scheme():
+def test_urlparse_with_invalid_scheme() -> None:
     with pytest.raises(httpx2.InvalidURL) as exc:
         httpx2.URL(scheme="~", host="www.example.com", path="/")
     assert str(exc.value) == "Invalid URL component 'scheme'"
 
 
-def test_urlparse_with_invalid_path():
+def test_urlparse_with_invalid_path() -> None:
     with pytest.raises(httpx2.InvalidURL) as exc:
         httpx2.URL(scheme="https", host="www.example.com", path="abc")
     assert str(exc.value) == "For absolute URLs, path must be empty or begin with '/'"
@@ -411,7 +413,7 @@ def test_urlparse_with_invalid_path():
     assert str(exc.value) == "Relative URLs cannot have a path starting with ':'"
 
 
-def test_url_with_relative_path():
+def test_url_with_relative_path() -> None:
     # This path would be invalid for an absolute URL, but is valid as a relative URL.
     url = httpx2.URL(path="abc")
     assert url.path == "abc"
@@ -420,7 +422,7 @@ def test_url_with_relative_path():
 # Tests for `httpx2.URL` python built-in operators.
 
 
-def test_url_eq_str():
+def test_url_eq_str() -> None:
     """
     Ensure that `httpx2.URL` supports the equality operator.
     """
@@ -429,7 +431,7 @@ def test_url_eq_str():
     assert str(url) == url
 
 
-def test_url_set():
+def test_url_set() -> None:
     """
     Ensure that `httpx2.URL` instances can be used in sets.
     """
@@ -446,7 +448,7 @@ def test_url_set():
 # Tests for TypeErrors when instantiating `httpx2.URL`.
 
 
-def test_url_invalid_type():
+def test_url_invalid_type() -> None:
     """
     Ensure that invalid types on `httpx2.URL()` raise a `TypeError`.
     """
@@ -458,7 +460,7 @@ def test_url_invalid_type():
         httpx2.URL(ExternalURLClass())  # type: ignore
 
 
-def test_url_with_invalid_component():
+def test_url_with_invalid_component() -> None:
     with pytest.raises(TypeError) as exc:
         httpx2.URL(scheme="https", host="www.example.com", incorrect="/")
     assert str(exc.value) == "'incorrect' is an invalid keyword argument for URL()"
@@ -467,7 +469,7 @@ def test_url_with_invalid_component():
 # Tests for `URL.join()`.
 
 
-def test_url_join():
+def test_url_join() -> None:
     """
     Some basic URL joining tests.
     """
@@ -478,7 +480,7 @@ def test_url_join():
     assert url.join("../../somewhere-else") == "https://example.org:123/somewhere-else"
 
 
-def test_relative_url_join():
+def test_relative_url_join() -> None:
     url = httpx2.URL("/path/to/somewhere")
     assert url.join("/somewhere-else") == "/somewhere-else"
     assert url.join("somewhere-else") == "/path/to/somewhere-else"
@@ -486,7 +488,7 @@ def test_relative_url_join():
     assert url.join("../../somewhere-else") == "/somewhere-else"
 
 
-def test_url_join_rfc3986():
+def test_url_join_rfc3986() -> None:
     """
     URL joining tests, as-per reference examples in RFC 3986.
 
@@ -541,7 +543,7 @@ def test_url_join_rfc3986():
     assert url.join("g#s/../x") == "http://example.com/b/c/g#s/../x"
 
 
-def test_resolution_error_1833():
+def test_resolution_error_1833() -> None:
     """
     See https://github.com/encode/httpx/issues/1833
     """
@@ -552,7 +554,7 @@ def test_resolution_error_1833():
 # Tests for `URL.copy_with()`.
 
 
-def test_copy_with():
+def test_copy_with() -> None:
     url = httpx2.URL("https://www.example.com/")
     assert str(url) == "https://www.example.com/"
 
@@ -569,7 +571,7 @@ def test_copy_with():
     assert str(url) == "http://example.com/abc"
 
 
-def test_url_copywith_authority_subcomponents():
+def test_url_copywith_authority_subcomponents() -> None:
     copy_with_kwargs = {
         "username": "username",
         "password": "password",
@@ -581,7 +583,7 @@ def test_url_copywith_authority_subcomponents():
     assert str(new) == "https://username:password@example.net:444"
 
 
-def test_url_copywith_netloc():
+def test_url_copywith_netloc() -> None:
     copy_with_kwargs = {
         "netloc": b"example.net:444",
     }
@@ -590,7 +592,7 @@ def test_url_copywith_netloc():
     assert str(new) == "https://example.net:444"
 
 
-def test_url_copywith_userinfo_subcomponents():
+def test_url_copywith_userinfo_subcomponents() -> None:
     copy_with_kwargs = {
         "username": "tom@example.org",
         "password": "abc123@ %",
@@ -603,7 +605,7 @@ def test_url_copywith_userinfo_subcomponents():
     assert new.userinfo == b"tom%40example.org:abc123%40%20%"
 
 
-def test_url_copywith_invalid_component():
+def test_url_copywith_invalid_component() -> None:
     url = httpx2.URL("https://example.org")
     with pytest.raises(TypeError):
         url.copy_with(pathh="/incorrect-spelling")
@@ -611,7 +613,7 @@ def test_url_copywith_invalid_component():
         url.copy_with(userinfo="should be bytes")
 
 
-def test_url_copywith_urlencoded_path():
+def test_url_copywith_urlencoded_path() -> None:
     url = httpx2.URL("https://example.org")
     url = url.copy_with(path="/path to somewhere")
     assert url.path == "/path to somewhere"
@@ -619,7 +621,7 @@ def test_url_copywith_urlencoded_path():
     assert url.raw_path == b"/path%20to%20somewhere"
 
 
-def test_url_copywith_query():
+def test_url_copywith_query() -> None:
     url = httpx2.URL("https://example.org")
     url = url.copy_with(query=b"a=123")
     assert url.path == "/"
@@ -627,7 +629,7 @@ def test_url_copywith_query():
     assert url.raw_path == b"/?a=123"
 
 
-def test_url_copywith_raw_path():
+def test_url_copywith_raw_path() -> None:
     url = httpx2.URL("https://example.org")
     url = url.copy_with(raw_path=b"/some/path")
     assert url.path == "/some/path"
@@ -647,7 +649,7 @@ def test_url_copywith_raw_path():
     assert url.raw_path == b"/some/path?a=123"
 
 
-def test_url_copywith_security():
+def test_url_copywith_security() -> None:
     """
     Prevent unexpected changes on URL after calling copy_with (CVE-2021-41945)
     """
@@ -668,7 +670,7 @@ def test_url_copywith_security():
 # `URL.copy_merge_params()`
 
 
-def test_url_set_param_manipulation():
+def test_url_set_param_manipulation() -> None:
     """
     Some basic URL query parameter manipulation.
     """
@@ -676,7 +678,7 @@ def test_url_set_param_manipulation():
     assert url.copy_set_param("a", "456") == "https://example.org:123/?a=456"
 
 
-def test_url_add_param_manipulation():
+def test_url_add_param_manipulation() -> None:
     """
     Some basic URL query parameter manipulation.
     """
@@ -684,7 +686,7 @@ def test_url_add_param_manipulation():
     assert url.copy_add_param("a", "456") == "https://example.org:123/?a=123&a=456"
 
 
-def test_url_remove_param_manipulation():
+def test_url_remove_param_manipulation() -> None:
     """
     Some basic URL query parameter manipulation.
     """
@@ -692,7 +694,7 @@ def test_url_remove_param_manipulation():
     assert url.copy_remove_param("a") == "https://example.org:123/"
 
 
-def test_url_merge_params_manipulation():
+def test_url_merge_params_manipulation() -> None:
     """
     Some basic URL query parameter manipulation.
     """
@@ -764,7 +766,7 @@ def test_url_merge_params_manipulation():
         "https_with_custom_port",
     ],
 )
-def test_idna_url(given, idna, host, raw_host, scheme, port):
+def test_idna_url(given: str, idna: str, host: str, raw_host: bytes, scheme: str, port: int | None) -> None:
     url = httpx2.URL(given)
     assert url == httpx2.URL(idna)
     assert url.host == host
@@ -773,17 +775,17 @@ def test_idna_url(given, idna, host, raw_host, scheme, port):
     assert url.port == port
 
 
-def test_url_unescaped_idna_host():
+def test_url_unescaped_idna_host() -> None:
     url = httpx2.URL("https://中国.icom.museum/")
     assert url.raw_host == b"xn--fiqs8s.icom.museum"
 
 
-def test_url_escaped_idna_host():
+def test_url_escaped_idna_host() -> None:
     url = httpx2.URL("https://xn--fiqs8s.icom.museum/")
     assert url.raw_host == b"xn--fiqs8s.icom.museum"
 
 
-def test_url_invalid_idna_host():
+def test_url_invalid_idna_host() -> None:
     with pytest.raises(httpx2.InvalidURL) as exc:
         httpx2.URL("https://☃.com/")
     assert str(exc.value) == "Invalid IDNA hostname: '☃.com'"
@@ -792,12 +794,12 @@ def test_url_invalid_idna_host():
 # Tests for IPv4 hostname support.
 
 
-def test_url_valid_ipv4():
+def test_url_valid_ipv4() -> None:
     url = httpx2.URL("https://1.2.3.4/")
     assert url.host == "1.2.3.4"
 
 
-def test_url_invalid_ipv4():
+def test_url_invalid_ipv4() -> None:
     with pytest.raises(httpx2.InvalidURL) as exc:
         httpx2.URL("https://999.999.999.999/")
     assert str(exc.value) == "Invalid IPv4 address: '999.999.999.999'"
@@ -806,26 +808,26 @@ def test_url_invalid_ipv4():
 # Tests for IPv6 hostname support.
 
 
-def test_ipv6_url():
+def test_ipv6_url() -> None:
     url = httpx2.URL("http://[::ffff:192.168.0.1]:5678/")
 
     assert url.host == "::ffff:192.168.0.1"
     assert url.netloc == b"[::ffff:192.168.0.1]:5678"
 
 
-def test_url_valid_ipv6():
+def test_url_valid_ipv6() -> None:
     url = httpx2.URL("https://[2001:db8::ff00:42:8329]/")
     assert url.host == "2001:db8::ff00:42:8329"
 
 
-def test_url_invalid_ipv6():
+def test_url_invalid_ipv6() -> None:
     with pytest.raises(httpx2.InvalidURL) as exc:
         httpx2.URL("https://[2001]/")
     assert str(exc.value) == "Invalid IPv6 address: '[2001]'"
 
 
 @pytest.mark.parametrize("host", ["[::ffff:192.168.0.1]", "::ffff:192.168.0.1"])
-def test_ipv6_url_from_raw_url(host):
+def test_ipv6_url_from_raw_url(host: str) -> None:
     url = httpx2.URL(scheme="https", host=host, port=443, path="/")
 
     assert url.host == "::ffff:192.168.0.1"
@@ -842,7 +844,7 @@ def test_ipv6_url_from_raw_url(host):
     ],
 )
 @pytest.mark.parametrize("new_host", ["[::ffff:192.168.0.1]", "::ffff:192.168.0.1"])
-def test_ipv6_url_copy_with_host(url_str, new_host):
+def test_ipv6_url_copy_with_host(url_str: str, new_host: str) -> None:
     url = httpx2.URL(url_str).copy_with(host=new_host)
 
     assert url.host == "::ffff:192.168.0.1"

--- a/tests/httpx2/models/test_whatwg.py
+++ b/tests/httpx2/models/test_whatwg.py
@@ -2,7 +2,10 @@
 #
 # https://url.spec.whatwg.org/
 
+from __future__ import annotations
+
 import json
+import typing
 
 import pytest
 
@@ -16,7 +19,7 @@ with open("tests/httpx2/models/whatwg.json", "r", encoding="utf-8") as input:
 
 
 @pytest.mark.parametrize("test_case", test_cases)
-def test_urlparse(test_case):
+def test_urlparse(test_case: dict[str, typing.Any]) -> None:
     if test_case["href"] in ("a: foo.com", "lolscheme:x x#x%20x"):
         # Skip these two test cases.
         # WHATWG cases where are not using percent-encoding for the space character.

--- a/tests/httpx2/test_api.py
+++ b/tests/httpx2/test_api.py
@@ -1,11 +1,16 @@
+from __future__ import annotations
+
 import typing
 
 import pytest
 
 import httpx2
 
+if typing.TYPE_CHECKING:  # pragma: no cover
+    from conftest import TestServer
 
-def test_get(server):
+
+def test_get(server: TestServer) -> None:
     response = httpx2.get(server.url)
     assert response.status_code == 200
     assert response.reason_phrase == "OK"
@@ -13,13 +18,13 @@ def test_get(server):
     assert response.http_version == "HTTP/1.1"
 
 
-def test_post(server):
+def test_post(server: TestServer) -> None:
     response = httpx2.post(server.url, content=b"Hello, world!")
     assert response.status_code == 200
     assert response.reason_phrase == "OK"
 
 
-def test_post_byte_iterator(server):
+def test_post_byte_iterator(server: TestServer) -> None:
     def data() -> typing.Iterator[bytes]:
         yield b"Hello"
         yield b", "
@@ -30,9 +35,9 @@ def test_post_byte_iterator(server):
     assert response.reason_phrase == "OK"
 
 
-def test_post_byte_stream(server):
+def test_post_byte_stream(server: TestServer) -> None:
     class Data(httpx2.SyncByteStream):
-        def __iter__(self):
+        def __iter__(self) -> typing.Iterator[bytes]:
             yield b"Hello"
             yield b", "
             yield b"world!"
@@ -42,37 +47,37 @@ def test_post_byte_stream(server):
     assert response.reason_phrase == "OK"
 
 
-def test_options(server):
+def test_options(server: TestServer) -> None:
     response = httpx2.options(server.url)
     assert response.status_code == 200
     assert response.reason_phrase == "OK"
 
 
-def test_head(server):
+def test_head(server: TestServer) -> None:
     response = httpx2.head(server.url)
     assert response.status_code == 200
     assert response.reason_phrase == "OK"
 
 
-def test_put(server):
+def test_put(server: TestServer) -> None:
     response = httpx2.put(server.url, content=b"Hello, world!")
     assert response.status_code == 200
     assert response.reason_phrase == "OK"
 
 
-def test_patch(server):
+def test_patch(server: TestServer) -> None:
     response = httpx2.patch(server.url, content=b"Hello, world!")
     assert response.status_code == 200
     assert response.reason_phrase == "OK"
 
 
-def test_delete(server):
+def test_delete(server: TestServer) -> None:
     response = httpx2.delete(server.url)
     assert response.status_code == 200
     assert response.reason_phrase == "OK"
 
 
-def test_stream(server):
+def test_stream(server: TestServer) -> None:
     with httpx2.stream("GET", server.url) as response:
         response.read()
 
@@ -82,13 +87,13 @@ def test_stream(server):
     assert response.http_version == "HTTP/1.1"
 
 
-def test_get_invalid_url():
+def test_get_invalid_url() -> None:
     with pytest.raises(httpx2.UnsupportedProtocol):
         httpx2.get("invalid://example.org")
 
 
 # check that httpcore isn't imported until we do a request
-def test_httpcore_lazy_loading(server):
+def test_httpcore_lazy_loading(server: TestServer) -> None:
     import sys
 
     # unload our module if it is already loaded

--- a/tests/httpx2/test_api.py
+++ b/tests/httpx2/test_api.py
@@ -6,7 +6,7 @@ import pytest
 
 import httpx2
 
-if typing.TYPE_CHECKING:  # pragma: no cover
+if typing.TYPE_CHECKING:
     from conftest import TestServer
 
 

--- a/tests/httpx2/test_asgi.py
+++ b/tests/httpx2/test_asgi.py
@@ -1,11 +1,17 @@
 import json
+import typing
 
 import pytest
 
 import httpx2
 
+Message = typing.MutableMapping[str, typing.Any]
+Receive = typing.Callable[[], typing.Awaitable[Message]]
+Send = typing.Callable[[typing.MutableMapping[str, typing.Any]], typing.Awaitable[None]]
+Scope = typing.MutableMapping[str, typing.Any]
 
-async def hello_world(scope, receive, send):
+
+async def hello_world(scope: Scope, receive: Receive, send: Send) -> None:
     status = 200
     output = b"Hello, World!"
     headers = [(b"content-type", "text/plain"), (b"content-length", str(len(output)))]
@@ -14,7 +20,7 @@ async def hello_world(scope, receive, send):
     await send({"type": "http.response.body", "body": output})
 
 
-async def echo_path(scope, receive, send):
+async def echo_path(scope: Scope, receive: Receive, send: Send) -> None:
     status = 200
     output = json.dumps({"path": scope["path"]}).encode("utf-8")
     headers = [(b"content-type", "text/plain"), (b"content-length", str(len(output)))]
@@ -23,7 +29,7 @@ async def echo_path(scope, receive, send):
     await send({"type": "http.response.body", "body": output})
 
 
-async def echo_raw_path(scope, receive, send):
+async def echo_raw_path(scope: Scope, receive: Receive, send: Send) -> None:
     status = 200
     output = json.dumps({"raw_path": scope["raw_path"].decode("ascii")}).encode("utf-8")
     headers = [(b"content-type", "text/plain"), (b"content-length", str(len(output)))]
@@ -32,7 +38,7 @@ async def echo_raw_path(scope, receive, send):
     await send({"type": "http.response.body", "body": output})
 
 
-async def echo_body(scope, receive, send):
+async def echo_body(scope: Scope, receive: Receive, send: Send) -> None:
     status = 200
     headers = [(b"content-type", "text/plain")]
 
@@ -45,7 +51,7 @@ async def echo_body(scope, receive, send):
         await send({"type": "http.response.body", "body": body, "more_body": more_body})
 
 
-async def echo_headers(scope, receive, send):
+async def echo_headers(scope: Scope, receive: Receive, send: Send) -> None:
     status = 200
     output = json.dumps({"headers": [[k.decode(), v.decode()] for k, v in scope["headers"]]}).encode("utf-8")
     headers = [(b"content-type", "text/plain"), (b"content-length", str(len(output)))]
@@ -54,11 +60,11 @@ async def echo_headers(scope, receive, send):
     await send({"type": "http.response.body", "body": output})
 
 
-async def raise_exc(scope, receive, send):
+async def raise_exc(scope: Scope, receive: Receive, send: Send) -> None:
     raise RuntimeError()
 
 
-async def raise_exc_after_response(scope, receive, send):
+async def raise_exc_after_response(scope: Scope, receive: Receive, send: Send) -> None:
     status = 200
     output = b"Hello, World!"
     headers = [(b"content-type", "text/plain"), (b"content-length", str(len(output)))]
@@ -69,7 +75,7 @@ async def raise_exc_after_response(scope, receive, send):
 
 
 @pytest.mark.anyio
-async def test_asgi_transport():
+async def test_asgi_transport() -> None:
     async with httpx2.ASGITransport(app=hello_world) as transport:
         request = httpx2.Request("GET", "http://www.example.com/")
         response = await transport.handle_async_request(request)
@@ -79,7 +85,7 @@ async def test_asgi_transport():
 
 
 @pytest.mark.anyio
-async def test_asgi_transport_no_body():
+async def test_asgi_transport_no_body() -> None:
     async with httpx2.ASGITransport(app=echo_body) as transport:
         request = httpx2.Request("GET", "http://www.example.com/")
         response = await transport.handle_async_request(request)
@@ -89,7 +95,7 @@ async def test_asgi_transport_no_body():
 
 
 @pytest.mark.anyio
-async def test_asgi():
+async def test_asgi() -> None:
     transport = httpx2.ASGITransport(app=hello_world)
     async with httpx2.AsyncClient(transport=transport) as client:
         response = await client.get("http://www.example.org/")
@@ -99,7 +105,7 @@ async def test_asgi():
 
 
 @pytest.mark.anyio
-async def test_asgi_urlencoded_path():
+async def test_asgi_urlencoded_path() -> None:
     transport = httpx2.ASGITransport(app=echo_path)
     async with httpx2.AsyncClient(transport=transport) as client:
         url = httpx2.URL("http://www.example.org/").copy_with(path="/user@example.org")
@@ -110,7 +116,7 @@ async def test_asgi_urlencoded_path():
 
 
 @pytest.mark.anyio
-async def test_asgi_raw_path():
+async def test_asgi_raw_path() -> None:
     transport = httpx2.ASGITransport(app=echo_raw_path)
     async with httpx2.AsyncClient(transport=transport) as client:
         url = httpx2.URL("http://www.example.org/").copy_with(path="/user@example.org")
@@ -121,7 +127,7 @@ async def test_asgi_raw_path():
 
 
 @pytest.mark.anyio
-async def test_asgi_raw_path_should_not_include_querystring_portion():
+async def test_asgi_raw_path_should_not_include_querystring_portion() -> None:
     """
     See https://github.com/encode/httpx/issues/2810
     """
@@ -135,7 +141,7 @@ async def test_asgi_raw_path_should_not_include_querystring_portion():
 
 
 @pytest.mark.anyio
-async def test_asgi_upload():
+async def test_asgi_upload() -> None:
     transport = httpx2.ASGITransport(app=echo_body)
     async with httpx2.AsyncClient(transport=transport) as client:
         response = await client.post("http://www.example.org/", content=b"example")
@@ -145,7 +151,7 @@ async def test_asgi_upload():
 
 
 @pytest.mark.anyio
-async def test_asgi_headers():
+async def test_asgi_headers() -> None:
     transport = httpx2.ASGITransport(app=echo_headers)
     async with httpx2.AsyncClient(transport=transport) as client:
         response = await client.get("http://www.example.org/")
@@ -163,7 +169,7 @@ async def test_asgi_headers():
 
 
 @pytest.mark.anyio
-async def test_asgi_exc():
+async def test_asgi_exc() -> None:
     transport = httpx2.ASGITransport(app=raise_exc)
     async with httpx2.AsyncClient(transport=transport) as client:
         with pytest.raises(RuntimeError):
@@ -171,7 +177,7 @@ async def test_asgi_exc():
 
 
 @pytest.mark.anyio
-async def test_asgi_exc_after_response():
+async def test_asgi_exc_after_response() -> None:
     transport = httpx2.ASGITransport(app=raise_exc_after_response)
     async with httpx2.AsyncClient(transport=transport) as client:
         with pytest.raises(RuntimeError):
@@ -179,10 +185,10 @@ async def test_asgi_exc_after_response():
 
 
 @pytest.mark.anyio
-async def test_asgi_disconnect_after_response_complete():
+async def test_asgi_disconnect_after_response_complete() -> None:
     disconnect = False
 
-    async def read_body(scope, receive, send):
+    async def read_body(scope: Scope, receive: Receive, send: Send) -> None:
         nonlocal disconnect
 
         status = 200
@@ -212,7 +218,7 @@ async def test_asgi_disconnect_after_response_complete():
 
 
 @pytest.mark.anyio
-async def test_asgi_exc_no_raise():
+async def test_asgi_exc_no_raise() -> None:
     transport = httpx2.ASGITransport(app=raise_exc, raise_app_exceptions=False)
     async with httpx2.AsyncClient(transport=transport) as client:
         response = await client.get("http://www.example.org/")

--- a/tests/httpx2/test_auth.py
+++ b/tests/httpx2/test_auth.py
@@ -11,7 +11,7 @@ import pytest
 import httpx2
 
 
-def test_basic_auth():
+def test_basic_auth() -> None:
     auth = httpx2.BasicAuth(username="user", password="pass")
     request = httpx2.Request("GET", "https://www.example.com")
 
@@ -26,7 +26,7 @@ def test_basic_auth():
         flow.send(response)
 
 
-def test_digest_auth_with_200():
+def test_digest_auth_with_200() -> None:
     auth = httpx2.DigestAuth(username="user", password="pass")
     request = httpx2.Request("GET", "https://www.example.com")
 
@@ -41,7 +41,7 @@ def test_digest_auth_with_200():
         flow.send(response)
 
 
-def test_digest_auth_with_401():
+def test_digest_auth_with_401() -> None:
     auth = httpx2.DigestAuth(username="user", password="pass")
     request = httpx2.Request("GET", "https://www.example.com")
 
@@ -62,7 +62,7 @@ def test_digest_auth_with_401():
         flow.send(response)
 
 
-def test_digest_auth_with_401_nonce_counting():
+def test_digest_auth_with_401_nonce_counting() -> None:
     auth = httpx2.DigestAuth(username="user", password="pass")
     request = httpx2.Request("GET", "https://www.example.com")
 
@@ -105,7 +105,7 @@ def set_cookies(request: httpx2.Request) -> httpx2.Response:
         raise NotImplementedError()  # pragma: no cover
 
 
-def test_digest_auth_setting_cookie_in_request():
+def test_digest_auth_setting_cookie_in_request() -> None:
     url = "https://www.example.com/auth"
     client = httpx2.Client(transport=httpx2.MockTransport(set_cookies))
     request = client.build_request("GET", url)
@@ -129,7 +129,7 @@ def test_digest_auth_setting_cookie_in_request():
         flow.send(response)
 
 
-def test_digest_auth_rfc_2069():
+def test_digest_auth_rfc_2069() -> None:
     # Example from https://datatracker.ietf.org/doc/html/rfc2069#section-2.4
     # with corrected response from https://www.rfc-editor.org/errata/eid749
 
@@ -165,7 +165,7 @@ def test_digest_auth_rfc_2069():
         flow.send(response)
 
 
-def test_digest_auth_rfc_7616_md5(monkeypatch):
+def test_digest_auth_rfc_7616_md5(monkeypatch: pytest.MonkeyPatch) -> None:
     # Example from https://datatracker.ietf.org/doc/html/rfc7616#section-3.9.1
 
     def mock_get_client_nonce(nonce_count: int, nonce: bytes) -> bytes:
@@ -211,7 +211,7 @@ def test_digest_auth_rfc_7616_md5(monkeypatch):
         flow.send(response)
 
 
-def test_digest_auth_rfc_7616_sha_256(monkeypatch):
+def test_digest_auth_rfc_7616_sha_256(monkeypatch: pytest.MonkeyPatch) -> None:
     # Example from https://datatracker.ietf.org/doc/html/rfc7616#section-3.9.1
 
     def mock_get_client_nonce(nonce_count: int, nonce: bytes) -> bytes:

--- a/tests/httpx2/test_config.py
+++ b/tests/httpx2/test_config.py
@@ -9,7 +9,7 @@ import pytest
 
 import httpx2
 
-if typing.TYPE_CHECKING:  # pragma: no cover
+if typing.TYPE_CHECKING:
     from conftest import TestServer
 
 

--- a/tests/httpx2/test_config.py
+++ b/tests/httpx2/test_config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import ssl
 import typing
 from pathlib import Path
@@ -7,14 +9,17 @@ import pytest
 
 import httpx2
 
+if typing.TYPE_CHECKING:  # pragma: no cover
+    from conftest import TestServer
 
-def test_load_ssl_config():
+
+def test_load_ssl_config() -> None:
     context = httpx2.create_ssl_context()
     assert context.verify_mode == ssl.VerifyMode.CERT_REQUIRED
     assert context.check_hostname is True
 
 
-def test_load_ssl_config_verify_non_existing_file():
+def test_load_ssl_config_verify_non_existing_file() -> None:
     with pytest.raises(IOError):
         context = httpx2.create_ssl_context()
         context.load_verify_locations(cafile="/path/to/nowhere")
@@ -27,21 +32,21 @@ def test_load_ssl_with_keylog(monkeypatch: typing.Any, tmp_path: Path) -> None:
     assert context.keylog_filename == str(keylog_file)
 
 
-def test_load_ssl_config_verify_existing_file():
+def test_load_ssl_config_verify_existing_file() -> None:
     context = httpx2.create_ssl_context()
     context.load_verify_locations(capath=certifi.where())
     assert context.verify_mode == ssl.VerifyMode.CERT_REQUIRED
     assert context.check_hostname is True
 
 
-def test_load_ssl_config_verify_directory():
+def test_load_ssl_config_verify_directory() -> None:
     context = httpx2.create_ssl_context()
     context.load_verify_locations(capath=Path(certifi.where()).parent)
     assert context.verify_mode == ssl.VerifyMode.CERT_REQUIRED
     assert context.check_hostname is True
 
 
-def test_load_ssl_config_cert_and_key(cert_pem_file, cert_private_key_file):
+def test_load_ssl_config_cert_and_key(cert_pem_file: str, cert_private_key_file: str) -> None:
     context = httpx2.create_ssl_context()
     context.load_cert_chain(cert_pem_file, cert_private_key_file)
     assert context.verify_mode == ssl.VerifyMode.CERT_REQUIRED
@@ -49,60 +54,64 @@ def test_load_ssl_config_cert_and_key(cert_pem_file, cert_private_key_file):
 
 
 @pytest.mark.parametrize("password", [b"password", "password"])
-def test_load_ssl_config_cert_and_encrypted_key(cert_pem_file, cert_encrypted_private_key_file, password):
+def test_load_ssl_config_cert_and_encrypted_key(
+    cert_pem_file: str, cert_encrypted_private_key_file: str, password: bytes | str
+) -> None:
     context = httpx2.create_ssl_context()
     context.load_cert_chain(cert_pem_file, cert_encrypted_private_key_file, password)
     assert context.verify_mode == ssl.VerifyMode.CERT_REQUIRED
     assert context.check_hostname is True
 
 
-def test_load_ssl_config_cert_and_key_invalid_password(cert_pem_file, cert_encrypted_private_key_file):
+def test_load_ssl_config_cert_and_key_invalid_password(
+    cert_pem_file: str, cert_encrypted_private_key_file: str
+) -> None:
     with pytest.raises(ssl.SSLError):
         context = httpx2.create_ssl_context()
         context.load_cert_chain(cert_pem_file, cert_encrypted_private_key_file, "password1")
 
 
-def test_load_ssl_config_cert_without_key_raises(cert_pem_file):
+def test_load_ssl_config_cert_without_key_raises(cert_pem_file: str) -> None:
     with pytest.raises(ssl.SSLError):
         context = httpx2.create_ssl_context()
         context.load_cert_chain(cert_pem_file)
 
 
-def test_load_ssl_config_no_verify():
+def test_load_ssl_config_no_verify() -> None:
     context = httpx2.create_ssl_context(verify=False)
     assert context.verify_mode == ssl.VerifyMode.CERT_NONE
     assert context.check_hostname is False
 
 
-def test_SSLContext_with_get_request(server, cert_pem_file):
+def test_SSLContext_with_get_request(server: TestServer, cert_pem_file: str) -> None:
     context = httpx2.create_ssl_context()
     context.load_verify_locations(cert_pem_file)
     response = httpx2.get(server.url, verify=context)
     assert response.status_code == 200
 
 
-def test_limits_repr():
+def test_limits_repr() -> None:
     limits = httpx2.Limits(max_connections=100)
     expected = "Limits(max_connections=100, max_keepalive_connections=None, keepalive_expiry=5.0)"
     assert repr(limits) == expected
 
 
-def test_limits_eq():
+def test_limits_eq() -> None:
     limits = httpx2.Limits(max_connections=100)
     assert limits == httpx2.Limits(max_connections=100)
 
 
-def test_timeout_eq():
+def test_timeout_eq() -> None:
     timeout = httpx2.Timeout(timeout=5.0)
     assert timeout == httpx2.Timeout(timeout=5.0)
 
 
-def test_timeout_all_parameters_set():
+def test_timeout_all_parameters_set() -> None:
     timeout = httpx2.Timeout(connect=5.0, read=5.0, write=5.0, pool=5.0)
     assert timeout == httpx2.Timeout(timeout=5.0)
 
 
-def test_timeout_from_nothing():
+def test_timeout_from_nothing() -> None:
     timeout = httpx2.Timeout(None)
     assert timeout.connect is None
     assert timeout.read is None
@@ -110,42 +119,42 @@ def test_timeout_from_nothing():
     assert timeout.pool is None
 
 
-def test_timeout_from_none():
+def test_timeout_from_none() -> None:
     timeout = httpx2.Timeout(timeout=None)
     assert timeout == httpx2.Timeout(None)
 
 
-def test_timeout_from_one_none_value():
+def test_timeout_from_one_none_value() -> None:
     timeout = httpx2.Timeout(None, read=None)
     assert timeout == httpx2.Timeout(None)
 
 
-def test_timeout_from_one_value():
+def test_timeout_from_one_value() -> None:
     timeout = httpx2.Timeout(None, read=5.0)
     assert timeout == httpx2.Timeout(timeout=(None, 5.0, None, None))
 
 
-def test_timeout_from_one_value_and_default():
+def test_timeout_from_one_value_and_default() -> None:
     timeout = httpx2.Timeout(5.0, pool=60.0)
     assert timeout == httpx2.Timeout(timeout=(5.0, 5.0, 5.0, 60.0))
 
 
-def test_timeout_missing_default():
+def test_timeout_missing_default() -> None:
     with pytest.raises(ValueError):
         httpx2.Timeout(pool=60.0)
 
 
-def test_timeout_from_tuple():
+def test_timeout_from_tuple() -> None:
     timeout = httpx2.Timeout(timeout=(5.0, 5.0, 5.0, 5.0))
     assert timeout == httpx2.Timeout(timeout=5.0)
 
 
-def test_timeout_from_config_instance():
+def test_timeout_from_config_instance() -> None:
     timeout = httpx2.Timeout(timeout=5.0)
     assert httpx2.Timeout(timeout) == httpx2.Timeout(timeout=5.0)
 
 
-def test_timeout_repr():
+def test_timeout_repr() -> None:
     timeout = httpx2.Timeout(timeout=5.0)
     assert repr(timeout) == "Timeout(timeout=5.0)"
 
@@ -153,7 +162,7 @@ def test_timeout_repr():
     assert repr(timeout) == "Timeout(connect=None, read=5.0, write=None, pool=None)"
 
 
-def test_proxy_from_url():
+def test_proxy_from_url() -> None:
     proxy = httpx2.Proxy("https://example.com")
 
     assert str(proxy.url) == "https://example.com"
@@ -162,7 +171,7 @@ def test_proxy_from_url():
     assert repr(proxy) == "Proxy('https://example.com')"
 
 
-def test_proxy_with_auth_from_url():
+def test_proxy_with_auth_from_url() -> None:
     proxy = httpx2.Proxy("https://username:password@example.com")
 
     assert str(proxy.url) == "https://example.com"
@@ -171,6 +180,6 @@ def test_proxy_with_auth_from_url():
     assert repr(proxy) == "Proxy('https://example.com', auth=('username', '********'))"
 
 
-def test_invalid_proxy_scheme():
+def test_invalid_proxy_scheme() -> None:
     with pytest.raises(ValueError):
         httpx2.Proxy("invalid://example.com")

--- a/tests/httpx2/test_content.py
+++ b/tests/httpx2/test_content.py
@@ -10,7 +10,7 @@ url = "https://www.example.com"
 
 
 @pytest.mark.anyio
-async def test_empty_content():
+async def test_empty_content() -> None:
     request = httpx2.Request(method, url)
     assert isinstance(request.stream, httpx2.SyncByteStream)
     assert isinstance(request.stream, httpx2.AsyncByteStream)
@@ -24,7 +24,7 @@ async def test_empty_content():
 
 
 @pytest.mark.anyio
-async def test_bytes_content():
+async def test_bytes_content() -> None:
     request = httpx2.Request(method, url, content=b"Hello, world!")
     assert isinstance(request.stream, typing.Iterable)
     assert isinstance(request.stream, typing.AsyncIterable)
@@ -51,7 +51,7 @@ async def test_bytes_content():
 
 
 @pytest.mark.anyio
-async def test_bytesio_content():
+async def test_bytesio_content() -> None:
     request = httpx2.Request(method, url, content=io.BytesIO(b"Hello, world!"))
     assert isinstance(request.stream, typing.Iterable)
     assert not isinstance(request.stream, typing.AsyncIterable)
@@ -63,7 +63,7 @@ async def test_bytesio_content():
 
 
 @pytest.mark.anyio
-async def test_async_bytesio_content():
+async def test_async_bytesio_content() -> None:
     class AsyncBytesIO:
         def __init__(self, content: bytes) -> None:
             self._idx = 0
@@ -74,7 +74,7 @@ async def test_async_bytesio_content():
             self._idx = self._idx + chunk_size
             return chunk
 
-        async def __aiter__(self):
+        async def __aiter__(self) -> typing.AsyncIterator[bytes]:
             yield self._content  # pragma: no cover
 
     request = httpx2.Request(method, url, content=AsyncBytesIO(b"Hello, world!"))
@@ -91,7 +91,7 @@ async def test_async_bytesio_content():
 
 
 @pytest.mark.anyio
-async def test_iterator_content():
+async def test_iterator_content() -> None:
     def hello_world() -> typing.Iterator[bytes]:
         yield b"Hello, "
         yield b"world!"
@@ -127,7 +127,7 @@ async def test_iterator_content():
 
 
 @pytest.mark.anyio
-async def test_aiterator_content():
+async def test_aiterator_content() -> None:
     async def hello_world() -> typing.AsyncIterator[bytes]:
         yield b"Hello, "
         yield b"world!"
@@ -163,7 +163,7 @@ async def test_aiterator_content():
 
 
 @pytest.mark.anyio
-async def test_json_content():
+async def test_json_content() -> None:
     request = httpx2.Request(method, url, json={"Hello": "world!"})
     assert isinstance(request.stream, typing.Iterable)
     assert isinstance(request.stream, typing.AsyncIterable)
@@ -181,7 +181,7 @@ async def test_json_content():
 
 
 @pytest.mark.anyio
-async def test_urlencoded_content():
+async def test_urlencoded_content() -> None:
     request = httpx2.Request(method, url, data={"Hello": "world!"})
     assert isinstance(request.stream, typing.Iterable)
     assert isinstance(request.stream, typing.AsyncIterable)
@@ -199,7 +199,7 @@ async def test_urlencoded_content():
 
 
 @pytest.mark.anyio
-async def test_urlencoded_boolean():
+async def test_urlencoded_boolean() -> None:
     request = httpx2.Request(method, url, data={"example": True})
     assert isinstance(request.stream, typing.Iterable)
     assert isinstance(request.stream, typing.AsyncIterable)
@@ -217,7 +217,7 @@ async def test_urlencoded_boolean():
 
 
 @pytest.mark.anyio
-async def test_urlencoded_none():
+async def test_urlencoded_none() -> None:
     request = httpx2.Request(method, url, data={"example": None})
     assert isinstance(request.stream, typing.Iterable)
     assert isinstance(request.stream, typing.AsyncIterable)
@@ -235,7 +235,7 @@ async def test_urlencoded_none():
 
 
 @pytest.mark.anyio
-async def test_urlencoded_list():
+async def test_urlencoded_list() -> None:
     request = httpx2.Request(method, url, data={"example": ["a", 1, True]})
     assert isinstance(request.stream, typing.Iterable)
     assert isinstance(request.stream, typing.AsyncIterable)
@@ -253,7 +253,7 @@ async def test_urlencoded_list():
 
 
 @pytest.mark.anyio
-async def test_multipart_files_content():
+async def test_multipart_files_content() -> None:
     files = {"file": io.BytesIO(b"<file content>")}
     headers = {"Content-Type": "multipart/form-data; boundary=+++"}
     request = httpx2.Request(
@@ -296,7 +296,7 @@ async def test_multipart_files_content():
 
 
 @pytest.mark.anyio
-async def test_multipart_data_and_files_content():
+async def test_multipart_data_and_files_content() -> None:
     data = {"message": "Hello, world!"}
     files = {"file": io.BytesIO(b"<file content>")}
     headers = {"Content-Type": "multipart/form-data; boundary=+++"}
@@ -343,7 +343,7 @@ async def test_multipart_data_and_files_content():
 
 
 @pytest.mark.anyio
-async def test_empty_request():
+async def test_empty_request() -> None:
     request = httpx2.Request(method, url, data={}, files={})
     assert isinstance(request.stream, typing.Iterable)
     assert isinstance(request.stream, typing.AsyncIterable)
@@ -356,7 +356,7 @@ async def test_empty_request():
     assert async_content == b""
 
 
-def test_invalid_argument():
+def test_invalid_argument() -> None:
     with pytest.raises(TypeError):
         httpx2.Request(method, url, content=123)  # type: ignore
 
@@ -365,7 +365,7 @@ def test_invalid_argument():
 
 
 @pytest.mark.anyio
-async def test_multipart_multiple_files_single_input_content():
+async def test_multipart_multiple_files_single_input_content() -> None:
     files = [
         ("file", io.BytesIO(b"<file content 1>")),
         ("file", io.BytesIO(b"<file content 2>")),
@@ -416,7 +416,7 @@ async def test_multipart_multiple_files_single_input_content():
 
 
 @pytest.mark.anyio
-async def test_response_empty_content():
+async def test_response_empty_content() -> None:
     response = httpx2.Response(200)
     assert isinstance(response.stream, typing.Iterable)
     assert isinstance(response.stream, typing.AsyncIterable)
@@ -430,7 +430,7 @@ async def test_response_empty_content():
 
 
 @pytest.mark.anyio
-async def test_response_bytes_content():
+async def test_response_bytes_content() -> None:
     response = httpx2.Response(200, content=b"Hello, world!")
     assert isinstance(response.stream, typing.Iterable)
     assert isinstance(response.stream, typing.AsyncIterable)
@@ -444,7 +444,7 @@ async def test_response_bytes_content():
 
 
 @pytest.mark.anyio
-async def test_response_iterator_content():
+async def test_response_iterator_content() -> None:
     def hello_world() -> typing.Iterator[bytes]:
         yield b"Hello, "
         yield b"world!"
@@ -463,7 +463,7 @@ async def test_response_iterator_content():
 
 
 @pytest.mark.anyio
-async def test_response_aiterator_content():
+async def test_response_aiterator_content() -> None:
     async def hello_world() -> typing.AsyncIterator[bytes]:
         yield b"Hello, "
         yield b"world!"
@@ -481,19 +481,19 @@ async def test_response_aiterator_content():
         [part async for part in response.stream]
 
 
-def test_response_invalid_argument():
+def test_response_invalid_argument() -> None:
     with pytest.raises(TypeError):
         httpx2.Response(200, content=123)  # type: ignore
 
 
-def test_ensure_ascii_false_with_french_characters():
+def test_ensure_ascii_false_with_french_characters() -> None:
     data = {"greeting": "Bonjour, ça va ?"}
     response = httpx2.Response(200, json=data)
     assert "ça va" in response.text, "ensure_ascii=False should preserve French accented characters"
     assert response.headers["Content-Type"] == "application/json"
 
 
-def test_separators_for_compact_json():
+def test_separators_for_compact_json() -> None:
     data = {"clé": "valeur", "liste": [1, 2, 3]}
     response = httpx2.Response(200, json=data)
     assert response.text == '{"clé":"valeur","liste":[1,2,3]}', (
@@ -502,7 +502,7 @@ def test_separators_for_compact_json():
     assert response.headers["Content-Type"] == "application/json"
 
 
-def test_allow_nan_false():
+def test_allow_nan_false() -> None:
     data_with_nan = {"nombre": float("nan")}
     data_with_inf = {"nombre": float("inf")}
 

--- a/tests/httpx2/test_decoders.py
+++ b/tests/httpx2/test_decoders.py
@@ -16,7 +16,7 @@ else:  # pragma: no cover
     import zstandard as zstd
 
 
-def test_deflate():
+def test_deflate() -> None:
     """
     Deflate encoding may use either 'zlib' or 'deflate' in the wild.
 
@@ -35,7 +35,7 @@ def test_deflate():
     assert response.content == body
 
 
-def test_zlib():
+def test_zlib() -> None:
     """
     Deflate encoding may use either 'zlib' or 'deflate' in the wild.
 
@@ -53,7 +53,7 @@ def test_zlib():
     assert response.content == body
 
 
-def test_gzip():
+def test_gzip() -> None:
     body = b"test 123"
     compressor = zlib.compressobj(9, zlib.DEFLATED, zlib.MAX_WBITS | 16)
     compressed_body = compressor.compress(body) + compressor.flush()
@@ -67,7 +67,7 @@ def test_gzip():
     assert response.content == body
 
 
-def test_brotli():
+def test_brotli() -> None:
     body = b"test 123"
     compressed_body = b"\x8b\x03\x80test 123\x03"
 
@@ -80,7 +80,7 @@ def test_brotli():
     assert response.content == body
 
 
-def test_zstd():
+def test_zstd() -> None:
     body = b"test 123"
     compressed_body = zstd.compress(body)
 
@@ -93,7 +93,7 @@ def test_zstd():
     assert response.content == body
 
 
-def test_zstd_decoding_error():
+def test_zstd_decoding_error() -> None:
     compressed_body = "this_is_not_zstd_compressed_data"
 
     headers = [(b"Content-Encoding", b"zstd")]
@@ -105,13 +105,13 @@ def test_zstd_decoding_error():
         )
 
 
-def test_zstd_empty():
+def test_zstd_empty() -> None:
     headers = [(b"Content-Encoding", b"zstd")]
     response = httpx2.Response(200, headers=headers, content=b"")
     assert response.content == b""
 
 
-def test_zstd_truncated():
+def test_zstd_truncated() -> None:
     body = b"test 123"
     compressed_body = zstd.compress(body)
 
@@ -124,7 +124,7 @@ def test_zstd_truncated():
         )
 
 
-def test_zstd_multiframe():
+def test_zstd_multiframe() -> None:
     # test inspired by urllib3 test suite
     data = (
         # Zstandard frame
@@ -146,7 +146,7 @@ def test_zstd_multiframe():
     assert response.content == b"foobar"
 
 
-def test_zstd_streaming_multiple_frames():
+def test_zstd_streaming_multiple_frames() -> None:
     body1 = b"test 123 "
     body2 = b"another frame"
 
@@ -166,7 +166,7 @@ def test_zstd_streaming_multiple_frames():
     assert response.content == body1 + body2
 
 
-def test_zstd_empty_decode_after_eof():
+def test_zstd_empty_decode_after_eof() -> None:
     # An empty `decode(b"")` after a complete frame must not raise EOFError on
     # stdlib `compression.zstd`. This path is reached via `MultiDecoder.flush()`,
     # which feeds b"" through each child to drain residue across stacked encodings.
@@ -178,7 +178,7 @@ def test_zstd_empty_decode_after_eof():
     assert response.content == body
 
 
-def test_multi():
+def test_multi() -> None:
     body = b"test 123"
 
     deflate_compressor = zlib.compressobj(9, zlib.DEFLATED, -zlib.MAX_WBITS)
@@ -196,7 +196,7 @@ def test_multi():
     assert response.content == body
 
 
-def test_multi_with_identity():
+def test_multi_with_identity() -> None:
     body = b"test 123"
     compressed_body = b"\x8b\x03\x80test 123\x03"
 
@@ -218,7 +218,7 @@ def test_multi_with_identity():
 
 
 @pytest.mark.anyio
-async def test_streaming():
+async def test_streaming() -> None:
     body = b"test 123"
     compressor = zlib.compressobj(9, zlib.DEFLATED, zlib.MAX_WBITS | 16)
 
@@ -237,7 +237,7 @@ async def test_streaming():
 
 
 @pytest.mark.parametrize("header_value", (b"deflate", b"gzip", b"br", b"identity"))
-def test_empty_content(header_value):
+def test_empty_content(header_value: bytes) -> None:
     headers = [(b"Content-Encoding", header_value)]
     response = httpx2.Response(
         200,
@@ -248,14 +248,14 @@ def test_empty_content(header_value):
 
 
 @pytest.mark.parametrize("header_value", (b"deflate", b"gzip", b"br", b"identity"))
-def test_decoders_empty_cases(header_value):
+def test_decoders_empty_cases(header_value: bytes) -> None:
     headers = [(b"Content-Encoding", header_value)]
     response = httpx2.Response(content=b"", status_code=200, headers=headers)
     assert response.read() == b""
 
 
 @pytest.mark.parametrize("header_value", (b"deflate", b"gzip", b"br"))
-def test_decoding_errors(header_value):
+def test_decoding_errors(header_value: bytes) -> None:
     headers = [(b"Content-Encoding", header_value)]
     compressed_body = b"invalid"
     with pytest.raises(httpx2.DecodingError):
@@ -276,13 +276,13 @@ def test_decoding_errors(header_value):
     ],
 )
 @pytest.mark.anyio
-async def test_text_decoder_with_autodetect(data, encoding):
+async def test_text_decoder_with_autodetect(data: tuple[bytes, ...], encoding: str) -> None:
     async def iterator() -> typing.AsyncIterator[bytes]:
         nonlocal data
         for chunk in data:
             yield chunk
 
-    def autodetect(content):
+    def autodetect(content: bytes) -> str | None:
         return chardet.detect(content).get("encoding")
 
     # Accessing `.text` on a read response.
@@ -299,7 +299,7 @@ async def test_text_decoder_with_autodetect(data, encoding):
 
 
 @pytest.mark.anyio
-async def test_text_decoder_known_encoding():
+async def test_text_decoder_known_encoding() -> None:
     async def iterator() -> typing.AsyncIterator[bytes]:
         yield b"\x83g"
         yield b"\x83"
@@ -315,7 +315,7 @@ async def test_text_decoder_known_encoding():
     assert "".join(response.text) == "トラベル"
 
 
-def test_text_decoder_empty_cases():
+def test_text_decoder_empty_cases() -> None:
     response = httpx2.Response(200, content=b"")
     assert response.text == ""
 
@@ -333,7 +333,7 @@ def test_streaming_text_decoder(data: typing.Iterable[bytes], expected: list[str
     assert list(response.iter_text()) == expected
 
 
-def test_line_decoder_nl():
+def test_line_decoder_nl() -> None:
     response = httpx2.Response(200, content=[b""])
     assert list(response.iter_lines()) == []
 
@@ -345,7 +345,7 @@ def test_line_decoder_nl():
     assert list(response.iter_lines()) == ["12345", "foo bar baz"]
 
 
-def test_line_decoder_cr():
+def test_line_decoder_cr() -> None:
     response = httpx2.Response(200, content=[b"", b"a\r\rb\rc"])
     assert list(response.iter_lines()) == ["a", "", "b", "c"]
 
@@ -357,7 +357,7 @@ def test_line_decoder_cr():
     assert list(response.iter_lines()) == ["12345", "foo bar baz"]
 
 
-def test_line_decoder_crnl():
+def test_line_decoder_crnl() -> None:
     response = httpx2.Response(200, content=[b"", b"a\r\n\r\nb\r\nc"])
     assert list(response.iter_lines()) == ["a", "", "b", "c"]
 
@@ -372,7 +372,7 @@ def test_line_decoder_crnl():
     assert list(response.iter_lines()) == ["12345", "foo bar baz"]
 
 
-def test_invalid_content_encoding_header():
+def test_invalid_content_encoding_header() -> None:
     headers = [(b"Content-Encoding", b"invalid-header")]
     body = b"test 123"
 

--- a/tests/httpx2/test_exceptions.py
+++ b/tests/httpx2/test_exceptions.py
@@ -7,7 +7,7 @@ import pytest
 import httpcore2
 import httpx2
 
-if typing.TYPE_CHECKING:  # pragma: no cover
+if typing.TYPE_CHECKING:
     from conftest import TestServer
 
 

--- a/tests/httpx2/test_main.py
+++ b/tests/httpx2/test_main.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import typing
 
@@ -5,6 +7,9 @@ from click.testing import CliRunner
 
 import httpx2
 from httpx2._main import main
+
+if typing.TYPE_CHECKING:  # pragma: no cover
+    from conftest import TestServer
 
 
 def splitlines(output: str) -> typing.Iterable[str]:
@@ -15,14 +20,14 @@ def remove_date_header(lines: typing.Iterable[str]) -> typing.Iterable[str]:
     return [line for line in lines if not line.startswith("date:")]
 
 
-def test_help():
+def test_help() -> None:
     runner = CliRunner()
     result = runner.invoke(main, ["--help"])
     assert result.exit_code == 0
     assert "A next generation HTTP client." in result.output
 
 
-def test_get(server):
+def test_get(server: TestServer) -> None:
     url = str(server.url)
     runner = CliRunner()
     result = runner.invoke(main, [url])
@@ -37,7 +42,7 @@ def test_get(server):
     ]
 
 
-def test_json(server):
+def test_json(server: TestServer) -> None:
     url = str(server.url.copy_with(path="/json"))
     runner = CliRunner()
     result = runner.invoke(main, [url])
@@ -54,7 +59,7 @@ def test_json(server):
     ]
 
 
-def test_binary(server):
+def test_binary(server: TestServer) -> None:
     url = str(server.url.copy_with(path="/echo_binary"))
     runner = CliRunner()
     content = "Hello, world!"
@@ -70,7 +75,7 @@ def test_binary(server):
     ]
 
 
-def test_redirects(server):
+def test_redirects(server: TestServer) -> None:
     url = str(server.url.copy_with(path="/redirect_301"))
     runner = CliRunner()
     result = runner.invoke(main, [url])
@@ -84,7 +89,7 @@ def test_redirects(server):
     ]
 
 
-def test_follow_redirects(server):
+def test_follow_redirects(server: TestServer) -> None:
     url = str(server.url.copy_with(path="/redirect_301"))
     runner = CliRunner()
     result = runner.invoke(main, [url, "--follow-redirects"])
@@ -104,7 +109,7 @@ def test_follow_redirects(server):
     ]
 
 
-def test_post(server):
+def test_post(server: TestServer) -> None:
     url = str(server.url.copy_with(path="/echo_body"))
     runner = CliRunner()
     result = runner.invoke(main, [url, "-m", "POST", "-j", '{"hello": "world"}'])
@@ -119,7 +124,7 @@ def test_post(server):
     ]
 
 
-def test_verbose(server):
+def test_verbose(server: TestServer) -> None:
     url = str(server.url)
     runner = CliRunner()
     result = runner.invoke(main, [url, "-v"])
@@ -143,7 +148,7 @@ def test_verbose(server):
     ]
 
 
-def test_auth(server):
+def test_auth(server: TestServer) -> None:
     url = str(server.url)
     runner = CliRunner()
     result = runner.invoke(main, [url, "-v", "--auth", "username", "password"])
@@ -169,7 +174,7 @@ def test_auth(server):
     ]
 
 
-def test_download(server):
+def test_download(server: TestServer) -> None:
     url = str(server.url)
     runner = CliRunner()
     with runner.isolated_filesystem():
@@ -179,7 +184,7 @@ def test_download(server):
             assert input_file.read() == "Hello, world!"
 
 
-def test_errors():
+def test_errors() -> None:
     runner = CliRunner()
     result = runner.invoke(main, ["invalid://example.org"])
     assert result.exit_code == 1

--- a/tests/httpx2/test_main.py
+++ b/tests/httpx2/test_main.py
@@ -8,7 +8,7 @@ from click.testing import CliRunner
 import httpx2
 from httpx2._main import main
 
-if typing.TYPE_CHECKING:  # pragma: no cover
+if typing.TYPE_CHECKING:
     from conftest import TestServer
 
 

--- a/tests/httpx2/test_multipart.py
+++ b/tests/httpx2/test_multipart.py
@@ -14,7 +14,7 @@ def echo_request_content(request: httpx2.Request) -> httpx2.Response:
 
 
 @pytest.mark.parametrize(("value,output"), (("abc", b"abc"), (b"abc", b"abc")))
-def test_multipart(value, output):
+def test_multipart(value: str | bytes, output: bytes) -> None:
     client = httpx2.Client(transport=httpx2.MockTransport(echo_request_content))
 
     # Test with a single-value 'data' argument, and a plain file 'files' argument.
@@ -95,7 +95,7 @@ def test_multipart_header_without_boundary(header: str) -> None:
 
 
 @pytest.mark.parametrize(("key"), (b"abc", 1, 2.3, None))
-def test_multipart_invalid_key(key):
+def test_multipart_invalid_key(key: typing.Any) -> None:
     client = httpx2.Client(transport=httpx2.MockTransport(echo_request_content))
 
     data = {key: "abc"}
@@ -111,7 +111,7 @@ def test_multipart_invalid_key(key):
 
 
 @pytest.mark.parametrize(("value"), (object(), {"key": "value"}))
-def test_multipart_invalid_value(value):
+def test_multipart_invalid_value(value: typing.Any) -> None:
     client = httpx2.Client(transport=httpx2.MockTransport(echo_request_content))
 
     data = {"text": value}
@@ -121,7 +121,7 @@ def test_multipart_invalid_value(value):
     assert "Invalid type for value" in str(e.value)
 
 
-def test_multipart_file_tuple():
+def test_multipart_file_tuple() -> None:
     client = httpx2.Client(transport=httpx2.MockTransport(echo_request_content))
 
     # Test with a list of values 'data' argument,
@@ -418,7 +418,7 @@ def test_multipart_encode_non_seekable_filelike() -> None:
     )
 
 
-def test_multipart_rewinds_files():
+def test_multipart_rewinds_files() -> None:
     with tempfile.TemporaryFile() as upload:
         upload.write(b"Hello, world!")
 
@@ -438,28 +438,28 @@ def test_multipart_rewinds_files():
 
 
 class TestHeaderParamHTML5Formatting:
-    def test_unicode(self):
+    def test_unicode(self) -> None:
         filename = "n\u00e4me"
         expected = b'filename="n\xc3\xa4me"'
         files = {"upload": (filename, b"<file content>")}
         request = httpx2.Request("GET", "https://www.example.com", files=files)
         assert expected in request.read()
 
-    def test_ascii(self):
+    def test_ascii(self) -> None:
         filename = "name"
         expected = b'filename="name"'
         files = {"upload": (filename, b"<file content>")}
         request = httpx2.Request("GET", "https://www.example.com", files=files)
         assert expected in request.read()
 
-    def test_unicode_escape(self):
+    def test_unicode_escape(self) -> None:
         filename = "hello\\world\u0022"
         expected = b'filename="hello\\\\world%22"'
         files = {"upload": (filename, b"<file content>")}
         request = httpx2.Request("GET", "https://www.example.com", files=files)
         assert expected in request.read()
 
-    def test_unicode_with_control_character(self):
+    def test_unicode_with_control_character(self) -> None:
         filename = "hello\x1a\x1b\x1c"
         expected = b'filename="hello%1A\x1b%1C"'
         files = {"upload": (filename, b"<file content>")}

--- a/tests/httpx2/test_status_codes.py
+++ b/tests/httpx2/test_status_codes.py
@@ -1,27 +1,27 @@
 import httpx2
 
 
-def test_status_code_as_int():
+def test_status_code_as_int() -> None:
     # mypy doesn't (yet) recognize that IntEnum members are ints, so ignore it here
     assert httpx2.codes.NOT_FOUND == 404  # type: ignore[comparison-overlap]
     assert str(httpx2.codes.NOT_FOUND) == "404"
 
 
-def test_status_code_value_lookup():
+def test_status_code_value_lookup() -> None:
     assert httpx2.codes(404) == 404
 
 
-def test_status_code_phrase_lookup():
+def test_status_code_phrase_lookup() -> None:
     assert httpx2.codes["NOT_FOUND"] == 404
 
 
-def test_lowercase_status_code():
+def test_lowercase_status_code() -> None:
     assert httpx2.codes.not_found == 404  # type: ignore
 
 
-def test_reason_phrase_for_status_code():
+def test_reason_phrase_for_status_code() -> None:
     assert httpx2.codes.get_reason_phrase(404) == "Not Found"
 
 
-def test_reason_phrase_for_unknown_status_code():
+def test_reason_phrase_for_unknown_status_code() -> None:
     assert httpx2.codes.get_reason_phrase(499) == ""

--- a/tests/httpx2/test_timeouts.py
+++ b/tests/httpx2/test_timeouts.py
@@ -1,10 +1,17 @@
+from __future__ import annotations
+
+import typing
+
 import pytest
 
 import httpx2
 
+if typing.TYPE_CHECKING:  # pragma: no cover
+    from conftest import TestServer
+
 
 @pytest.mark.anyio
-async def test_read_timeout(server):
+async def test_read_timeout(server: TestServer) -> None:
     timeout = httpx2.Timeout(None, read=1e-6)
 
     async with httpx2.AsyncClient(timeout=timeout) as client:
@@ -13,7 +20,7 @@ async def test_read_timeout(server):
 
 
 @pytest.mark.anyio
-async def test_write_timeout(server):
+async def test_write_timeout(server: TestServer) -> None:
     timeout = httpx2.Timeout(None, write=1e-6)
 
     async with httpx2.AsyncClient(timeout=timeout) as client:
@@ -24,7 +31,7 @@ async def test_write_timeout(server):
 
 @pytest.mark.anyio
 @pytest.mark.network
-async def test_connect_timeout(server):
+async def test_connect_timeout(server: TestServer) -> None:
     timeout = httpx2.Timeout(None, connect=1e-6)
 
     async with httpx2.AsyncClient(timeout=timeout) as client:
@@ -34,7 +41,7 @@ async def test_connect_timeout(server):
 
 
 @pytest.mark.anyio
-async def test_pool_timeout(server):
+async def test_pool_timeout(server: TestServer) -> None:
     limits = httpx2.Limits(max_connections=1)
     timeout = httpx2.Timeout(None, pool=1e-4)
 
@@ -45,7 +52,7 @@ async def test_pool_timeout(server):
 
 
 @pytest.mark.anyio
-async def test_async_client_new_request_send_timeout(server):
+async def test_async_client_new_request_send_timeout(server: TestServer) -> None:
     timeout = httpx2.Timeout(1e-6)
 
     async with httpx2.AsyncClient(timeout=timeout) as client:

--- a/tests/httpx2/test_timeouts.py
+++ b/tests/httpx2/test_timeouts.py
@@ -6,7 +6,7 @@ import pytest
 
 import httpx2
 
-if typing.TYPE_CHECKING:  # pragma: no cover
+if typing.TYPE_CHECKING:
     from conftest import TestServer
 
 

--- a/tests/httpx2/test_utils.py
+++ b/tests/httpx2/test_utils.py
@@ -1,12 +1,18 @@
+from __future__ import annotations
+
 import json
 import logging
 import os
 import random
+import typing
 
 import pytest
 
 import httpx2
 from httpx2._utils import URLPattern, get_environment_proxies
+
+if typing.TYPE_CHECKING:  # pragma: no cover
+    from conftest import TestServer
 
 
 @pytest.mark.parametrize(
@@ -22,13 +28,13 @@ from httpx2._utils import URLPattern, get_environment_proxies
         "utf-32-le",
     ),
 )
-def test_encoded(encoding):
+def test_encoded(encoding: str) -> None:
     content = '{"abc": 123}'.encode(encoding)
     response = httpx2.Response(200, content=content)
     assert response.json() == {"abc": 123}
 
 
-def test_bad_utf_like_encoding():
+def test_bad_utf_like_encoding() -> None:
     content = b"\x00\x00\x00\x00"
     response = httpx2.Response(200, content=content)
     with pytest.raises(json.decoder.JSONDecodeError):
@@ -44,13 +50,13 @@ def test_bad_utf_like_encoding():
         ("utf-32-le", "utf-32"),
     ),
 )
-def test_guess_by_bom(encoding, expected):
+def test_guess_by_bom(encoding: str, expected: str) -> None:
     content = '\ufeff{"abc": 123}'.encode(encoding)
     response = httpx2.Response(200, content=content)
     assert response.json() == {"abc": 123}
 
 
-def test_logging_request(server, caplog):
+def test_logging_request(server: TestServer, caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.INFO)
     with httpx2.Client() as client:
         response = client.get(server.url)
@@ -65,7 +71,7 @@ def test_logging_request(server, caplog):
     ]
 
 
-def test_logging_redirect_chain(server, caplog):
+def test_logging_redirect_chain(server: TestServer, caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.INFO)
     with httpx2.Client(follow_redirects=True) as client:
         response = client.get(server.url.copy_with(path="/redirect_301"))
@@ -105,7 +111,7 @@ def test_logging_redirect_chain(server, caplog):
         ({"no_proxy": "http://github.com"}, {"http://github.com": None}),
     ],
 )
-def test_get_environment_proxies(environment, proxies):
+def test_get_environment_proxies(environment: dict[str, str], proxies: dict[str, str | None]) -> None:
     os.environ.update(environment)
 
     assert get_environment_proxies() == proxies
@@ -128,12 +134,12 @@ def test_get_environment_proxies(environment, proxies):
         ("", "https://example.com:123", True),
     ],
 )
-def test_url_matches(pattern, url, expected):
-    pattern = URLPattern(pattern)
-    assert pattern.matches(httpx2.URL(url)) == expected
+def test_url_matches(pattern: str, url: str, expected: bool) -> None:
+    url_pattern = URLPattern(pattern)
+    assert url_pattern.matches(httpx2.URL(url)) == expected
 
 
-def test_pattern_priority():
+def test_pattern_priority() -> None:
     matchers = [
         URLPattern("all://"),
         URLPattern("http://"),

--- a/tests/httpx2/test_utils.py
+++ b/tests/httpx2/test_utils.py
@@ -11,7 +11,7 @@ import pytest
 import httpx2
 from httpx2._utils import URLPattern, get_environment_proxies
 
-if typing.TYPE_CHECKING:  # pragma: no cover
+if typing.TYPE_CHECKING:
     from conftest import TestServer
 
 

--- a/tests/httpx2/test_wsgi.py
+++ b/tests/httpx2/test_wsgi.py
@@ -10,7 +10,7 @@ import pytest
 
 import httpx2
 
-if typing.TYPE_CHECKING:  # pragma: no cover
+if typing.TYPE_CHECKING:
     from _typeshed.wsgi import StartResponse, WSGIApplication, WSGIEnvironment
 
 

--- a/tests/httpx2/test_wsgi.py
+++ b/tests/httpx2/test_wsgi.py
@@ -15,7 +15,7 @@ if typing.TYPE_CHECKING:  # pragma: no cover
 
 
 def application_factory(output: typing.Iterable[bytes]) -> WSGIApplication:
-    def application(environ, start_response):
+    def application(environ: WSGIEnvironment, start_response: StartResponse) -> typing.Iterator[bytes]:
         status = "200 OK"
 
         response_headers = [
@@ -81,13 +81,13 @@ def raise_exc(
     return [output]
 
 
-def log_to_wsgi_log_buffer(environ, start_response):
+def log_to_wsgi_log_buffer(environ: WSGIEnvironment, start_response: StartResponse) -> typing.Iterable[bytes]:
     print("test1", file=environ["wsgi.errors"])
     environ["wsgi.errors"].write("test2")
     return echo_body(environ, start_response)
 
 
-def test_wsgi():
+def test_wsgi() -> None:
     transport = httpx2.WSGITransport(app=application_factory([b"Hello, World!"]))
     client = httpx2.Client(transport=transport)
     response = client.get("http://www.example.org/")
@@ -95,7 +95,7 @@ def test_wsgi():
     assert response.text == "Hello, World!"
 
 
-def test_wsgi_upload():
+def test_wsgi_upload() -> None:
     transport = httpx2.WSGITransport(app=echo_body)
     client = httpx2.Client(transport=transport)
     response = client.post("http://www.example.org/", content=b"example")
@@ -103,7 +103,7 @@ def test_wsgi_upload():
     assert response.text == "example"
 
 
-def test_wsgi_upload_with_response_stream():
+def test_wsgi_upload_with_response_stream() -> None:
     transport = httpx2.WSGITransport(app=echo_body_with_response_stream)
     client = httpx2.Client(transport=transport)
     response = client.post("http://www.example.org/", content=b"example")
@@ -111,21 +111,21 @@ def test_wsgi_upload_with_response_stream():
     assert response.text == "example"
 
 
-def test_wsgi_exc():
+def test_wsgi_exc() -> None:
     transport = httpx2.WSGITransport(app=raise_exc)
     client = httpx2.Client(transport=transport)
     with pytest.raises(ValueError):
         client.get("http://www.example.org/")
 
 
-def test_wsgi_http_error():
+def test_wsgi_http_error() -> None:
     transport = httpx2.WSGITransport(app=partial(raise_exc, exc=RuntimeError))
     client = httpx2.Client(transport=transport)
     with pytest.raises(RuntimeError):
         client.get("http://www.example.org/")
 
 
-def test_wsgi_generator():
+def test_wsgi_generator() -> None:
     output = [b"", b"", b"Some content", b" and more content"]
     transport = httpx2.WSGITransport(app=application_factory(output))
     client = httpx2.Client(transport=transport)
@@ -134,7 +134,7 @@ def test_wsgi_generator():
     assert response.text == "Some content and more content"
 
 
-def test_wsgi_generator_empty():
+def test_wsgi_generator_empty() -> None:
     output = [b"", b"", b"", b""]
     transport = httpx2.WSGITransport(app=application_factory(output))
     client = httpx2.Client(transport=transport)
@@ -143,7 +143,7 @@ def test_wsgi_generator_empty():
     assert response.text == ""
 
 
-def test_logging():
+def test_logging() -> None:
     buffer = StringIO()
     transport = httpx2.WSGITransport(app=log_to_wsgi_log_buffer, wsgi_errors=buffer)
     client = httpx2.Client(transport=transport)
@@ -168,7 +168,7 @@ def test_wsgi_server_port(url: str, expected_server_port: str) -> None:
     hello_world_app = application_factory([b"Hello, World!"])
     server_port: str | None = None
 
-    def app(environ, start_response):
+    def app(environ: WSGIEnvironment, start_response: StartResponse) -> typing.Iterable[bytes]:
         nonlocal server_port
         server_port = environ["SERVER_PORT"]
         return hello_world_app(environ, start_response)
@@ -181,10 +181,10 @@ def test_wsgi_server_port(url: str, expected_server_port: str) -> None:
     assert server_port == expected_server_port
 
 
-def test_wsgi_server_protocol():
+def test_wsgi_server_protocol() -> None:
     server_protocol = None
 
-    def app(environ, start_response):
+    def app(environ: WSGIEnvironment, start_response: StartResponse) -> typing.Iterable[bytes]:
         nonlocal server_protocol
         server_protocol = environ["SERVER_PROTOCOL"]
         start_response("200 OK", [("Content-Type", "text/plain")])


### PR DESCRIPTION
Removes the last `disallow_untyped_defs = false` mypy override (`tests.httpx2.*`), so the entire test suite is now held to strict typing alongside the source. Annotates the 535 functions this flagged: ~388 just needed `-> None`, ~147 needed parameter types (fixtures, ASGI/WSGI scope/receive/send handlers, parametrized values, event-hook dicts).

The transport subclasses in the context-manager tests gained an explicit `return self` in `__enter__`/`__aenter__` to satisfy the base `-> Self` contract; behavior is unchanged (the tests don't bind the `as` target).

mypy, ruff check/format, the unasync `--check`, and the affected test files all pass.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.