### PR TITLE
Add fallback version for builds without git

### DIFF
--- a/src/httpcore2/pyproject.toml
+++ b/src/httpcore2/pyproject.toml
@@ -13,6 +13,7 @@ source = "uv-dynamic-versioning"
 vcs = "git"
 style = "pep440"
 bump = true
+fallback-version = "0.0.0"
 
 [project]
 name = "httpcore2"

--- a/src/httpx2/pyproject.toml
+++ b/src/httpx2/pyproject.toml
@@ -9,6 +9,7 @@ source = "uv-dynamic-versioning"
 vcs = "git"
 style = "pep440"
 bump = true
+fallback-version = "0.0.0"
 
 [project]
 name = "httpx2"


### PR DESCRIPTION
Building `httpx2`/`httpcore2` from a release tarball (which has no `.git`) fails because `uv-dynamic-versioning` queries git for the version:

```
RuntimeError: Error getting the version from source `uv-dynamic-versioning`: This does not appear to be a Git project
```

Set `fallback-version` in both packages so `uv-dynamic-versioning` resolves a version when git is unavailable. Packagers resolve the real version outside the sandbox and patch this value at build time, per the [upstream tip](https://github.com/ninoseki/uv-dynamic-versioning/blob/main/docs/tips.md#nix-and-other-sandboxed-build-environments).

Closes #1001

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `fallback-version` ("0.0.0") to `httpx2` and `httpcore2` so `uv-dynamic-versioning` can resolve a version without `.git`, enabling builds from release tarballs. This prevents the "This does not appear to be a Git project" error and lets packagers patch the real version at build time.

<sup>Written for commit 534e805823e2a69c1d8bb982a6b793d1adddf743. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

