### PR TITLE
Release HTTP/2 semaphore permit on NoAvailableStreamIDError

### DIFF
--- a/src/httpcore2/httpcore2/_async/http2.py
+++ b/src/httpcore2/httpcore2/_async/http2.py
@@ -123,6 +123,7 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
         except h2.exceptions.NoAvailableStreamIDError:  # pragma: no cover
             self._used_all_stream_ids = True
             self._request_count -= 1
+            await self._max_streams_semaphore.release()
             raise ConnectionNotAvailable()
 
         try:

--- a/src/httpcore2/httpcore2/_sync/http2.py
+++ b/src/httpcore2/httpcore2/_sync/http2.py
@@ -123,6 +123,7 @@ class HTTP2Connection(ConnectionInterface):
         except h2.exceptions.NoAvailableStreamIDError:  # pragma: no cover
             self._used_all_stream_ids = True
             self._request_count -= 1
+            self._max_streams_semaphore.release()
             raise ConnectionNotAvailable()
 
         try:


### PR DESCRIPTION
## Summary

`AsyncHTTP2Connection.handle_async_request` acquires a permit from `_max_streams_semaphore` *before* calling `self._h2_state.get_next_available_stream_id()`. If the stream-ID space is exhausted and `NoAvailableStreamIDError` is raised, the exception handler sets `_used_all_stream_ids = True` and decrements `_request_count` but never releases the permit — leaking it permanently.

In practice `_used_all_stream_ids = True` prevents further requests on the same connection so the visible impact is limited, but the resource cleanup is still wrong.

This PR adds the missing `release()` call in both the async and sync paths.

Ports [encode/httpcore#1061](https://github.com/encode/httpcore/pull/1061) (bysiber, currently open upstream), via [codeberg.org/httpxyz/httpcorexyz@e88f30b](https://codeberg.org/httpxyz/httpcorexyz/commit/e88f30b). The fork bundled this fix with [encode/httpcore#1062](https://github.com/encode/httpcore/pull/1062); I'm splitting them into two httpx2 PRs to mirror the upstream split.

## Notes

- Only `_async/http2.py` was edited by hand; `_sync/http2.py` was regenerated by `scripts/unasync.py`.
- No new test: the `NoAvailableStreamIDError` branch is already marked `# pragma: no cover` because exhausting the H/2 client stream-ID space (≈ 2³⁰ requests) is impractical to exercise in a unit test. The upstream PR doesn't ship a test either. 100% coverage preserved.

---

*Note: this change was prepared with AI assistance (Claude Code).*