### PR TITLE
Close proxy connection when tunnel TLS handshake fails

### DIFF
--- a/src/httpcore2/httpcore2/_async/http_proxy.py
+++ b/src/httpcore2/httpcore2/_async/http_proxy.py
@@ -294,9 +294,16 @@ class AsyncTunnelHTTPConnection(AsyncConnectionInterface):
                     "server_hostname": self._remote_origin.host.decode("ascii"),
                     "timeout": timeout,
                 }
-                async with Trace("start_tls", logger, request, kwargs) as trace:
-                    stream = await stream.start_tls(**kwargs)
-                    trace.return_value = stream
+                try:
+                    async with Trace("start_tls", logger, request, kwargs) as trace:
+                        stream = await stream.start_tls(**kwargs)
+                        trace.return_value = stream
+                except Exception:
+                    # If TLS setup fails, close the underlying CONNECT
+                    # connection so the pool can discard it instead of
+                    # leaving it ACTIVE until max_connections is exhausted.
+                    await self._connection.aclose()
+                    raise
 
                 # Determine if we should be using HTTP/1.1 or HTTP/2
                 ssl_object = stream.get_extra_info("ssl_object")

--- a/src/httpcore2/httpcore2/_sync/http_proxy.py
+++ b/src/httpcore2/httpcore2/_sync/http_proxy.py
@@ -294,9 +294,16 @@ class TunnelHTTPConnection(ConnectionInterface):
                     "server_hostname": self._remote_origin.host.decode("ascii"),
                     "timeout": timeout,
                 }
-                with Trace("start_tls", logger, request, kwargs) as trace:
-                    stream = stream.start_tls(**kwargs)
-                    trace.return_value = stream
+                try:
+                    with Trace("start_tls", logger, request, kwargs) as trace:
+                        stream = stream.start_tls(**kwargs)
+                        trace.return_value = stream
+                except Exception:
+                    # If TLS setup fails, close the underlying CONNECT
+                    # connection so the pool can discard it instead of
+                    # leaving it ACTIVE until max_connections is exhausted.
+                    self._connection.close()
+                    raise
 
                 # Determine if we should be using HTTP/1.1 or HTTP/2
                 ssl_object = stream.get_extra_info("ssl_object")

--- a/tests/httpcore2/_async/test_http_proxy.py
+++ b/tests/httpcore2/_async/test_http_proxy.py
@@ -240,3 +240,48 @@ def test_proxy_headers() -> None:
         auth=("username", "password"),
     )
     assert proxy.headers == [(b"Proxy-Authorization", b"Basic dXNlcm5hbWU6cGFzc3dvcmQ=")]
+
+
+class BrokenTLSStream(AsyncMockStream):
+    async def start_tls(
+        self,
+        ssl_context: ssl.SSLContext,
+        server_hostname: typing.Optional[str] = None,
+        timeout: typing.Optional[float] = None,
+    ) -> AsyncNetworkStream:
+        raise OSError("TLS Failure")
+
+
+class BrokenTLSBackend(AsyncMockBackend):
+    async def connect_tcp(
+        self,
+        host: str,
+        port: int,
+        timeout: typing.Optional[float] = None,
+        local_address: typing.Optional[str] = None,
+        socket_options: typing.Optional[typing.Iterable[SOCKET_OPTION]] = None,
+    ) -> AsyncNetworkStream:
+        return BrokenTLSStream(list(self._buffer))
+
+
+@pytest.mark.anyio
+async def test_proxy_tunneling_tls_error() -> None:
+    """
+    Send an HTTPS request via a proxy where the TLS handshake fails after the
+    CONNECT tunnel is established. The CONNECT connection must be closed so it
+    doesn't leak from the pool.
+    """
+    network_backend = BrokenTLSBackend(
+        [
+            b"HTTP/1.1 200 OK\r\n\r\n",
+        ]
+    )
+
+    async with AsyncConnectionPool(
+        proxy=Proxy("http://localhost:8080/"),
+        network_backend=network_backend,
+    ) as proxy:
+        with pytest.raises(OSError, match="TLS Failure"):
+            await proxy.request("GET", "https://example.com/")
+
+        assert not proxy.connections

--- a/tests/httpcore2/_sync/test_http_proxy.py
+++ b/tests/httpcore2/_sync/test_http_proxy.py
@@ -240,3 +240,48 @@ def test_proxy_headers() -> None:
         auth=("username", "password"),
     )
     assert proxy.headers == [(b"Proxy-Authorization", b"Basic dXNlcm5hbWU6cGFzc3dvcmQ=")]
+
+
+class BrokenTLSStream(MockStream):
+    def start_tls(
+        self,
+        ssl_context: ssl.SSLContext,
+        server_hostname: typing.Optional[str] = None,
+        timeout: typing.Optional[float] = None,
+    ) -> NetworkStream:
+        raise OSError("TLS Failure")
+
+
+class BrokenTLSBackend(MockBackend):
+    def connect_tcp(
+        self,
+        host: str,
+        port: int,
+        timeout: typing.Optional[float] = None,
+        local_address: typing.Optional[str] = None,
+        socket_options: typing.Optional[typing.Iterable[SOCKET_OPTION]] = None,
+    ) -> NetworkStream:
+        return BrokenTLSStream(list(self._buffer))
+
+
+
+def test_proxy_tunneling_tls_error() -> None:
+    """
+    Send an HTTPS request via a proxy where the TLS handshake fails after the
+    CONNECT tunnel is established. The CONNECT connection must be closed so it
+    doesn't leak from the pool.
+    """
+    network_backend = BrokenTLSBackend(
+        [
+            b"HTTP/1.1 200 OK\r\n\r\n",
+        ]
+    )
+
+    with ConnectionPool(
+        proxy=Proxy("http://localhost:8080/"),
+        network_backend=network_backend,
+    ) as proxy:
+        with pytest.raises(OSError, match="TLS Failure"):
+            proxy.request("GET", "https://example.com/")
+
+        assert not proxy.connections


### PR DESCRIPTION
## Summary

When an HTTP CONNECT proxy tunnel is established but the subsequent TLS handshake with the remote server fails, the underlying TCP connection to the proxy is left in ACTIVE state and never removed from the pool. The pool eventually hits `max_connections` and stalls forever.

This PR wraps the `start_tls()` call in `AsyncTunnelHTTPConnection.handle_async_request()` (and its sync twin) in a `try/except`, so any exception during TLS setup triggers an `aclose()` on the CONNECT connection — returning it to a closed state the pool can discard.

Ports [encode/httpcore#1049](https://github.com/encode/httpcore/pull/1049) (baizhu), via [codeberg.org/httpxyz/httpcorexyz@b192486](https://codeberg.org/httpxyz/httpcorexyz/commit/b192486).

## Notes

- Only `_async/http_proxy.py` and `tests/httpcore2/_async/test_http_proxy.py` were edited by hand; the `_sync/` counterparts were regenerated by `scripts/unasync.py`.
- Added `test_proxy_tunneling_tls_error`, which uses a `BrokenTLSStream` that raises `OSError` from `start_tls()`. The test asserts that the request fails *and* that `proxy.connections` is empty afterwards (i.e. the leaked connection is gone). 100% coverage preserved.

---

*Note: this change was prepared with AI assistance (Claude Code).*