### PR TITLE
Allow version 15 of rich in httpx2’s cli extra

### DIFF
--- a/src/httpx2/pyproject.toml
+++ b/src/httpx2/pyproject.toml
@@ -57,7 +57,7 @@ brotli = [
 cli = [
     "click==8.*",
     "pygments==2.*",
-    "rich>=10,<15",
+    "rich>=10,<16",
 ]
 http2 = [
     "h2>=3,<5",

--- a/uv.lock
+++ b/uv.lock
@@ -1382,7 +1382,7 @@ requires-dist = [
     { name = "httpcore2", editable = "src/httpcore2" },
     { name = "idna" },
     { name = "pygments", marker = "extra == 'cli'", specifier = "==2.*" },
-    { name = "rich", marker = "extra == 'cli'", specifier = ">=10,<15" },
+    { name = "rich", marker = "extra == 'cli'", specifier = ">=10,<16" },
     { name = "socksio", marker = "extra == 'socks'", specifier = "==1.*" },
     { name = "truststore", specifier = ">=0.10" },
     { name = "zstandard", marker = "python_full_version < '3.14' and extra == 'zstd'", specifier = ">=0.18.0" },
@@ -2963,15 +2963,15 @@ wheels = [
 
 [[package]]
 name = "rich"
-version = "14.3.4"
+version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/67/cae617f1351490c25a4b8ac3b8b63a4dda609295d8222bad12242dfdc629/rich-14.3.4.tar.gz", hash = "sha256:817e02727f2b25b40ef56f5aa2217f400c8489f79ca8f46ea2b70dd5e14558a9", size = 230524, upload-time = "2026-04-11T02:57:45.419Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/76/6d163cfac87b632216f71879e6b2cf17163f773ff59c00b5ff4900a80fa3/rich-14.3.4-py3-none-any.whl", hash = "sha256:07e7adb4690f68864777b1450859253bed81a99a31ac321ac1817b2313558952", size = 310480, upload-time = "2026-04-11T02:57:47.484Z" },
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX2! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->
Update `httpx2`’s `cli` extra to allow `rich` 15; update `uv.lock` so we test with `rich` 15.

The only documented breaking change in `rich` 15 is that support for the end-of-life Python version 3.8 was dropped.

https://github.com/Textualize/rich/blob/v15.0.0/CHANGELOG.md

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change. **This is covered by existing tests.**
- [x] I've updated the documentation accordingly. **No documentation changes are required.**
