### PR TITLE
Require uv-dynamic-versioning>=0.8.0 for fallback-version support

### DIFF
--- a/src/httpcore2/pyproject.toml
+++ b/src/httpcore2/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "hatchling",
     "hatch-fancy-pypi-readme",
-    "uv-dynamic-versioning>=0.7.0",
+    "uv-dynamic-versioning>=0.8.0",
 ]
 build-backend = "hatchling.build"
 

--- a/src/httpx2/pyproject.toml
+++ b/src/httpx2/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling", "hatch-fancy-pypi-readme", "uv-dynamic-versioning>=0.7.0"]
+requires = ["hatchling", "hatch-fancy-pypi-readme", "uv-dynamic-versioning>=0.8.0"]
 build-backend = "hatchling.build"
 
 [tool.hatch.version]


### PR DESCRIPTION
The `fallback-version` setting added in #1003 only works with `uv-dynamic-versioning>=0.8.0`; 0.7.0's config schema has no `fallback_version` field, so constrained/offline no-git builds could resolve 0.7.x, ignore the key, and fail with the same VCS error.

Bumps the `build-system.requires` lower bound to `>=0.8.0` in both `httpx2` and `httpcore2` pyprojects.

Addresses https://github.com/pydantic/httpx2/pull/1003#discussion_r3333805177.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.