### PR TITLE
Version 2.3.0

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -30,7 +30,7 @@ jobs:
         shell: bash
 
       - name: Run the benchmarks
-        uses: CodSpeedHQ/action@9d332c4d90b43981c3e55ae8e38e68709996240f # v4
+        uses: CodSpeedHQ/action@9d332c4d90b43981c3e55ae8e38e68709996240f # v4.17.0
         with:
           mode: instrumentation
           run: uv run pytest tests/test_benchmark.py --codspeed

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -30,7 +30,7 @@ jobs:
         shell: bash
 
       - name: Run the benchmarks
-        uses: CodSpeedHQ/action@3194d9a39c4d46684cb44bf7207fc56626aad8fd # v4
+        uses: CodSpeedHQ/action@9d332c4d90b43981c3e55ae8e38e68709996240f # v4
         with:
           mode: instrumentation
           run: uv run pytest tests/test_benchmark.py --codspeed

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ The HTTPX2 project relies on these excellent libraries:
 * `httpcore2` - The underlying transport implementation for `httpx2`.
   * `h11` - HTTP/1.1 support.
 * `anyio` - Structured concurrency primitives, used to support both `asyncio` and `trio`.
-* `certifi` - SSL certificates.
+* `truststore` - SSL verification using the operating system's trust store.
 * `idna` - Internationalized domain name support.
 
 As well as these optional installs:
@@ -127,7 +127,7 @@ As well as these optional installs:
 * `rich` - Rich terminal support. *(Optional, with `httpx2[cli]`)*
 * `click` - Command line client support. *(Optional, with `httpx2[cli]`)*
 * `brotli` or `brotlicffi` - Decoding for "brotli" compressed responses. *(Optional, with `httpx2[brotli]`)*
-* `zstandard` - Decoding for "zstd" compressed responses on Python 3.13 and below. *(Optional, with `httpx2[zstd]`. On Python 3.14+, `zstd` is supported natively via the stdlib [`compression.zstd`](https://docs.python.org/3/library/compression.zstd.html) module.)*
+* `zstandard` - Decoding for "zstd" compressed responses on Python 3.13 and below. *(Optional, with `httpx2[zstd]`. On Python 3.14+, `zstd` is supported via the stdlib [`compression.zstd`](https://docs.python.org/3/library/compression.zstd.html) module when it is available; the `httpx2[zstd]` extra installs nothing there, so decoding falls back to `zstandard` only on 3.13 and below.)*
 
 A huge amount of credit is due to `requests` for the API layout that
 much of this work follows, as well as to `urllib3` for plenty of design

--- a/docs/advanced/ssl.md
+++ b/docs/advanced/ssl.md
@@ -20,29 +20,29 @@ You can disable SSL verification completely and allow insecure requests...
 
 If you're using a `Client()` instance you should pass any `verify=<...>` configuration when instantiating the client.
 
-By default the [certifi CA bundle](https://certifiio.readthedocs.io/en/latest/) is used for SSL verification.
+By default the operating system's trust store is used for SSL verification, via [the `truststore` package](https://truststore.readthedocs.io/).
 
 For more complex configurations you can pass an [SSL Context](https://docs.python.org/3/library/ssl.html) instance...
-
-```python
-import certifi
-import httpx2
-import ssl
-
-# This SSL context is equivalent to the default `verify=True`.
-ctx = ssl.create_default_context(cafile=certifi.where())
-client = httpx2.Client(verify=ctx)
-```
-
-Using [the `truststore` package](https://truststore.readthedocs.io/) to support system certificate stores...
 
 ```python
 import ssl
 import truststore
 import httpx2
 
-# Use system certificate stores.
+# This SSL context is equivalent to the default `verify=True`.
 ctx = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+client = httpx2.Client(verify=ctx)
+```
+
+Using [the `certifi` CA bundle](https://certifiio.readthedocs.io/en/latest/) instead of the system trust store...
+
+```python
+import certifi
+import httpx2
+import ssl
+
+# Use the certifi CA bundle.
+ctx = ssl.create_default_context(cafile=certifi.where())
 client = httpx2.Client(verify=ctx)
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -108,7 +108,7 @@ The HTTPX2 project relies on these excellent libraries:
 * `httpcore2` - The underlying transport implementation for `httpx2`.
   * `h11` - HTTP/1.1 support.
 * `anyio` - Structured concurrency primitives, used to support both `asyncio` and `trio`.
-* `certifi` - SSL certificates.
+* `truststore` - SSL verification using the operating system's trust store.
 * `idna` - Internationalized domain name support.
 
 As well as these optional installs:
@@ -118,7 +118,7 @@ As well as these optional installs:
 * `rich` - Rich terminal support. *(Optional, with `httpx2[cli]`)*
 * `click` - Command line client support. *(Optional, with `httpx2[cli]`)*
 * `brotli` or `brotlicffi` - Decoding for "brotli" compressed responses. *(Optional, with `httpx2[brotli]`)*
-* `zstandard` - Decoding for "zstd" compressed responses on Python 3.13 and below. *(Optional, with `httpx2[zstd]`. On Python 3.14+, `zstd` is supported natively via the stdlib [`compression.zstd`][] module.)*
+* `zstandard` - Decoding for "zstd" compressed responses on Python 3.13 and below. *(Optional, with `httpx2[zstd]`. On Python 3.14+, `zstd` is supported via the stdlib [`compression.zstd`][] module when it is available; the `httpx2[zstd]` extra installs nothing there, so decoding falls back to `zstandard` only on 3.13 and below.)*
 
 A huge amount of credit is due to `requests` for the API layout that
 much of this work follows, as well as to `urllib3` for plenty of design

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -101,8 +101,8 @@ b'<!doctype html>\n<html>\n<head>\n<title>Example Domain</title>...'
 Any `gzip` and `deflate` HTTP response encodings will automatically
 be decoded for you. If `brotlipy` is installed, then the `brotli` response
 encoding will be supported. The `zstd` response encoding is supported
-natively on Python 3.14+ via the stdlib [`compression.zstd`][]
-module; on Python 3.13 and below it requires the `zstandard` package.
+on Python 3.14+ via the stdlib [`compression.zstd`][] module when it is
+available; on Python 3.13 and below it requires the `zstandard` package.
 
 For example, to create an image from binary data returned by a request, you can use the following code:
 

--- a/src/httpcore2/CHANGELOG.md
+++ b/src/httpcore2/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2.3.0 (June 1st, 2026)
+
+### Changed
+
+* Use `truststore` instead of `certifi` for default SSL verification, loading the operating system's trust store. ([#1002](https://github.com/pydantic/httpx2/pull/1002))
+* Rewrite `_assign_requests_to_connections` as a single-pass loop. ([#974](https://github.com/pydantic/httpx2/pull/974))
+* Use `anyio`'s `fast_acquire` for `Lock` and `Semaphore`. ([#970](https://github.com/pydantic/httpx2/pull/970))
+* Use `memoryview` in `write()` to avoid copies. ([#954](https://github.com/pydantic/httpx2/pull/954))
+
 ## 2.2.0 (May 16th, 2026)
 
 No changes since `2.1.0`. Version bumped to stay in lockstep with `httpx2`.

--- a/src/httpcore2/README.md
+++ b/src/httpcore2/README.md
@@ -85,7 +85,7 @@ The motivation for `httpcore` is:
 The `httpcore` package has the following dependencies...
 
 * `h11`
-* `certifi`
+* `truststore`
 
 And the following optional extras...
 

--- a/src/httpx2/CHANGELOG.md
+++ b/src/httpx2/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2.3.0 (June 1st, 2026)
+
+### Changed
+
+* Use `truststore` instead of `certifi` for default SSL verification, loading the operating system's trust store. ([#209](https://github.com/pydantic/httpx2/pull/209))
+
+### Fixed
+
+* Raise when `verify` is a string path and a client-side `cert` is also provided to `create_ssl_context`. ([#990](https://github.com/pydantic/httpx2/pull/990))
+* Allow a `default_encoding` callable to return `None`. ([#951](https://github.com/pydantic/httpx2/pull/951))
+* Make the `zstd` import optional on Python 3.14. ([#1000](https://github.com/pydantic/httpx2/pull/1000))
+* Store elapsed time on the stream wrapper to avoid reference cycles. ([#948](https://github.com/pydantic/httpx2/pull/948))
+
 ## 2.2.0 (May 16th, 2026)
 
 ### Fixed

--- a/uv.lock
+++ b/uv.lock
@@ -1412,11 +1412,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.16"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
 ]
 
 [[package]]
@@ -2695,15 +2695,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21.2"
+version = "10.21.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6", size = 269002, upload-time = "2026-05-13T12:57:30.296Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Prepares the 2.3.0 release.

- Add 2.3.0 changelog entries for `httpx2` and `httpcore2` (lockstep), covering the `certifi` -> `truststore` switch, SSL/`cert` validation, optional zstd import, and the `httpcore2` perf changes.
- Update docs and READMEs: default SSL verification now uses the OS trust store via `truststore` (not the certifi CA bundle).
- Tighten the zstd wording - `compression.zstd` is used on 3.14+ only when available, and `httpx2[zstd]` installs nothing there.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
