### PR TITLE
Replace `Extensions` with `RequestExtensions` and `ResponseExtensions` TypedDicts

### DIFF
--- a/src/httpcore2/httpcore2/_api.py
+++ b/src/httpcore2/httpcore2/_api.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import contextlib
 import typing
 
-from ._models import URL, Extensions, HeaderTypes, Response
+from ._models import URL, HeaderTypes, RequestExtensions, Response
 from ._sync.connection_pool import ConnectionPool
 
 
@@ -13,7 +13,7 @@ def request(
     *,
     headers: HeaderTypes = None,
     content: bytes | typing.Iterator[bytes] | None = None,
-    extensions: Extensions | None = None,
+    extensions: RequestExtensions | None = None,
 ) -> Response:
     """
     Sends an HTTP request, returning the response.
@@ -54,7 +54,7 @@ def stream(
     *,
     headers: HeaderTypes = None,
     content: bytes | typing.Iterator[bytes] | None = None,
-    extensions: Extensions | None = None,
+    extensions: RequestExtensions | None = None,
 ) -> typing.Generator[Response]:
     """
     Sends an HTTP request, returning the response within a content manager.

--- a/src/httpcore2/httpcore2/_async/interfaces.py
+++ b/src/httpcore2/httpcore2/_async/interfaces.py
@@ -6,10 +6,10 @@ from collections.abc import AsyncGenerator
 
 from .._models import (
     URL,
-    Extensions,
     HeaderTypes,
     Origin,
     Request,
+    RequestExtensions,
     Response,
     enforce_bytes,
     enforce_headers,
@@ -26,7 +26,7 @@ class AsyncRequestInterface:
         *,
         headers: HeaderTypes = None,
         content: bytes | typing.AsyncIterator[bytes] | None = None,
-        extensions: Extensions | None = None,
+        extensions: RequestExtensions | None = None,
     ) -> Response:
         # Strict type checking on our parameters.
         method = enforce_bytes(method, name="method")
@@ -58,7 +58,7 @@ class AsyncRequestInterface:
         *,
         headers: HeaderTypes = None,
         content: bytes | typing.AsyncIterator[bytes] | None = None,
-        extensions: Extensions | None = None,
+        extensions: RequestExtensions | None = None,
     ) -> AsyncGenerator[Response]:
         # Strict type checking on our parameters.
         method = enforce_bytes(method, name="method")

--- a/src/httpcore2/httpcore2/_models.py
+++ b/src/httpcore2/httpcore2/_models.py
@@ -3,21 +3,43 @@ from __future__ import annotations
 
 import base64
 import ssl
+import sys
 import typing
 import urllib.parse
 from collections.abc import AsyncGenerator
 
+if sys.version_info >= (3, 15):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
+
 from ._utils import safe_async_iterate
-
-# Functions for typechecking...
-
 
 ByteOrStr = typing.Union[bytes, str]
 HeadersAsSequence = typing.Sequence[typing.Tuple[ByteOrStr, ByteOrStr]]
 HeadersAsMapping = typing.Mapping[ByteOrStr, ByteOrStr]
 HeaderTypes = typing.Union[HeadersAsSequence, HeadersAsMapping, None]
 
-Extensions = typing.MutableMapping[str, typing.Any]
+
+class Timeout(TypedDict, total=False):
+    connect: float | None
+    read: float | None
+    write: float | None
+    pool: float | None
+
+
+class RequestExtensions(TypedDict, total=False, extra_items=typing.Any):
+    timeout: Timeout
+    sni_hostname: str | None
+    trace: typing.Callable[[str, dict[str, typing.Any]], typing.Any]
+    target: bytes
+
+
+class ResponseExtensions(TypedDict, total=False, extra_items=typing.Any):
+    http_version: typing.Required[bytes]
+    reason_phrase: bytes
+    network_stream: typing.Required[typing.Any]
+    stream_id: int
 
 
 def enforce_bytes(value: bytes | str, *, name: str) -> bytes:
@@ -319,7 +341,7 @@ class Request:
         *,
         headers: HeaderTypes = None,
         content: bytes | typing.Iterable[bytes] | typing.AsyncIterable[bytes] | None = None,
-        extensions: Extensions | None = None,
+        extensions: RequestExtensions | None = None,
     ) -> None:
         """
         Parameters:
@@ -336,7 +358,7 @@ class Request:
         self.url: URL = enforce_url(url, name="url")
         self.headers: list[tuple[bytes, bytes]] = enforce_headers(headers, name="headers")
         self.stream: typing.Iterable[bytes] | typing.AsyncIterable[bytes] = enforce_stream(content, name="content")
-        self.extensions: Extensions = {} if extensions is None else extensions
+        self.extensions: RequestExtensions = {} if extensions is None else extensions
 
         if "target" in self.extensions:
             self.url = URL(
@@ -361,7 +383,7 @@ class Response:
         *,
         headers: HeaderTypes = None,
         content: bytes | typing.Iterable[bytes] | typing.AsyncIterable[bytes] | None = None,
-        extensions: Extensions | None = None,
+        extensions: ResponseExtensions | None = None,
     ) -> None:
         """
         Parameters:
@@ -369,13 +391,13 @@ class Response:
             headers: The HTTP response headers.
             content: The content of the response body.
             extensions: A dictionary of optional extra information included on
-                the responseself.Possible keys include `"http_version"`,
+                the response. Possible keys include `"http_version"`,
                 `"reason_phrase"`, and `"network_stream"`.
         """
         self.status: int = status
         self.headers: list[tuple[bytes, bytes]] = enforce_headers(headers, name="headers")
         self.stream: typing.Iterable[bytes] | typing.AsyncIterable[bytes] = enforce_stream(content, name="content")
-        self.extensions: Extensions = {} if extensions is None else extensions
+        self.extensions: ResponseExtensions = {} if extensions is None else extensions
 
         self._stream_consumed = False
 

--- a/src/httpcore2/httpcore2/_sync/interfaces.py
+++ b/src/httpcore2/httpcore2/_sync/interfaces.py
@@ -6,10 +6,10 @@ from collections.abc import Generator
 
 from .._models import (
     URL,
-    Extensions,
     HeaderTypes,
     Origin,
     Request,
+    RequestExtensions,
     Response,
     enforce_bytes,
     enforce_headers,
@@ -26,7 +26,7 @@ class RequestInterface:
         *,
         headers: HeaderTypes = None,
         content: bytes | typing.Iterator[bytes] | None = None,
-        extensions: Extensions | None = None,
+        extensions: RequestExtensions | None = None,
     ) -> Response:
         # Strict type checking on our parameters.
         method = enforce_bytes(method, name="method")
@@ -58,7 +58,7 @@ class RequestInterface:
         *,
         headers: HeaderTypes = None,
         content: bytes | typing.Iterator[bytes] | None = None,
-        extensions: Extensions | None = None,
+        extensions: RequestExtensions | None = None,
     ) -> Generator[Response]:
         # Strict type checking on our parameters.
         method = enforce_bytes(method, name="method")

--- a/src/httpcore2/pyproject.toml
+++ b/src/httpcore2/pyproject.toml
@@ -42,7 +42,11 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
     "Topic :: Internet :: WWW/HTTP",
 ]
-dependencies = ["truststore>=0.10", "h11>=0.16"]
+dependencies = [
+    "truststore>=0.10",
+    "h11>=0.16",
+    "typing-extensions>=4.13; python_version < '3.15'",
+]
 
 [project.optional-dependencies]
 http2 = ["h2>=3,<5"]

--- a/src/httpx2/httpx2/_models.py
+++ b/src/httpx2/httpx2/_models.py
@@ -387,7 +387,7 @@ class Request:
         self.method = method.upper()
         self.url = URL(url) if params is None else URL(url, params=params)
         self.headers = Headers(headers)
-        self.extensions = {} if extensions is None else dict(extensions)
+        self.extensions: RequestExtensions = {} if extensions is None else dict(extensions)
 
         if cookies:
             Cookies(cookies).set_cookie_header(self)

--- a/tests/httpcore2/_async/test_connection_pool.py
+++ b/tests/httpcore2/_async/test_connection_pool.py
@@ -7,6 +7,7 @@ import pytest
 import trio as concurrency
 
 import httpcore2
+from httpcore2._models import RequestExtensions
 
 
 @pytest.mark.anyio
@@ -681,8 +682,7 @@ async def test_connection_pool_timeout() -> None:
         # fails with a timeout.
         async with pool.stream("GET", "https://example.com/"):
             with pytest.raises(httpcore2.PoolTimeout):
-                extensions = {"timeout": {"pool": 0.0001}}
-                await pool.request("GET", "https://example.com/", extensions=extensions)
+                await pool.request("GET", "https://example.com/", extensions={"timeout": {"pool": 0.0001}})
 
 
 @pytest.mark.anyio
@@ -707,7 +707,7 @@ async def test_connection_pool_timeout_zero() -> None:
     )
 
     # Use a pool timeout of zero.
-    extensions = {"timeout": {"pool": 0}}
+    extensions: RequestExtensions = {"timeout": {"pool": 0}}
 
     # A connection pool configured to allow only one connection at a time.
     async with httpcore2.AsyncConnectionPool(network_backend=network_backend, max_connections=1) as pool:

--- a/tests/httpcore2/test_models.py
+++ b/tests/httpcore2/test_models.py
@@ -64,12 +64,10 @@ def test_request() -> None:
 
 
 def test_request_with_target_extension() -> None:
-    extensions = {"target": b"/another_path"}
-    request = httpcore2.Request("GET", "https://www.example.com/path", extensions=extensions)
+    request = httpcore2.Request("GET", "https://www.example.com/path", extensions={"target": b"/another_path"})
     assert request.url.target == b"/another_path"
 
-    extensions = {"target": b"/unescaped|path"}
-    request = httpcore2.Request("GET", "https://www.example.com/path", extensions=extensions)
+    request = httpcore2.Request("GET", "https://www.example.com/path", extensions={"target": b"/unescaped|path"})
     assert request.url.target == b"/unescaped|path"
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1315,6 +1315,7 @@ source = { editable = "src/httpcore2" }
 dependencies = [
     { name = "h11" },
     { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.15'" },
 ]
 
 [package.optional-dependencies]
@@ -1339,6 +1340,7 @@ requires-dist = [
     { name = "socksio", marker = "extra == 'socks'", specifier = "==1.*" },
     { name = "trio", marker = "extra == 'trio'", specifier = ">=0.22.0,<1.0" },
     { name = "truststore", specifier = ">=0.10" },
+    { name = "typing-extensions", marker = "python_full_version < '3.15'", specifier = ">=4.13" },
 ]
 provides-extras = ["asyncio", "http2", "socks", "trio"]
 


### PR DESCRIPTION
Replaces the loosely-typed `Extensions = MutableMapping[str, Any]` alias in `httpcore2` with explicit `RequestExtensions` and `ResponseExtensions` TypedDicts, derived from the extension keys the backends actually read and write.

- `RequestExtensions`: `timeout` (a nested `Timeout` TypedDict with `connect`/`read`/`write`/`pool`), `sni_hostname`, `trace`, `target`. Declared with `extra_items=Any` so user/middleware keys still type-check.
- `ResponseExtensions`: `http_version`, `reason_phrase`, `network_stream`, `stream_id`, also `extra_items=Any`.
- `extra_items=` (PEP 728) lands in stdlib `typing` only in Python 3.15, so `TypedDict` is imported from `typing_extensions` below 3.15 and from `typing` at/above it; the dependency carries a matching `python_version < '3.15'` marker.
- Updates `_api.py` and the sync/async `interfaces.py` to the new types, and threads `RequestExtensions` through `httpx2.Request`.

Note: `scripts/check` is not fully green yet (pre-existing items unrelated to this typing change).

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.