### PR TITLE
Make zstd import optional on Python 3.14

### DIFF
--- a/src/httpx2/httpx2/_decoders.py
+++ b/src/httpx2/httpx2/_decoders.py
@@ -29,9 +29,9 @@ except ImportError:  # pragma: no cover
 
 
 # Zstandard support is optional on Python <= 3.13.
-# On Python 3.14, the stdlib includes a built-in zstd implementation, so we can support
-# it without an extra dependency.
+# On Python 3.14+, the stdlib includes an optional built-in zstd implementation.
 if typing.TYPE_CHECKING:
+    # We keep checking Python version in the type checker path because try..except doesn't help type checkers.
     if sys.version_info >= (3, 14):
         from compression.zstd import ZstdDecompressor, ZstdError
     else:
@@ -41,21 +41,20 @@ if typing.TYPE_CHECKING:
 
     _zstandard_installed: bool
 else:  # pragma: no cover
-    if sys.version_info >= (3, 14):
-        try:
-            from compression.zstd import ZstdDecompressor, ZstdError
+    _zstandard_installed = False
+    try:
+        from compression.zstd import ZstdDecompressor, ZstdError
 
-            _zstandard_installed = True
-        except ImportError:
-            _zstandard_installed = False
-    else:
+        _zstandard_installed = True
+    # Either Python <3.14 or the distro doesn't have `compression.zstd`.
+    except ImportError:
         try:
             from zstandard import ZstdDecompressor as _ZstdDecompressor, ZstdError
 
             ZstdDecompressor = functools.partial(_ZstdDecompressor().decompressobj)
             _zstandard_installed = True
         except ImportError:
-            _zstandard_installed = False
+            pass
 
 
 class ContentDecoder:
@@ -184,11 +183,10 @@ class BrotliDecoder(ContentDecoder):
 
 
 class ZStandardDecoder(ContentDecoder):
-    """
-    Handle 'zstd' RFC 8878 decoding.
+    """Handle 'zstd' RFC 8878 decoding.
 
-    Requires `pip install zstandard`.
-    Can be installed as a dependency of httpx using `pip install httpx[zstd]`.
+    If running on Python 3.14+ or a distro that doesn't have the `compression.zstd` stdlib module, requires either:
+    `pip install zstandard` or `pip install httpx2[zstd]`.
     """
 
     # inspired by the ZstdDecoder implementation in urllib3

--- a/src/httpx2/httpx2/_decoders.py
+++ b/src/httpx2/httpx2/_decoders.py
@@ -39,12 +39,15 @@ if typing.TYPE_CHECKING:
 
         ZstdDecompressor = functools.partial(_ZstdDecompressor().decompressobj)
 
-    _zstandard_installed: bool = True
+    _zstandard_installed: bool
 else:  # pragma: no cover
     if sys.version_info >= (3, 14):
-        from compression.zstd import ZstdDecompressor, ZstdError
+        try:
+            from compression.zstd import ZstdDecompressor, ZstdError
 
-        _zstandard_installed = True
+            _zstandard_installed = True
+        except ImportError:
+            _zstandard_installed = False
     else:
         try:
             from zstandard import ZstdDecompressor as _ZstdDecompressor, ZstdError


### PR DESCRIPTION
On Python 3.14, `compression.zstd` requires the `_zstd` C extension, which is not present in every CPython build. We imported it unconditionally, so `import httpx2` crashed with `ModuleNotFoundError: No module named '_zstd'` on those builds.

This wraps the 3.14 import in `try/except ImportError` (mirroring the existing `< 3.14` branch), so a missing `_zstd` sets `_zstandard_installed = False` and drops `zstd` from `SUPPORTED_DECODERS` instead of crashing.

Fixes the report in https://github.com/pydantic/httpx2/discussions/999#discussioncomment-17130374.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.