### PR TITLE
Mark httpx2 and httpcore2 classifiers as Production/Stable

### DIFF
--- a/src/httpcore2/pyproject.toml
+++ b/src/httpcore2/pyproject.toml
@@ -28,6 +28,7 @@ maintainers = [
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Web Environment",
+    "Framework :: AnyIO",
     "Framework :: AsyncIO",
     "Framework :: Trio",
     "Intended Audience :: Developers",

--- a/src/httpcore2/pyproject.toml
+++ b/src/httpcore2/pyproject.toml
@@ -26,7 +26,7 @@ maintainers = [
     { name = "Pydantic Services Inc.", email = "engineering@pydantic.dev" },
 ]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 5 - Production/Stable",
     "Environment :: Web Environment",
     "Framework :: AsyncIO",
     "Framework :: Trio",

--- a/src/httpx2/pyproject.toml
+++ b/src/httpx2/pyproject.toml
@@ -23,7 +23,7 @@ maintainers = [
     { name = "Pydantic Services Inc.", email = "engineering@pydantic.dev" }
 ]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Environment :: Web Environment",
     "Framework :: AsyncIO",
     "Framework :: Trio",

--- a/src/httpx2/pyproject.toml
+++ b/src/httpx2/pyproject.toml
@@ -25,6 +25,7 @@ maintainers = [
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Web Environment",
+    "Framework :: AnyIO",
     "Framework :: AsyncIO",
     "Framework :: Trio",
     "Intended Audience :: Developers",


### PR DESCRIPTION
Promote the `Development Status` trove classifier to `5 - Production/Stable` for both packages:

- `httpx2`: was `4 - Beta`
- `httpcore2`: was `3 - Alpha`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.