### PR TITLE
In the main description, replace “Python 3” with just “Python”

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <a href="https://pypi.org/project/httpx2/"><img src="https://badge.fury.io/py/httpx2.svg" alt="Package version"></a>
 </p>
 
-HTTPX2 is a fully featured HTTP client library for Python 3. It includes **an integrated command line client**, has support for both **HTTP/1.1 and HTTP/2**, and provides both **sync and async APIs**.
+HTTPX2 is a fully featured HTTP client library for Python. It includes **an integrated command line client**, has support for both **HTTP/1.1 and HTTP/2**, and provides both **sync and async APIs**.
 
 > [!NOTE]
 > HTTPX2 is a continuation of the wonderful work started by [@lovelydinosaur](https://github.com/lovelydinosaur) and the broader HTTPX community. We're enormously grateful for everything that has gone into HTTPX over the years - it has been a foundational piece of the modern Python ecosystem, and this project would not exist without it.

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ HTTPX2
 <em>A next-generation HTTP client for Python.</em>
 </div>
 
-HTTPX2 is a fully featured HTTP client for Python 3, which provides sync and async APIs, and support for both HTTP/1.1 and HTTP/2.
+HTTPX2 is a fully featured HTTP client for Python, which provides sync and async APIs, and support for both HTTP/1.1 and HTTP/2.
 
 !!! note
     HTTPX2 is a continuation of the wonderful work started by [@lovelydinosaur](https://github.com/lovelydinosaur) and the broader HTTPX community. We're enormously grateful for everything that has gone into HTTPX over the years - it has been a foundational piece of the modern Python ecosystem, and this project would not exist without it.


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX2! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

In the main description, replace “Python 3” with just “Python.”

At this point, Python 2 has been end-of-life for over six years, and a reader should start with the assumption that it isn’t supported; the explicit “Python 3” now just adds noise.
<!-- Write a small summary about what is happening here. -->

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change. **No tests required; not a code change**
- [x] I've updated the documentation accordingly. **This is a documentation change.**
