### PR TITLE
Point `httpcore2` project.urls at this repository

### DIFF
--- a/src/httpcore2/pyproject.toml
+++ b/src/httpcore2/pyproject.toml
@@ -52,7 +52,7 @@ asyncio = ["anyio>=4.5.0,<5.0"]
 [project.urls]
 Changelog = "https://github.com/pydantic/httpx2/blob/main/src/httpcore2/CHANGELOG.md"
 Homepage = "https://github.com/pydantic/httpx2"
-Source = "https://github.com/pydantic/httpx2"
+Source = "https://github.com/pydantic/httpx2/blob/main/src/httpcore2"
 
 [tool.hatch.build.targets.sdist]
 include = ["/httpcore2", "/CHANGELOG.md", "/LICENSE.md", "/README.md", "/tests"]

--- a/src/httpcore2/pyproject.toml
+++ b/src/httpcore2/pyproject.toml
@@ -50,9 +50,9 @@ trio = ["trio>=0.22.0,<1.0"]
 asyncio = ["anyio>=4.5.0,<5.0"]
 
 [project.urls]
-Documentation = "https://www.encode.io/httpcore"
-Homepage = "https://www.encode.io/httpcore/"
-Source = "https://github.com/encode/httpcore"
+Changelog = "https://github.com/pydantic/httpx2/blob/main/src/httpcore2/CHANGELOG.md"
+Homepage = "https://github.com/pydantic/httpx2"
+Source = "https://github.com/pydantic/httpx2"
 
 [tool.hatch.build.targets.sdist]
 include = ["/httpcore2", "/CHANGELOG.md", "/LICENSE.md", "/README.md", "/tests"]


### PR DESCRIPTION
The `httpcore2` `project.urls` pointed at upstream `encode/httpcore` locations, which misdirected users browsing from PyPI. Update them to the `pydantic/httpx2` repository, matching the convention already used in `src/httpx2/pyproject.toml`.

Closes #991

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.