### PR TITLE
Decode IDNA labels in non-leading host positions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ package = false
 default-groups = ["dev", "docs", "bench"]
 required-version = ">=0.8.6"
 exclude-newer = "7 days"
+exclude-newer-package = { idna = "2026-06-03T00:00:00Z" }
 
 [tool.uv.workspace]
 members = ["src/httpx2", "src/httpcore2"]

--- a/src/httpx2/httpx2/_urls.py
+++ b/src/httpx2/httpx2/_urls.py
@@ -184,8 +184,8 @@ class URL:
         """
         host: str = self._uri_reference.host
 
-        if host.startswith("xn--"):
-            host = idna.decode(host)
+        if "xn--" in host:
+            host = idna.decode(host, display=True)
 
         return host
 

--- a/src/httpx2/pyproject.toml
+++ b/src/httpx2/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "truststore>=0.10",
     "httpcore2=={{ version }}",
     "anyio",
-    "idna",
+    "idna>=3.18",
 ]
 
 [project.optional-dependencies]

--- a/tests/httpx2/models/test_url.py
+++ b/tests/httpx2/models/test_url.py
@@ -756,6 +756,14 @@ def test_url_merge_params_manipulation() -> None:
             "https",
             4433,
         ),
+        (
+            "https://www.égalité-femmes-hommes.gouv.fr",
+            "https://www.xn--galit-femmes-hommes-9ybf.gouv.fr",
+            "www.égalité-femmes-hommes.gouv.fr",
+            b"www.xn--galit-femmes-hommes-9ybf.gouv.fr",
+            "https",
+            None,
+        ),
     ],
     ids=[
         "http_with_port",
@@ -764,6 +772,7 @@ def test_url_merge_params_manipulation() -> None:
         "https_with_port",
         "http_with_custom_port",
         "https_with_custom_port",
+        "idna_label_after_ascii_label",
     ],
 )
 def test_idna_url(given: str, idna: str, host: str, raw_host: bytes, scheme: str, port: int | None) -> None:
@@ -783,6 +792,16 @@ def test_url_unescaped_idna_host() -> None:
 def test_url_escaped_idna_host() -> None:
     url = httpx2.URL("https://xn--fiqs8s.icom.museum/")
     assert url.raw_host == b"xn--fiqs8s.icom.museum"
+
+
+def test_url_malformed_idna_label_after_ascii_label() -> None:
+    url = httpx2.URL("https://a.b.c.xn--pokxncvks/")
+    assert url.host == "a.b.c.xn--pokxncvks"
+
+
+def test_url_mixed_valid_and_malformed_idna_labels() -> None:
+    url = httpx2.URL("https://xn--fiqs8s.xn--pokxncvks/")
+    assert url.host == "中国.xn--pokxncvks"
 
 
 def test_url_invalid_idna_host() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,9 @@ resolution-markers = [
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
+[options.exclude-newer-package]
+idna = "2026-06-03T00:00:00Z"
+
 [manifest]
 members = [
     "httpcore2",
@@ -1380,7 +1383,7 @@ requires-dist = [
     { name = "click", marker = "extra == 'cli'", specifier = "==8.*" },
     { name = "h2", marker = "extra == 'http2'", specifier = ">=3,<5" },
     { name = "httpcore2", editable = "src/httpcore2" },
-    { name = "idna" },
+    { name = "idna", specifier = ">=3.18" },
     { name = "pygments", marker = "extra == 'cli'", specifier = "==2.*" },
     { name = "rich", marker = "extra == 'cli'", specifier = ">=10,<15" },
     { name = "socksio", marker = "extra == 'socks'", specifier = "==1.*" },
@@ -1412,11 +1415,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.16"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Supersedes #979 — uses the new `idna.decode(..., display=True)` added in idna 3.18 ([kjd/idna#248](https://github.com/kjd/idna/issues/248), [kjd/idna@1a5bf80](https://github.com/kjd/idna/commit/1a5bf80f2fa40454589e6144efe5f72015ef9d24), released 2026-06-02), so the per-label recovery lives in idna where Kludex preferred it.

---

AI-assisted: change drafted by Claude under my review.