### PR TITLE
Move HTTP/2 stream events cleanup inside _state_lock

### DIFF
--- a/src/httpcore2/httpcore2/_async/http2.py
+++ b/src/httpcore2/httpcore2/_async/http2.py
@@ -377,8 +377,8 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
 
     async def _response_closed(self, stream_id: int) -> None:
         await self._max_streams_semaphore.release()
-        del self._events[stream_id]
         async with self._state_lock:
+            del self._events[stream_id]
             if self._connection_terminated and not self._events:
                 await self.aclose()
 

--- a/src/httpcore2/httpcore2/_sync/http2.py
+++ b/src/httpcore2/httpcore2/_sync/http2.py
@@ -377,8 +377,8 @@ class HTTP2Connection(ConnectionInterface):
 
     def _response_closed(self, stream_id: int) -> None:
         self._max_streams_semaphore.release()
-        del self._events[stream_id]
         with self._state_lock:
+            del self._events[stream_id]
             if self._connection_terminated and not self._events:
                 self.close()
 


### PR DESCRIPTION
## Summary

In `AsyncHTTP2Connection._response_closed`, the `del self._events[stream_id]` happens **outside** the `_state_lock`, but the `not self._events` check that decides whether to transition the connection to IDLE happens **inside** the lock. With multiplexed HTTP/2 requests this creates a race:

1. Request A is the last active stream. `_response_closed` runs: releases the semaphore, deletes its events entry, then **yields** before acquiring the lock.
2. Request B enters `handle_async_request`, acquires `_state_lock`, sets `state=ACTIVE`, releases the lock.
3. Request B acquires the semaphore and a new stream ID — but has not yet written `self._events[stream_id] = []`.
4. Request A resumes, acquires `_state_lock`, observes `not self._events` is True (B's entry isn't there yet), and marks the connection IDLE with an expiry timer — while Request B is actively using it.

The pool may then see the connection as expired and close it mid-request, or evict it as an excess idle connection.

Moving `del self._events[stream_id]` inside `_state_lock` makes the events-dict mutation and the IDLE-transition check atomic.

Ports [encode/httpcore#1062](https://github.com/encode/httpcore/pull/1062) (bysiber, currently open upstream), via [codeberg.org/httpxyz/httpcorexyz@e88f30b](https://codeberg.org/httpxyz/httpcorexyz/commit/e88f30b). The fork bundled this with [encode/httpcore#1061](https://github.com/encode/httpcore/pull/1061); I'm splitting them into two httpx2 PRs to mirror the upstream split. Sibling PR for #1061 is #1012.

## Notes

- Only `_async/http2.py` was edited by hand; `_sync/http2.py` was regenerated by `scripts/unasync.py`.
- No new test: reproducing this race deterministically needs careful coroutine scheduling and isn't currently feasible against the public `AsyncConnectionPool` API. The upstream PR doesn't ship a test either. 100% coverage preserved; existing HTTP/2 tests continue to pass.

---

*Note: this change was prepared with AI assistance (Claude Code).*