### PR TITLE
Exclude `TYPE_CHECKING` blocks via coverage `exclude_also`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,3 +86,11 @@ markers = [
 [tool.coverage.run]
 source_pkgs = ["httpx2", "httpcore2", "tests"]
 omit = ["src/httpcore2/httpcore2/_sync/*", "tests/test_benchmark.py"]
+
+[tool.coverage.report]
+exclude_also = [
+  "if TYPE_CHECKING:",
+  "if typing.TYPE_CHECKING:",
+  "raise NotImplementedError",
+  "@(typing\\.)?overload",
+]

--- a/src/httpx2/httpx2/_auth.py
+++ b/src/httpx2/httpx2/_auth.py
@@ -12,7 +12,7 @@ from ._exceptions import ProtocolError
 from ._models import Cookies, Request, Response
 from ._utils import to_bytes, to_str, unquote
 
-if typing.TYPE_CHECKING:  # pragma: no cover
+if typing.TYPE_CHECKING:
     from hashlib import _Hash
 
 

--- a/src/httpx2/httpx2/_transports/asgi.py
+++ b/src/httpx2/httpx2/_transports/asgi.py
@@ -6,7 +6,7 @@ from .._models import Request, Response
 from .._types import AsyncByteStream
 from .base import AsyncBaseTransport
 
-if typing.TYPE_CHECKING:  # pragma: no cover
+if typing.TYPE_CHECKING:
     import asyncio
 
     import trio

--- a/src/httpx2/httpx2/_types.py
+++ b/src/httpx2/httpx2/_types.py
@@ -21,7 +21,7 @@ from typing import (
     Union,
 )
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from ._auth import Auth  # noqa: F401
     from ._config import Proxy, Timeout  # noqa: F401
     from ._models import Cookies, Headers, Request  # noqa: F401

--- a/src/httpx2/httpx2/_utils.py
+++ b/src/httpx2/httpx2/_utils.py
@@ -8,7 +8,7 @@ from urllib.request import getproxies
 
 from ._types import PrimitiveData
 
-if typing.TYPE_CHECKING:  # pragma: no cover
+if typing.TYPE_CHECKING:
     from ._urls import URL
 
 


### PR DESCRIPTION
Adds a `[tool.coverage.report]` `exclude_also` for `if TYPE_CHECKING:`, `raise NotImplementedError`, and `@overload`, so these are excluded from coverage uniformly across the codebase rather than relying on a `# pragma: no cover` on individual `TYPE_CHECKING` blocks. Only 4 of the 12 `TYPE_CHECKING` blocks carried the pragma before; the four manual pragmas are now removed.

Coverage stays at 100% and the full suite passes.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.