### PR TITLE
Correct `pragma: nocover` to `pragma: no cover` and tidy docstrings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ package = false
 default-groups = ["dev", "docs", "bench"]
 required-version = ">=0.8.6"
 exclude-newer = "7 days"
-exclude-newer-package = { urllib3 = "2026-05-09T00:00:00Z", zensical = "2026-05-11T00:00:00Z" }
 
 [tool.uv.workspace]
 members = ["src/httpx2", "src/httpcore2"]

--- a/src/httpcore2/httpcore2/__init__.py
+++ b/src/httpcore2/httpcore2/__init__.py
@@ -51,7 +51,7 @@ from ._sync import (
 # The 'httpcore2.AnyIOBackend' class is conditional on 'anyio' being installed.
 try:
     from ._backends.anyio import AnyIOBackend
-except ImportError:  # pragma: nocover
+except ImportError:  # pragma: no cover
 
     class AnyIOBackend:  # type: ignore
         def __init__(self, *args, **kwargs):  # type: ignore
@@ -62,7 +62,7 @@ except ImportError:  # pragma: nocover
 # The 'httpcore2.TrioBackend' class is conditional on 'trio' being installed.
 try:
     from ._backends.trio import TrioBackend
-except ImportError:  # pragma: nocover
+except ImportError:  # pragma: no cover
 
     class TrioBackend:  # type: ignore
         def __init__(self, *args, **kwargs):  # type: ignore

--- a/src/httpcore2/httpcore2/_async/__init__.py
+++ b/src/httpcore2/httpcore2/_async/__init__.py
@@ -6,7 +6,7 @@ from .interfaces import AsyncConnectionInterface
 
 try:
     from .http2 import AsyncHTTP2Connection
-except ImportError:  # pragma: nocover
+except ImportError:  # pragma: no cover
 
     class AsyncHTTP2Connection:  # type: ignore
         def __init__(self, *args, **kwargs) -> None:  # type: ignore
@@ -18,7 +18,7 @@ except ImportError:  # pragma: nocover
 
 try:
     from .socks_proxy import AsyncSOCKSProxy
-except ImportError:  # pragma: nocover
+except ImportError:  # pragma: no cover
 
     class AsyncSOCKSProxy:  # type: ignore
         def __init__(self, *args, **kwargs) -> None:  # type: ignore

--- a/src/httpcore2/httpcore2/_async/connection_pool.py
+++ b/src/httpcore2/httpcore2/_async/connection_pool.py
@@ -229,7 +229,7 @@ class AsyncConnectionPool(AsyncRequestInterface):
                     # In this case we clear the connection and try again.
                     pool_request.clear_connection()
                 else:
-                    break  # pragma: nocover
+                    break  # pragma: no cover
 
         except BaseException as exc:
             with self._optional_thread_lock:

--- a/src/httpcore2/httpcore2/_async/http2.py
+++ b/src/httpcore2/httpcore2/_async/http2.py
@@ -120,7 +120,7 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
         try:
             stream_id = self._h2_state.get_next_available_stream_id()
             self._events[stream_id] = []
-        except h2.exceptions.NoAvailableStreamIDError:  # pragma: nocover
+        except h2.exceptions.NoAvailableStreamIDError:  # pragma: no cover
             self._used_all_stream_ids = True
             self._request_count -= 1
             raise ConnectionNotAvailable()
@@ -161,11 +161,11 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
                 #
                 # In this case we'll have stored the event, and should raise
                 # it as a RemoteProtocolError.
-                if self._connection_terminated:  # pragma: nocover
+                if self._connection_terminated:  # pragma: no cover
                     raise RemoteProtocolError(self._connection_terminated)
                 # If h2 raises a protocol error in some other state then we
                 # must somehow have made a protocol violation.
-                raise LocalProtocolError(exc)  # pragma: nocover
+                raise LocalProtocolError(exc)  # pragma: no cover
 
             raise exc
 
@@ -387,7 +387,7 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
                 if self._keepalive_expiry is not None:
                     now = time.monotonic()
                     self._expire_at = now + self._keepalive_expiry
-                if self._used_all_stream_ids:  # pragma: nocover
+                if self._used_all_stream_ids:  # pragma: no cover
                     await self.aclose()
 
     async def aclose(self) -> None:
@@ -404,7 +404,7 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
         timeout = timeouts.get("read", None)
 
         if self._read_exception is not None:
-            raise self._read_exception  # pragma: nocover
+            raise self._read_exception  # pragma: no cover
 
         try:
             data = await self._network_stream.read(self.READ_NUM_BYTES, timeout)
@@ -435,11 +435,11 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
             data_to_send = self._h2_state.data_to_send()
 
             if self._write_exception is not None:
-                raise self._write_exception  # pragma: nocover
+                raise self._write_exception  # pragma: no cover
 
             try:
                 await self._network_stream.write(data_to_send, timeout)
-            except Exception as exc:  # pragma: nocover
+            except Exception as exc:  # pragma: no cover
                 # If we get a network error we should:
                 #
                 # 1. Save the exception and just raise it immediately on any future write.

--- a/src/httpcore2/httpcore2/_async/http_proxy.py
+++ b/src/httpcore2/httpcore2/_async/http_proxy.py
@@ -47,7 +47,7 @@ def merge_headers(
     return default_headers + override_headers
 
 
-class AsyncHTTPProxy(AsyncConnectionPool):  # pragma: nocover
+class AsyncHTTPProxy(AsyncConnectionPool):  # pragma: no cover
     """
     A connection pool that sends requests via an HTTP proxy.
     """

--- a/src/httpcore2/httpcore2/_async/interfaces.py
+++ b/src/httpcore2/httpcore2/_async/interfaces.py
@@ -82,18 +82,18 @@ class AsyncRequestInterface:
             await response.aclose()
 
     async def handle_async_request(self, request: Request) -> Response:
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()  # pragma: no cover
 
 
 class AsyncConnectionInterface(AsyncRequestInterface):
     async def aclose(self) -> None:
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()  # pragma: no cover
 
     def info(self) -> str:
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()  # pragma: no cover
 
     def can_handle_request(self, origin: Origin) -> bool:
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()  # pragma: no cover
 
     def is_available(self) -> bool:
         """
@@ -111,7 +111,7 @@ class AsyncConnectionInterface(AsyncRequestInterface):
         required exceptions if multiple requests are attempted over a connection
         that ends up being established as HTTP/1.1.
         """
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()  # pragma: no cover
 
     def has_expired(self) -> bool:
         """
@@ -120,13 +120,13 @@ class AsyncConnectionInterface(AsyncRequestInterface):
         This either means that the connection is idle and it has passed the
         expiry time on its keep-alive, or that server has sent an EOF.
         """
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()  # pragma: no cover
 
     def is_idle(self) -> bool:
         """
         Return `True` if the connection is currently idle.
         """
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()  # pragma: no cover
 
     def is_closed(self) -> bool:
         """
@@ -135,4 +135,4 @@ class AsyncConnectionInterface(AsyncRequestInterface):
         Used when a response is closed to determine if the connection may be
         returned to the connection pool or not.
         """
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()  # pragma: no cover

--- a/src/httpcore2/httpcore2/_async/socks_proxy.py
+++ b/src/httpcore2/httpcore2/_async/socks_proxy.py
@@ -96,7 +96,7 @@ async def _init_socks5_connection(
         raise ProxyError(f"Proxy Server could not connect: {reply_code}.")
 
 
-class AsyncSOCKSProxy(AsyncConnectionPool):  # pragma: nocover
+class AsyncSOCKSProxy(AsyncConnectionPool):  # pragma: no cover
     """
     A connection pool that sends requests via an HTTP proxy.
     """
@@ -254,7 +254,7 @@ class AsyncSocks5Connection(AsyncConnectionInterface):
                     http2_negotiated = ssl_object is not None and ssl_object.selected_alpn_protocol() == "h2"
 
                     # Create the HTTP/1.1 or HTTP/2 connection
-                    if http2_negotiated or (self._http2 and not self._http1):  # pragma: nocover
+                    if http2_negotiated or (self._http2 and not self._http1):  # pragma: no cover
                         from .http2 import AsyncHTTP2Connection
 
                         self._connection = AsyncHTTP2Connection(
@@ -271,7 +271,7 @@ class AsyncSocks5Connection(AsyncConnectionInterface):
                 except Exception as exc:
                     self._connect_failed = True
                     raise exc
-            elif not self._connection.is_available():  # pragma: nocover
+            elif not self._connection.is_available():  # pragma: no cover
                 raise ConnectionNotAvailable()
 
         return await self._connection.handle_async_request(request)
@@ -284,7 +284,7 @@ class AsyncSocks5Connection(AsyncConnectionInterface):
             await self._connection.aclose()
 
     def is_available(self) -> bool:
-        if self._connection is None:  # pragma: nocover
+        if self._connection is None:  # pragma: no cover
             # If HTTP/2 support is enabled, and the resulting connection could
             # end up as HTTP/2 then we should indicate the connection as being
             # available to service multiple requests.
@@ -294,22 +294,22 @@ class AsyncSocks5Connection(AsyncConnectionInterface):
         return self._connection.is_available()
 
     def has_expired(self) -> bool:
-        if self._connection is None:  # pragma: nocover
+        if self._connection is None:  # pragma: no cover
             return self._connect_failed
         return self._connection.has_expired()
 
     def is_idle(self) -> bool:
-        if self._connection is None:  # pragma: nocover
+        if self._connection is None:  # pragma: no cover
             return self._connect_failed
         return self._connection.is_idle()
 
     def is_closed(self) -> bool:
-        if self._connection is None:  # pragma: nocover
+        if self._connection is None:  # pragma: no cover
             return self._connect_failed
         return self._connection.is_closed()
 
     def info(self) -> str:
-        if self._connection is None:  # pragma: nocover
+        if self._connection is None:  # pragma: no cover
             return "CONNECTION FAILED" if self._connect_failed else "CONNECTING"
         return self._connection.info()
 

--- a/src/httpcore2/httpcore2/_backends/anyio.py
+++ b/src/httpcore2/httpcore2/_backends/anyio.py
@@ -33,7 +33,7 @@ class AnyIOStream(AsyncNetworkStream):
             with anyio.fail_after(timeout):
                 try:
                     return await self._stream.receive(max_bytes=max_bytes)
-                except anyio.EndOfStream:  # pragma: nocover
+                except anyio.EndOfStream:  # pragma: no cover
                     return b""
 
     async def write(self, buffer: bytes, timeout: float | None = None) -> None:
@@ -74,7 +74,7 @@ class AnyIOStream(AsyncNetworkStream):
                         standard_compatible=False,
                         server_side=False,
                     )
-            except Exception as exc:  # pragma: nocover
+            except Exception as exc:  # pragma: no cover
                 await self.aclose()
                 raise exc
         return AnyIOStream(ssl_stream)
@@ -102,7 +102,7 @@ class AnyIOBackend(AsyncNetworkBackend):
         timeout: float | None = None,
         local_address: str | None = None,
         socket_options: typing.Iterable[SOCKET_OPTION] | None = None,
-    ) -> AsyncNetworkStream:  # pragma: nocover
+    ) -> AsyncNetworkStream:  # pragma: no cover
         if socket_options is None:
             socket_options = []
         exc_map = {
@@ -127,7 +127,7 @@ class AnyIOBackend(AsyncNetworkBackend):
         path: str,
         timeout: float | None = None,
         socket_options: typing.Iterable[SOCKET_OPTION] | None = None,
-    ) -> AsyncNetworkStream:  # pragma: nocover
+    ) -> AsyncNetworkStream:  # pragma: no cover
         if socket_options is None:
             socket_options = []
         exc_map = {
@@ -143,4 +143,4 @@ class AnyIOBackend(AsyncNetworkBackend):
         return AnyIOStream(stream)
 
     async def sleep(self, seconds: float) -> None:
-        await anyio.sleep(seconds)  # pragma: nocover
+        await anyio.sleep(seconds)  # pragma: no cover

--- a/src/httpcore2/httpcore2/_backends/auto.py
+++ b/src/httpcore2/httpcore2/_backends/auto.py
@@ -41,10 +41,10 @@ class AutoBackend(AsyncNetworkBackend):
         path: str,
         timeout: float | None = None,
         socket_options: typing.Iterable[SOCKET_OPTION] | None = None,
-    ) -> AsyncNetworkStream:  # pragma: nocover
+    ) -> AsyncNetworkStream:  # pragma: no cover
         await self._init_backend()
         return await self._backend.connect_unix_socket(path, timeout=timeout, socket_options=socket_options)
 
-    async def sleep(self, seconds: float) -> None:  # pragma: nocover
+    async def sleep(self, seconds: float) -> None:  # pragma: no cover
         await self._init_backend()
         return await self._backend.sleep(seconds)

--- a/src/httpcore2/httpcore2/_backends/base.py
+++ b/src/httpcore2/httpcore2/_backends/base.py
@@ -13,13 +13,13 @@ SOCKET_OPTION = typing.Union[
 
 class NetworkStream:
     def read(self, max_bytes: int, timeout: float | None = None) -> bytes:
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()  # pragma: no cover
 
     def write(self, buffer: bytes, timeout: float | None = None) -> None:
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()  # pragma: no cover
 
     def close(self) -> None:
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()  # pragma: no cover
 
     def start_tls(
         self,
@@ -27,10 +27,10 @@ class NetworkStream:
         server_hostname: str | None = None,
         timeout: float | None = None,
     ) -> NetworkStream:
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()  # pragma: no cover
 
     def get_extra_info(self, info: str) -> typing.Any:
-        return None  # pragma: nocover
+        return None  # pragma: no cover
 
 
 class NetworkBackend:
@@ -42,7 +42,7 @@ class NetworkBackend:
         local_address: str | None = None,
         socket_options: typing.Iterable[SOCKET_OPTION] | None = None,
     ) -> NetworkStream:
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()  # pragma: no cover
 
     def connect_unix_socket(
         self,
@@ -50,21 +50,21 @@ class NetworkBackend:
         timeout: float | None = None,
         socket_options: typing.Iterable[SOCKET_OPTION] | None = None,
     ) -> NetworkStream:
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()  # pragma: no cover
 
     def sleep(self, seconds: float) -> None:
-        time.sleep(seconds)  # pragma: nocover
+        time.sleep(seconds)  # pragma: no cover
 
 
 class AsyncNetworkStream:
     async def read(self, max_bytes: int, timeout: float | None = None) -> bytes:
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()  # pragma: no cover
 
     async def write(self, buffer: bytes, timeout: float | None = None) -> None:
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()  # pragma: no cover
 
     async def aclose(self) -> None:
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()  # pragma: no cover
 
     async def start_tls(
         self,
@@ -72,10 +72,10 @@ class AsyncNetworkStream:
         server_hostname: str | None = None,
         timeout: float | None = None,
     ) -> AsyncNetworkStream:
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()  # pragma: no cover
 
     def get_extra_info(self, info: str) -> typing.Any:
-        return None  # pragma: nocover
+        return None  # pragma: no cover
 
 
 class AsyncNetworkBackend:
@@ -87,7 +87,7 @@ class AsyncNetworkBackend:
         local_address: str | None = None,
         socket_options: typing.Iterable[SOCKET_OPTION] | None = None,
     ) -> AsyncNetworkStream:
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()  # pragma: no cover
 
     async def connect_unix_socket(
         self,
@@ -95,7 +95,7 @@ class AsyncNetworkBackend:
         timeout: float | None = None,
         socket_options: typing.Iterable[SOCKET_OPTION] | None = None,
     ) -> AsyncNetworkStream:
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()  # pragma: no cover
 
     async def sleep(self, seconds: float) -> None:
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()  # pragma: no cover

--- a/src/httpcore2/httpcore2/_backends/sync.py
+++ b/src/httpcore2/httpcore2/_backends/sync.py
@@ -161,7 +161,7 @@ class SyncStream(NetworkStream):
                 else:
                     self._sock.settimeout(timeout)
                     sock = ssl_context.wrap_socket(self._sock, server_hostname=server_hostname)
-            except Exception as exc:  # pragma: nocover
+            except Exception as exc:  # pragma: no cover
                 self.close()
                 raise exc
         return SyncStream(sock)
@@ -216,7 +216,7 @@ class SyncBackend(NetworkBackend):
         path: str,
         timeout: float | None = None,
         socket_options: typing.Iterable[SOCKET_OPTION] | None = None,
-    ) -> NetworkStream:  # pragma: nocover
+    ) -> NetworkStream:  # pragma: no cover
         if sys.platform == "win32":
             raise RuntimeError("Attempted to connect to a UNIX socket on a Windows system.")
         if socket_options is None:

--- a/src/httpcore2/httpcore2/_backends/trio.py
+++ b/src/httpcore2/httpcore2/_backends/trio.py
@@ -73,7 +73,7 @@ class TrioStream(AsyncNetworkStream):
             try:
                 with trio.fail_after(timeout_or_inf):
                     await ssl_stream.do_handshake()
-            except Exception as exc:  # pragma: nocover
+            except Exception as exc:  # pragma: no cover
                 await self.aclose()
                 raise exc
         return TrioStream(ssl_stream)
@@ -137,7 +137,7 @@ class TrioBackend(AsyncNetworkBackend):
         path: str,
         timeout: float | None = None,
         socket_options: typing.Iterable[SOCKET_OPTION] | None = None,
-    ) -> AsyncNetworkStream:  # pragma: nocover
+    ) -> AsyncNetworkStream:  # pragma: no cover
         if socket_options is None:
             socket_options = []
         timeout_or_inf = float("inf") if timeout is None else timeout
@@ -154,4 +154,4 @@ class TrioBackend(AsyncNetworkBackend):
         return TrioStream(stream)
 
     async def sleep(self, seconds: float) -> None:
-        await trio.sleep(seconds)  # pragma: nocover
+        await trio.sleep(seconds)  # pragma: no cover

--- a/src/httpcore2/httpcore2/_exceptions.py
+++ b/src/httpcore2/httpcore2/_exceptions.py
@@ -12,7 +12,7 @@ def map_exceptions(map: ExceptionMapping) -> typing.Iterator[None]:
         for from_exc, to_exc in map.items():
             if isinstance(exc, from_exc):
                 raise to_exc(exc) from exc
-        raise  # pragma: nocover
+        raise  # pragma: no cover
 
 
 class ConnectionNotAvailable(Exception):

--- a/src/httpcore2/httpcore2/_models.py
+++ b/src/httpcore2/httpcore2/_models.py
@@ -128,7 +128,7 @@ def include_request_headers(
             content_length = str(len(content)).encode("ascii")
             headers += [(b"Content-Length", content_length)]
         else:
-            headers += [(b"Transfer-Encoding", b"chunked")]  # pragma: nocover
+            headers += [(b"Transfer-Encoding", b"chunked")]  # pragma: no cover
 
     return headers
 
@@ -398,7 +398,7 @@ class Response:
     # Sync interface...
 
     def read(self) -> bytes:
-        if not isinstance(self.stream, typing.Iterable):  # pragma: nocover
+        if not isinstance(self.stream, typing.Iterable):  # pragma: no cover
             raise RuntimeError(
                 "Attempted to read an asynchronous response using 'response.read()'. "
                 "You should use 'await response.aread()' instead."
@@ -408,7 +408,7 @@ class Response:
         return self._content
 
     def iter_stream(self) -> typing.Iterator[bytes]:
-        if not isinstance(self.stream, typing.Iterable):  # pragma: nocover
+        if not isinstance(self.stream, typing.Iterable):  # pragma: no cover
             raise RuntimeError(
                 "Attempted to stream an asynchronous response using 'for ... in "
                 "response.iter_stream()'. "
@@ -421,7 +421,7 @@ class Response:
             yield chunk
 
     def close(self) -> None:
-        if not isinstance(self.stream, typing.Iterable):  # pragma: nocover
+        if not isinstance(self.stream, typing.Iterable):  # pragma: no cover
             raise RuntimeError(
                 "Attempted to close an asynchronous response using 'response.close()'. "
                 "You should use 'await response.aclose()' instead."
@@ -432,7 +432,7 @@ class Response:
     # Async interface...
 
     async def aread(self) -> bytes:
-        if not isinstance(self.stream, typing.AsyncIterable):  # pragma: nocover
+        if not isinstance(self.stream, typing.AsyncIterable):  # pragma: no cover
             raise RuntimeError(
                 "Attempted to read an synchronous response using "
                 "'await response.aread()'. "
@@ -444,7 +444,7 @@ class Response:
         return self._content
 
     async def aiter_stream(self) -> AsyncGenerator[bytes]:
-        if not isinstance(self.stream, typing.AsyncIterable):  # pragma: nocover
+        if not isinstance(self.stream, typing.AsyncIterable):  # pragma: no cover
             raise RuntimeError(
                 "Attempted to stream an synchronous response using 'async for ... in "
                 "response.aiter_stream()'. "
@@ -458,7 +458,7 @@ class Response:
                 yield chunk
 
     async def aclose(self) -> None:
-        if not isinstance(self.stream, typing.AsyncIterable):  # pragma: nocover
+        if not isinstance(self.stream, typing.AsyncIterable):  # pragma: no cover
             raise RuntimeError(
                 "Attempted to close a synchronous response using "
                 "'await response.aclose()'. "

--- a/src/httpcore2/httpcore2/_sync/__init__.py
+++ b/src/httpcore2/httpcore2/_sync/__init__.py
@@ -6,7 +6,7 @@ from .interfaces import ConnectionInterface
 
 try:
     from .http2 import HTTP2Connection
-except ImportError:  # pragma: nocover
+except ImportError:  # pragma: no cover
 
     class HTTP2Connection:  # type: ignore
         def __init__(self, *args, **kwargs) -> None:  # type: ignore
@@ -18,7 +18,7 @@ except ImportError:  # pragma: nocover
 
 try:
     from .socks_proxy import SOCKSProxy
-except ImportError:  # pragma: nocover
+except ImportError:  # pragma: no cover
 
     class SOCKSProxy:  # type: ignore
         def __init__(self, *args, **kwargs) -> None:  # type: ignore

--- a/src/httpcore2/httpcore2/_sync/connection_pool.py
+++ b/src/httpcore2/httpcore2/_sync/connection_pool.py
@@ -229,7 +229,7 @@ class ConnectionPool(RequestInterface):
                     # In this case we clear the connection and try again.
                     pool_request.clear_connection()
                 else:
-                    break  # pragma: nocover
+                    break  # pragma: no cover
 
         except BaseException as exc:
             with self._optional_thread_lock:

--- a/src/httpcore2/httpcore2/_sync/http2.py
+++ b/src/httpcore2/httpcore2/_sync/http2.py
@@ -120,7 +120,7 @@ class HTTP2Connection(ConnectionInterface):
         try:
             stream_id = self._h2_state.get_next_available_stream_id()
             self._events[stream_id] = []
-        except h2.exceptions.NoAvailableStreamIDError:  # pragma: nocover
+        except h2.exceptions.NoAvailableStreamIDError:  # pragma: no cover
             self._used_all_stream_ids = True
             self._request_count -= 1
             raise ConnectionNotAvailable()
@@ -161,11 +161,11 @@ class HTTP2Connection(ConnectionInterface):
                 #
                 # In this case we'll have stored the event, and should raise
                 # it as a RemoteProtocolError.
-                if self._connection_terminated:  # pragma: nocover
+                if self._connection_terminated:  # pragma: no cover
                     raise RemoteProtocolError(self._connection_terminated)
                 # If h2 raises a protocol error in some other state then we
                 # must somehow have made a protocol violation.
-                raise LocalProtocolError(exc)  # pragma: nocover
+                raise LocalProtocolError(exc)  # pragma: no cover
 
             raise exc
 
@@ -387,7 +387,7 @@ class HTTP2Connection(ConnectionInterface):
                 if self._keepalive_expiry is not None:
                     now = time.monotonic()
                     self._expire_at = now + self._keepalive_expiry
-                if self._used_all_stream_ids:  # pragma: nocover
+                if self._used_all_stream_ids:  # pragma: no cover
                     self.close()
 
     def close(self) -> None:
@@ -404,7 +404,7 @@ class HTTP2Connection(ConnectionInterface):
         timeout = timeouts.get("read", None)
 
         if self._read_exception is not None:
-            raise self._read_exception  # pragma: nocover
+            raise self._read_exception  # pragma: no cover
 
         try:
             data = self._network_stream.read(self.READ_NUM_BYTES, timeout)
@@ -435,11 +435,11 @@ class HTTP2Connection(ConnectionInterface):
             data_to_send = self._h2_state.data_to_send()
 
             if self._write_exception is not None:
-                raise self._write_exception  # pragma: nocover
+                raise self._write_exception  # pragma: no cover
 
             try:
                 self._network_stream.write(data_to_send, timeout)
-            except Exception as exc:  # pragma: nocover
+            except Exception as exc:  # pragma: no cover
                 # If we get a network error we should:
                 #
                 # 1. Save the exception and just raise it immediately on any future write.

--- a/src/httpcore2/httpcore2/_sync/http_proxy.py
+++ b/src/httpcore2/httpcore2/_sync/http_proxy.py
@@ -47,7 +47,7 @@ def merge_headers(
     return default_headers + override_headers
 
 
-class HTTPProxy(ConnectionPool):  # pragma: nocover
+class HTTPProxy(ConnectionPool):  # pragma: no cover
     """
     A connection pool that sends requests via an HTTP proxy.
     """

--- a/src/httpcore2/httpcore2/_sync/interfaces.py
+++ b/src/httpcore2/httpcore2/_sync/interfaces.py
@@ -82,18 +82,18 @@ class RequestInterface:
             response.close()
 
     def handle_request(self, request: Request) -> Response:
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()  # pragma: no cover
 
 
 class ConnectionInterface(RequestInterface):
     def close(self) -> None:
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()  # pragma: no cover
 
     def info(self) -> str:
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()  # pragma: no cover
 
     def can_handle_request(self, origin: Origin) -> bool:
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()  # pragma: no cover
 
     def is_available(self) -> bool:
         """
@@ -111,7 +111,7 @@ class ConnectionInterface(RequestInterface):
         required exceptions if multiple requests are attempted over a connection
         that ends up being established as HTTP/1.1.
         """
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()  # pragma: no cover
 
     def has_expired(self) -> bool:
         """
@@ -120,13 +120,13 @@ class ConnectionInterface(RequestInterface):
         This either means that the connection is idle and it has passed the
         expiry time on its keep-alive, or that server has sent an EOF.
         """
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()  # pragma: no cover
 
     def is_idle(self) -> bool:
         """
         Return `True` if the connection is currently idle.
         """
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()  # pragma: no cover
 
     def is_closed(self) -> bool:
         """
@@ -135,4 +135,4 @@ class ConnectionInterface(RequestInterface):
         Used when a response is closed to determine if the connection may be
         returned to the connection pool or not.
         """
-        raise NotImplementedError()  # pragma: nocover
+        raise NotImplementedError()  # pragma: no cover

--- a/src/httpcore2/httpcore2/_sync/socks_proxy.py
+++ b/src/httpcore2/httpcore2/_sync/socks_proxy.py
@@ -96,7 +96,7 @@ def _init_socks5_connection(
         raise ProxyError(f"Proxy Server could not connect: {reply_code}.")
 
 
-class SOCKSProxy(ConnectionPool):  # pragma: nocover
+class SOCKSProxy(ConnectionPool):  # pragma: no cover
     """
     A connection pool that sends requests via an HTTP proxy.
     """
@@ -254,7 +254,7 @@ class Socks5Connection(ConnectionInterface):
                     http2_negotiated = ssl_object is not None and ssl_object.selected_alpn_protocol() == "h2"
 
                     # Create the HTTP/1.1 or HTTP/2 connection
-                    if http2_negotiated or (self._http2 and not self._http1):  # pragma: nocover
+                    if http2_negotiated or (self._http2 and not self._http1):  # pragma: no cover
                         from .http2 import HTTP2Connection
 
                         self._connection = HTTP2Connection(
@@ -271,7 +271,7 @@ class Socks5Connection(ConnectionInterface):
                 except Exception as exc:
                     self._connect_failed = True
                     raise exc
-            elif not self._connection.is_available():  # pragma: nocover
+            elif not self._connection.is_available():  # pragma: no cover
                 raise ConnectionNotAvailable()
 
         return self._connection.handle_request(request)
@@ -284,7 +284,7 @@ class Socks5Connection(ConnectionInterface):
             self._connection.close()
 
     def is_available(self) -> bool:
-        if self._connection is None:  # pragma: nocover
+        if self._connection is None:  # pragma: no cover
             # If HTTP/2 support is enabled, and the resulting connection could
             # end up as HTTP/2 then we should indicate the connection as being
             # available to service multiple requests.
@@ -294,22 +294,22 @@ class Socks5Connection(ConnectionInterface):
         return self._connection.is_available()
 
     def has_expired(self) -> bool:
-        if self._connection is None:  # pragma: nocover
+        if self._connection is None:  # pragma: no cover
             return self._connect_failed
         return self._connection.has_expired()
 
     def is_idle(self) -> bool:
-        if self._connection is None:  # pragma: nocover
+        if self._connection is None:  # pragma: no cover
             return self._connect_failed
         return self._connection.is_idle()
 
     def is_closed(self) -> bool:
-        if self._connection is None:  # pragma: nocover
+        if self._connection is None:  # pragma: no cover
             return self._connect_failed
         return self._connection.is_closed()
 
     def info(self) -> str:
-        if self._connection is None:  # pragma: nocover
+        if self._connection is None:  # pragma: no cover
             return "CONNECTION FAILED" if self._connect_failed else "CONNECTING"
         return self._connection.info()
 

--- a/src/httpcore2/httpcore2/_synchronization.py
+++ b/src/httpcore2/httpcore2/_synchronization.py
@@ -10,12 +10,12 @@ from ._exceptions import ExceptionMapping, PoolTimeout, map_exceptions
 
 try:
     import trio
-except (ImportError, NotImplementedError):  # pragma: nocover
+except (ImportError, NotImplementedError):  # pragma: no cover
     trio = None  # type: ignore
 
 try:
     import anyio
-except ImportError:  # pragma: nocover
+except ImportError:  # pragma: no cover
     anyio = None  # type: ignore
 
 
@@ -24,18 +24,18 @@ def current_async_library() -> str:
     # See https://sniffio.readthedocs.io/en/latest/
     try:
         import sniffio
-    except ImportError:  # pragma: nocover
+    except ImportError:  # pragma: no cover
         environment = "asyncio"
     else:
         environment = sniffio.current_async_library()
 
-    if environment not in ("asyncio", "trio"):  # pragma: nocover
+    if environment not in ("asyncio", "trio"):  # pragma: no cover
         raise RuntimeError("Running under an unsupported async environment.")
 
-    if environment == "asyncio" and anyio is None:  # pragma: nocover
+    if environment == "asyncio" and anyio is None:  # pragma: no cover
         raise RuntimeError("Running with asyncio requires installation of 'httpcore[asyncio]'.")
 
-    if environment == "trio" and trio is None:  # pragma: nocover
+    if environment == "trio" and trio is None:  # pragma: no cover
         raise RuntimeError("Running with trio requires installation of 'httpcore[trio]'.")
 
     return environment
@@ -280,7 +280,7 @@ class Event:
         if timeout == float("inf"):  # pragma: no cover
             timeout = None
         if not self._event.wait(timeout=timeout):
-            raise PoolTimeout()  # pragma: nocover
+            raise PoolTimeout()  # pragma: no cover
 
 
 class Semaphore:

--- a/src/httpcore2/httpcore2/_utils.py
+++ b/src/httpcore2/httpcore2/_utils.py
@@ -31,7 +31,7 @@ def is_socket_readable(sock: socket.socket | None) -> bool:
     # descriptor, we treat it as being readable, as if it the next read operation
     # on it is ready to return the terminating `b""`.
     sock_fd = None if sock is None else sock.fileno()
-    if sock_fd is None or sock_fd < 0:  # pragma: nocover
+    if sock_fd is None or sock_fd < 0:  # pragma: no cover
         return True
 
     # The implementation below was stolen from:
@@ -40,7 +40,7 @@ def is_socket_readable(sock: socket.socket | None) -> bool:
 
     # Use select.select on Windows, and when poll is unavailable and select.poll
     # everywhere else. (E.g. When eventlet is in use. See #327)
-    if sys.platform == "win32" or getattr(select, "poll", None) is None:  # pragma: nocover
+    if sys.platform == "win32" or getattr(select, "poll", None) is None:  # pragma: no cover
         rready, _, _ = select.select([sock_fd], [], [], 0)
         return bool(rready)
     p = select.poll()

--- a/src/httpx2/httpx2/_api.py
+++ b/src/httpx2/httpx2/_api.py
@@ -54,41 +54,28 @@ def request(
     verify: ssl.SSLContext | str | bool = True,
     trust_env: bool = True,
 ) -> Response:
-    """
-    Sends an HTTP request.
+    """Sends an HTTP request.
 
-    **Parameters:**
+    Parameters:
+        method: HTTP method for the new `Request` object: `GET`, `OPTIONS`, `HEAD`, `POST`, `PUT`, `PATCH`, or `DELETE`.
+        url: URL for the new `Request` object.
+        params: *(optional)* Query parameters to include in the URL, as a string, dictionary, or sequence of two-tuples.
+        content: *(optional)* Binary content to include in the body of the request, as bytes or a byte iterator.
+        data: *(optional)* Form data to include in the body of the request, as a dictionary.
+        files: *(optional)* A dictionary of upload files to include in the body of the request.
+        json: *(optional)* A JSON serializable object to include in the body of the request.
+        headers: *(optional)* Dictionary of HTTP headers to include in the request.
+        cookies: *(optional)* Dictionary of Cookie items to include in the request.
+        auth: *(optional)* An authentication class to use when sending the request.
+        proxy: *(optional)* A proxy URL where all the traffic should be routed.
+        timeout: *(optional)* The timeout configuration to use when sending the request.
+        follow_redirects: *(optional)* Enables or disables HTTP redirects.
+        verify: *(optional)* Either `True` to use an SSL context with the default CA bundle, `False` to disable
+            verification, or an instance of `ssl.SSLContext` to use a custom context.
+        trust_env: *(optional)* Enables or disables usage of environment variables for configuration.
 
-    * **method** - HTTP method for the new `Request` object: `GET`, `OPTIONS`,
-    `HEAD`, `POST`, `PUT`, `PATCH`, or `DELETE`.
-    * **url** - URL for the new `Request` object.
-    * **params** - *(optional)* Query parameters to include in the URL, as a
-    string, dictionary, or sequence of two-tuples.
-    * **content** - *(optional)* Binary content to include in the body of the
-    request, as bytes or a byte iterator.
-    * **data** - *(optional)* Form data to include in the body of the request,
-    as a dictionary.
-    * **files** - *(optional)* A dictionary of upload files to include in the
-    body of the request.
-    * **json** - *(optional)* A JSON serializable object to include in the body
-    of the request.
-    * **headers** - *(optional)* Dictionary of HTTP headers to include in the
-    request.
-    * **cookies** - *(optional)* Dictionary of Cookie items to include in the
-    request.
-    * **auth** - *(optional)* An authentication class to use when sending the
-    request.
-    * **proxy** - *(optional)* A proxy URL where all the traffic should be routed.
-    * **timeout** - *(optional)* The timeout configuration to use when sending
-    the request.
-    * **follow_redirects** - *(optional)* Enables or disables HTTP redirects.
-    * **verify** - *(optional)* Either `True` to use an SSL context with the
-    default CA bundle, `False` to disable verification, or an instance of
-    `ssl.SSLContext` to use a custom context.
-    * **trust_env** - *(optional)* Enables or disables usage of environment
-    variables for configuration.
-
-    **Returns:** `Response`
+    Returns:
+        The `Response` object.
 
     Usage:
 

--- a/src/httpx2/httpx2/_config.py
+++ b/src/httpx2/httpx2/_config.py
@@ -31,9 +31,9 @@ def create_ssl_context(
     import truststore
 
     if verify is True:
-        if trust_env and os.environ.get("SSL_CERT_FILE"):  # pragma: nocover
+        if trust_env and os.environ.get("SSL_CERT_FILE"):  # pragma: no cover
             ctx = ssl.create_default_context(cafile=os.environ["SSL_CERT_FILE"])
-        elif trust_env and os.environ.get("SSL_CERT_DIR"):  # pragma: nocover
+        elif trust_env and os.environ.get("SSL_CERT_DIR"):  # pragma: no cover
             ctx = ssl.create_default_context(capath=os.environ["SSL_CERT_DIR"])
         else:
             # Default case: rely on the system trust store via `truststore`.
@@ -42,7 +42,7 @@ def create_ssl_context(
         ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
         ctx.check_hostname = False
         ctx.verify_mode = ssl.CERT_NONE
-    elif isinstance(verify, str):  # pragma: nocover
+    elif isinstance(verify, str):  # pragma: no cover
         message = (
             "`verify=<str>` is deprecated. "
             "Use `verify=ssl.create_default_context(cafile=...)` "
@@ -55,7 +55,7 @@ def create_ssl_context(
     else:
         ctx = verify
 
-    if cert:  # pragma: nocover
+    if cert:  # pragma: no cover
         message = (
             "`cert=...` is deprecated. Use `verify=<ssl_context>` instead,"
             "with `.load_cert_chain()` to configure the certificate chain."

--- a/src/httpx2/httpx2/_transports/__init__.py
+++ b/src/httpx2/httpx2/_transports/__init__.py
@@ -1,8 +1,8 @@
-from .asgi import *
-from .base import *
-from .default import *
-from .mock import *
-from .wsgi import *
+from .asgi import ASGITransport
+from .base import AsyncBaseTransport, BaseTransport
+from .default import AsyncHTTPTransport, HTTPTransport
+from .mock import MockTransport
+from .wsgi import WSGITransport
 
 __all__ = [
     "ASGITransport",

--- a/src/httpx2/httpx2/_transports/asgi.py
+++ b/src/httpx2/httpx2/_transports/asgi.py
@@ -31,7 +31,7 @@ def is_running_trio() -> bool:
 
         if sniffio.current_async_library() == "trio":
             return True
-    except ImportError:  # pragma: nocover
+    except ImportError:  # pragma: no cover
         pass
 
     return False
@@ -70,14 +70,12 @@ class ASGITransport(AsyncBaseTransport):
     ```
 
     Arguments:
-
-    * `app` - The ASGI application.
-    * `raise_app_exceptions` - Boolean indicating if exceptions in the application
-       should be raised. Default to `True`. Can be set to `False` for use cases
-       such as testing the content of a client 500 response.
-    * `root_path` - The root path on which the ASGI application should be mounted.
-    * `client` - A two-tuple indicating the client IP and port of incoming requests.
-    ```
+        app: The ASGI application.
+        raise_app_exceptions: Boolean indicating if exceptions in the application
+            should be raised. Default to `True`. Can be set to `False` for use cases
+            such as testing the content of a client 500 response.
+        root_path: The root path on which the ASGI application should be mounted.
+        client: A two-tuple indicating the client IP and port of incoming requests.
     """
 
     def __init__(
@@ -92,10 +90,7 @@ class ASGITransport(AsyncBaseTransport):
         self.root_path = root_path
         self.client = client
 
-    async def handle_async_request(
-        self,
-        request: Request,
-    ) -> Response:
+    async def handle_async_request(self, request: Request) -> Response:
         assert isinstance(request.stream, AsyncByteStream)
 
         # ASGI scope.
@@ -121,7 +116,7 @@ class ASGITransport(AsyncBaseTransport):
         # Response.
         status_code = None
         response_headers = None
-        body_parts = []
+        body_parts: list[bytes] = []
         response_started = False
         response_complete = create_event()
 

--- a/src/httpx2/httpx2/_transports/base.py
+++ b/src/httpx2/httpx2/_transports/base.py
@@ -5,6 +5,7 @@ from types import TracebackType
 
 from .._models import Request, Response
 
+# TODO(Marcelo): When Python 3.10 reaches EOF, we can use `typing.Self` instead of defining those two.
 T = typing.TypeVar("T", bound="BaseTransport")
 A = typing.TypeVar("A", bound="AsyncBaseTransport")
 

--- a/src/httpx2/httpx2/_transports/mock.py
+++ b/src/httpx2/httpx2/_transports/mock.py
@@ -26,10 +26,7 @@ class MockTransport(AsyncBaseTransport, BaseTransport):
             raise TypeError("Cannot use an async handler in a sync Client")
         return response
 
-    async def handle_async_request(
-        self,
-        request: Request,
-    ) -> Response:
+    async def handle_async_request(self, request: Request) -> Response:
         await request.aread()
         response = self.handler(request)
 

--- a/src/httpx2/httpx2/_transports/wsgi.py
+++ b/src/httpx2/httpx2/_transports/wsgi.py
@@ -64,14 +64,12 @@ class WSGITransport(BaseTransport):
     ```
 
     Arguments:
-
-    * `app` - The WSGI application.
-    * `raise_app_exceptions` - Boolean indicating if exceptions in the application
-       should be raised. Default to `True`. Can be set to `False` for use cases
-       such as testing the content of a client 500 response.
-    * `script_name` - The root path on which the WSGI application should be mounted.
-    * `remote_addr` - A string indicating the client IP of incoming requests.
-    ```
+        app: The WSGI application.
+        raise_app_exceptions: Boolean indicating if exceptions in the application
+            should be raised. Default to `True`. Can be set to `False` for use cases
+            such as testing the content of a client 500 response.
+        script_name: The root path on which the WSGI application should be mounted.
+        remote_addr: A string indicating the client IP of incoming requests.
     """
 
     def __init__(

--- a/src/httpx2/httpx2/_urls.py
+++ b/src/httpx2/httpx2/_urls.py
@@ -398,7 +398,7 @@ class URL:
         return f"{self.__class__.__name__}({url!r})"
 
     @property
-    def raw(self) -> tuple[bytes, bytes, int, bytes]:  # pragma: nocover
+    def raw(self) -> tuple[bytes, bytes, int, bytes]:  # pragma: no cover
         import collections
         import warnings
 

--- a/tests/httpcore2/test_models.py
+++ b/tests/httpcore2/test_models.py
@@ -135,7 +135,7 @@ def test_response_sync_streaming() -> None:
     # Once we've streamed the response, we can't access the stream again.
     with pytest.raises(RuntimeError):
         for _chunk in response.iter_stream():
-            pass  # pragma: nocover
+            pass  # pragma: no cover
 
 
 # Tests for reading and streaming async byte streams...
@@ -172,4 +172,4 @@ async def test_response_async_streaming() -> None:
     # Once we've streamed the response, we can't access the stream again.
     with pytest.raises(RuntimeError):
         async for _chunk in response.aiter_stream():
-            pass  # pragma: nocover
+            pass  # pragma: no cover

--- a/tests/httpx2/conftest.py
+++ b/tests/httpx2/conftest.py
@@ -222,7 +222,7 @@ class TestServer(Server):
     def install_signal_handlers(self) -> None:
         # Disable the default installation of handlers for signals such as SIGTERM,
         # because it can only be done in the main thread.
-        pass  # pragma: nocover
+        pass  # pragma: no cover
 
     async def serve(self, sockets: list[socket.socket] | None = None) -> None:
         self.restart_requested = asyncio.Event()

--- a/uv.lock
+++ b/uv.lock
@@ -12,10 +12,6 @@ resolution-markers = [
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
-[options.exclude-newer-package]
-urllib3 = "2026-05-09T00:00:00Z"
-zensical = "2026-05-11T00:00:00Z"
-
 [manifest]
 members = [
     "httpcore2",


### PR DESCRIPTION
Coverage.py only recognizes `# pragma: no cover` (with a space) - the `nocover` spelling silently does nothing, so those branches were never actually being excluded from coverage. This sweeps the typo across `httpcore2` and `httpx2`.

While here:
- Convert the public API / transport docstrings to Google-style (`Args:`/`Returns:`).
- Replace wildcard transport imports (`from .asgi import *`) with explicit names.
- Annotate `body_parts: list[bytes]` in the ASGI transport.
- Drop the stale `exclude-newer-package` pins for `urllib3`/`zensical`.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix coverage exclusions by replacing all `# pragma: nocover` with `# pragma: no cover`, restoring accurate reporting. Also tidies docstrings and transport exports for clearer API and adds a small typing improvement.

- **Bug Fixes**
  - Use `# pragma: no cover` across `httpcore2` and `httpx2` so excluded lines are correctly ignored by coverage.

- **Refactors**
  - Convert public API and transport docstrings to Google-style (`Args:`/`Returns:`).
  - Replace wildcard imports in `httpx2._transports` with explicit exports.
  - Annotate ASGI transport `body_parts: list[bytes]`.
  - Remove stale `exclude-newer-package` pins for `urllib3` and `zensical`.

<sup>Written for commit d5077d205f46cc858acf7dde14c5c5101d2cfeb9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

