### PR TITLE
tests: select available TCP port

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -67,10 +67,6 @@ To run the tests, use:
 $ scripts/test
 ```
 
-!!! warning
-    The test suite spawns testing servers on ports **8000** and **8001**.
-    Make sure these are not in use, so the tests can run properly.
-
 You can run a single test script like this:
 
 ```shell

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -67,10 +67,6 @@ To run the tests, use:
 $ scripts/test
 ```
 
-!!! warning
-    The test suite spawns testing servers on ports **8000** and **8001**.
-    Make sure these are not in use, so the tests can run properly.
-
 Any additional arguments will be passed to `pytest`. See the [pytest documentation](https://docs.pytest.org/en/latest/how-to/usage.html) for more information.
 
 For example, to run a single test script:

--- a/tests/httpx2/conftest.py
+++ b/tests/httpx2/conftest.py
@@ -273,7 +273,7 @@ def serve_in_thread(server: TestServer) -> typing.Iterator[TestServer]:
 
 
 @pytest.fixture(scope="session")
-def server() -> typing.Iterator[TestServer]:
-    config = Config(app=app, lifespan="off", loop="asyncio")
+def server(free_tcp_port_factory: typing.Callable[[], int]) -> typing.Iterator[TestServer]:
+    config = Config(app=app, lifespan="off", loop="asyncio", port=free_tcp_port_factory())
     server = TestServer(config=config)
     yield from serve_in_thread(server)

--- a/tests/httpx2/test_main.py
+++ b/tests/httpx2/test_main.py
@@ -131,7 +131,7 @@ def test_verbose(server: TestServer) -> None:
     assert result.exit_code == 0
     assert remove_date_header(splitlines(result.output)) == [
         "* Connecting to '127.0.0.1'",
-        "* Connected to '127.0.0.1' on port 8000",
+        f"* Connected to '127.0.0.1' on port {server.url.port}",
         "GET / HTTP/1.1",
         f"Host: {server.url.netloc.decode('ascii')}",
         "Accept: */*",
@@ -156,7 +156,7 @@ def test_auth(server: TestServer) -> None:
     assert result.exit_code == 0
     assert remove_date_header(splitlines(result.output)) == [
         "* Connecting to '127.0.0.1'",
-        "* Connected to '127.0.0.1' on port 8000",
+        f"* Connected to '127.0.0.1' on port {server.url.port}",
         "GET / HTTP/1.1",
         f"Host: {server.url.netloc.decode('ascii')}",
         "Accept: */*",

--- a/tests/httpx2/test_utils.py
+++ b/tests/httpx2/test_utils.py
@@ -66,27 +66,28 @@ def test_logging_request(server: TestServer, caplog: pytest.LogCaptureFixture) -
         (
             "httpx2",
             logging.INFO,
-            'HTTP Request: GET http://127.0.0.1:8000/ "HTTP/1.1 200 OK"',
+            f'HTTP Request: GET {server.url} "HTTP/1.1 200 OK"',
         )
     ]
 
 
 def test_logging_redirect_chain(server: TestServer, caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.INFO)
+    redirect_url = server.url.copy_with(path="/redirect_301")
     with httpx2.Client(follow_redirects=True) as client:
-        response = client.get(server.url.copy_with(path="/redirect_301"))
+        response = client.get(redirect_url)
         assert response.status_code == 200
 
     assert caplog.record_tuples == [
         (
             "httpx2",
             logging.INFO,
-            'HTTP Request: GET http://127.0.0.1:8000/redirect_301 "HTTP/1.1 301 Moved Permanently"',
+            f'HTTP Request: GET {redirect_url} "HTTP/1.1 301 Moved Permanently"',
         ),
         (
             "httpx2",
             logging.INFO,
-            'HTTP Request: GET http://127.0.0.1:8000/ "HTTP/1.1 200 OK"',
+            f'HTTP Request: GET {server.url} "HTTP/1.1 200 OK"',
         ),
     ]
 


### PR DESCRIPTION
# Summary
If TCP port 8000 is in use on the developers' machine, the tests hang. It is mentioned in the CONTRIBUTING.md but it is not great developer experience.

Let's instead select a random free port by specifying port=0 in uvicorn.

Fixes https://github.com/pydantic/httpx2/issues/681

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
