### PR TITLE
Use RLock instead of Lock to prevent thread deadlock

### DIFF
--- a/src/httpcore2/httpcore2/_synchronization.py
+++ b/src/httpcore2/httpcore2/_synchronization.py
@@ -254,7 +254,7 @@ class ThreadLock:
     """
 
     def __init__(self) -> None:
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
 
     def __enter__(self) -> ThreadLock:
         self._lock.acquire()


### PR DESCRIPTION
## Summary

A thread that already holds `_optional_thread_lock` on `(Async)ConnectionPool` can re-enter the lock in nested call paths. `threading.Lock` deadlocks on a second acquire from the same thread; `threading.RLock` allows re-entrant acquisition and resolves the hang.

This PR:
- Swaps `threading.Lock()` for `threading.RLock()` in the sync variant. The async variant remains a no-op.
~~- Renames `ThreadLock` → `ThreadRLock` and `AsyncThreadLock` → `AsyncThreadRLock` in `httpcore2/_synchronization.py` to make the lock semantics explicit. The names are private (module is `_synchronization`), so this is not a public API change.~~
~~- Updates the two import / usage sites in `_async/connection_pool.py` and `_sync/connection_pool.py`.~~

Ported from [encode/httpcore#1003](https://github.com/encode/httpcore/pull/1003) (Zenulous), via [codeberg.org/httpxyz/httpcorexyz@3058e2d](https://codeberg.org/httpxyz/httpcorexyz/commit/3058e2d).

---

*Note: this change was prepared with AI assistance (Claude Code).*