### PR TITLE
Adapt two more tests for chardet 6.x compatibility

### DIFF
--- a/tests/httpx2/client/test_client.py
+++ b/tests/httpx2/client/test_client.py
@@ -429,7 +429,10 @@ def test_client_decode_text_using_autodetect() -> None:
 
         assert response.status_code == 200
         assert response.reason_phrase == "OK"
-        assert response.encoding == "ISO-8859-1"
+        # The encoded byte string is consistent with either ISO-8859-1 or
+        # WINDOWS-1252. Versions <6.0 of chardet claim the former, while
+        # chardet 6.0 detects the latter.
+        assert response.encoding in ("ISO-8859-1", "WINDOWS-1252")
         assert response.text == text
 
 
@@ -456,5 +459,8 @@ def test_client_decode_text_using_explicit_encoding() -> None:
 
         assert response.status_code == 200
         assert response.reason_phrase == "OK"
-        assert response.encoding == "ISO-8859-1"
+        # The encoded byte string is consistent with either ISO-8859-1 or
+        # WINDOWS-1252. Versions <6.0 of chardet claim the former, while
+        # chardet 6.0 detects the latter.
+        assert response.encoding in ("ISO-8859-1", "WINDOWS-1252")
         assert response.text == text


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX2! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->
See https://github.com/encode/httpx/pull/3773, which was merged into `httpx` before `httpx2` was forked; this extends that approach to similar tests that were added in `httpx2`, allowing the entire test suite to pass with `chardet` 6.x while preserving backwards-compatibility with `chardet` 5.x. This is helpful in Fedora, where our `python-chardet` package is at `6.0.0.post1`.

While this makes the tests compatible with both `chardet` 5.x and 6.x, I did not update the version of `chardet` in the `dev` dependency group, which is still at `==5.2.0`.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change. **N/A; this is a testing change.**
- [x] I've updated the documentation accordingly. **Nothing to update**

# Additional information

This fixes the following two test failures with `chardet==6.0.0.post1`.

```
========================================================================================= FAILURES =========================================================================================
_________________________________________________________________________ test_client_decode_text_using_autodetect _________________________________________________________________________

    def test_client_decode_text_using_autodetect() -> None:
        # Ensure that a 'default_encoding=autodetect' on the response allows for
        # encoding autodetection to be used when no "Content-Type: text/plain; charset=..."
        # info is present.
        #
        # Here we have some french text encoded with ISO-8859-1, rather than UTF-8.
        text = (
            "Non-seulement Despréaux ne se trompait pas, mais de tous les écrivains "
            "que la France a produits, sans excepter Voltaire lui-même, imprégné de "
            "l'esprit anglais par son séjour à Londres, c'est incontestablement "
            "Molière ou Poquelin qui reproduit avec l'exactitude la plus vive et la "
            "plus complète le fond du génie français."
        )

        def cp1252_but_no_content_type(request: httpx2.Request) -> httpx2.Response:
            content = text.encode("ISO-8859-1")
            return httpx2.Response(200, content=content)

        transport = httpx2.MockTransport(cp1252_but_no_content_type)
        with httpx2.Client(transport=transport, default_encoding=autodetect) as client:
            response = client.get("http://www.example.com")

            assert response.status_code == 200
            assert response.reason_phrase == "OK"
>           assert response.encoding == "ISO-8859-1"
E           AssertionError: assert 'WINDOWS-1252' == 'ISO-8859-1'
E             
E             - ISO-8859-1
E             + WINDOWS-1252

tests/httpx2/client/test_client.py:432: AssertionError
_____________________________________________________________________ test_client_decode_text_using_explicit_encoding ______________________________________________________________________

    def test_client_decode_text_using_explicit_encoding() -> None:
        # Ensure that a 'default_encoding="..."' on the response is used for text decoding
        # when no "Content-Type: text/plain; charset=..."" info is present.
        #
        # Here we have some french text encoded with ISO-8859-1, rather than UTF-8.
        text = (
            "Non-seulement Despréaux ne se trompait pas, mais de tous les écrivains "
            "que la France a produits, sans excepter Voltaire lui-même, imprégné de "
            "l'esprit anglais par son séjour à Londres, c'est incontestablement "
            "Molière ou Poquelin qui reproduit avec l'exactitude la plus vive et la "
            "plus complète le fond du génie français."
        )

        def cp1252_but_no_content_type(request: httpx2.Request) -> httpx2.Response:
            content = text.encode("ISO-8859-1")
            return httpx2.Response(200, content=content)

        transport = httpx2.MockTransport(cp1252_but_no_content_type)
        with httpx2.Client(transport=transport, default_encoding=autodetect) as client:
            response = client.get("http://www.example.com")

            assert response.status_code == 200
            assert response.reason_phrase == "OK"
>           assert response.encoding == "ISO-8859-1"
E           AssertionError: assert 'WINDOWS-1252' == 'ISO-8859-1'
E             
E             - ISO-8859-1
E             + WINDOWS-1252

tests/httpx2/client/test_client.py:459: AssertionError
================================================================================= short test summary info ==================================================================================
SKIPPED [1] tests/httpx2/client/test_auth.py:253: netrc files without a password are valid from Python >= 3.11
======================================================================== 2 failed, 1658 passed, 1 skipped in 4.09s =========================================================================
```