### PR TITLE
Enable ruff UP rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ line-length = 120
 exclude = ["src/httpcore2/httpcore2/_sync", "tests/httpcore2/_sync"]
 
 [tool.ruff.lint]
-select = ["B", "C4", "E", "F", "I", "PERF", "PIE", "W"]
+select = ["B", "C4", "E", "F", "I", "PERF", "PIE", "UP", "W"]
 ignore = ["B904", "B028", "C401", "PERF203"]
 
 [tool.ruff.lint.isort]

--- a/scripts/unasync.py
+++ b/scripts/unasync.py
@@ -44,7 +44,7 @@ def unasync_line(line):
 
 
 def unasync_file(in_path, out_path):
-    with open(in_path, "r") as in_file:
+    with open(in_path) as in_file:
         with open(out_path, "w", newline="") as out_file:
             for line in in_file.readlines():
                 line = unasync_line(line)
@@ -52,8 +52,8 @@ def unasync_file(in_path, out_path):
 
 
 def unasync_file_check(in_path, out_path):
-    with open(in_path, "r") as in_file:
-        with open(out_path, "r") as out_file:
+    with open(in_path) as in_file:
+        with open(out_path) as out_file:
             for in_line, out_line in zip(in_file.readlines(), out_file.readlines(), strict=True):
                 expected = unasync_line(in_line)
                 if out_line != expected:

--- a/src/httpcore2/httpcore2/_async/http11.py
+++ b/src/httpcore2/httpcore2/_async/http11.py
@@ -28,11 +28,7 @@ logger = logging.getLogger("httpcore2.http11")
 
 
 # A subset of `h11.Event` types supported by `_send_event`
-H11SendEvent = typing.Union[
-    h11.Request,
-    h11.Data,
-    h11.EndOfMessage,
-]
+H11SendEvent = h11.Request | h11.Data | h11.EndOfMessage
 
 
 class HTTPConnectionState(enum.IntEnum):

--- a/src/httpcore2/httpcore2/_async/http_proxy.py
+++ b/src/httpcore2/httpcore2/_async/http_proxy.py
@@ -24,8 +24,8 @@ from .connection_pool import AsyncConnectionPool
 from .http11 import AsyncHTTP11Connection
 from .interfaces import AsyncConnectionInterface
 
-ByteOrStr = typing.Union[bytes, str]
-HeadersAsSequence = typing.Sequence[typing.Tuple[ByteOrStr, ByteOrStr]]
+ByteOrStr = bytes | str
+HeadersAsSequence = typing.Sequence[tuple[ByteOrStr, ByteOrStr]]
 HeadersAsMapping = typing.Mapping[ByteOrStr, ByteOrStr]
 
 
@@ -278,7 +278,7 @@ class AsyncTunnelHTTPConnection(AsyncConnectionInterface):
                 if connect_response.status < 200 or connect_response.status > 299:
                     reason_bytes = connect_response.extensions.get("reason_phrase", b"")
                     reason_str = reason_bytes.decode("ascii", errors="ignore")
-                    msg = "%d %s" % (connect_response.status, reason_str)
+                    msg = f"{connect_response.status} {reason_str}"
                     await self._connection.aclose()
                     raise ProxyError(msg)
 

--- a/src/httpcore2/httpcore2/_backends/base.py
+++ b/src/httpcore2/httpcore2/_backends/base.py
@@ -4,11 +4,7 @@ import ssl
 import time
 import typing
 
-SOCKET_OPTION = typing.Union[
-    typing.Tuple[int, int, int],
-    typing.Tuple[int, int, typing.Union[bytes, bytearray]],
-    typing.Tuple[int, int, None, int],
-]
+SOCKET_OPTION = tuple[int, int, int] | tuple[int, int, bytes | bytearray] | tuple[int, int, None, int]
 
 
 class NetworkStream:

--- a/src/httpcore2/httpcore2/_exceptions.py
+++ b/src/httpcore2/httpcore2/_exceptions.py
@@ -1,7 +1,7 @@
 import contextlib
 import typing
 
-ExceptionMapping = typing.Mapping[typing.Type[Exception], typing.Type[Exception]]
+ExceptionMapping = typing.Mapping[type[Exception], type[Exception]]
 
 
 @contextlib.contextmanager

--- a/src/httpcore2/httpcore2/_models.py
+++ b/src/httpcore2/httpcore2/_models.py
@@ -11,10 +11,10 @@ from ._utils import safe_async_iterate
 # Functions for typechecking...
 
 
-ByteOrStr = typing.Union[bytes, str]
-HeadersAsSequence = typing.Sequence[typing.Tuple[ByteOrStr, ByteOrStr]]
+ByteOrStr = bytes | str
+HeadersAsSequence = typing.Sequence[tuple[ByteOrStr, ByteOrStr]]
 HeadersAsMapping = typing.Mapping[ByteOrStr, ByteOrStr]
-HeaderTypes = typing.Union[HeadersAsSequence, HeadersAsMapping, None]
+HeaderTypes = HeadersAsSequence | HeadersAsMapping | None
 
 Extensions = typing.MutableMapping[str, typing.Any]
 
@@ -110,7 +110,7 @@ DEFAULT_PORTS = {
 def include_request_headers(
     headers: list[tuple[bytes, bytes]],
     *,
-    url: "URL",
+    url: URL,
     content: None | bytes | typing.Iterable[bytes] | typing.AsyncIterable[bytes],
 ) -> list[tuple[bytes, bytes]]:
     headers_set = {k.lower() for k, v in headers}
@@ -417,8 +417,7 @@ class Response:
         if self._stream_consumed:
             raise RuntimeError("Attempted to call 'for ... in response.iter_stream()' more than once.")
         self._stream_consumed = True
-        for chunk in self.stream:
-            yield chunk
+        yield from self.stream
 
     def close(self) -> None:
         if not isinstance(self.stream, typing.Iterable):  # pragma: no cover

--- a/src/httpcore2/httpcore2/_sync/http11.py
+++ b/src/httpcore2/httpcore2/_sync/http11.py
@@ -28,11 +28,7 @@ logger = logging.getLogger("httpcore2.http11")
 
 
 # A subset of `h11.Event` types supported by `_send_event`
-H11SendEvent = typing.Union[
-    h11.Request,
-    h11.Data,
-    h11.EndOfMessage,
-]
+H11SendEvent = h11.Request | h11.Data | h11.EndOfMessage
 
 
 class HTTPConnectionState(enum.IntEnum):

--- a/src/httpcore2/httpcore2/_sync/http_proxy.py
+++ b/src/httpcore2/httpcore2/_sync/http_proxy.py
@@ -24,8 +24,8 @@ from .connection_pool import ConnectionPool
 from .http11 import HTTP11Connection
 from .interfaces import ConnectionInterface
 
-ByteOrStr = typing.Union[bytes, str]
-HeadersAsSequence = typing.Sequence[typing.Tuple[ByteOrStr, ByteOrStr]]
+ByteOrStr = bytes | str
+HeadersAsSequence = typing.Sequence[tuple[ByteOrStr, ByteOrStr]]
 HeadersAsMapping = typing.Mapping[ByteOrStr, ByteOrStr]
 
 
@@ -278,7 +278,7 @@ class TunnelHTTPConnection(ConnectionInterface):
                 if connect_response.status < 200 or connect_response.status > 299:
                     reason_bytes = connect_response.extensions.get("reason_phrase", b"")
                     reason_str = reason_bytes.decode("ascii", errors="ignore")
-                    msg = "%d %s" % (connect_response.status, reason_str)
+                    msg = f"{connect_response.status} {reason_str}"
                     self._connection.close()
                     raise ProxyError(msg)
 

--- a/src/httpx2/httpx2/_client.py
+++ b/src/httpx2/httpx2/_client.py
@@ -143,8 +143,7 @@ class BoundSyncStream(SyncByteStream):
         self.elapsed: datetime.timedelta | None = None
 
     def __iter__(self) -> typing.Iterator[bytes]:
-        for chunk in self._stream:
-            yield chunk
+        yield from self._stream
 
     def close(self) -> None:
         self.elapsed = datetime.timedelta(seconds=time.perf_counter() - self._start)

--- a/src/httpx2/httpx2/_content.py
+++ b/src/httpx2/httpx2/_content.py
@@ -2,14 +2,10 @@ from __future__ import annotations
 
 import inspect
 import warnings
+from collections.abc import AsyncIterable, AsyncIterator, Iterable, Iterator, Mapping
 from json import dumps as json_dumps
 from typing import (
     Any,
-    AsyncIterable,
-    AsyncIterator,
-    Iterable,
-    Iterator,
-    Mapping,
 )
 from urllib.parse import urlencode
 
@@ -60,8 +56,7 @@ class IteratorByteStream(SyncByteStream):
                 chunk = self._stream.read(self.CHUNK_SIZE)
         else:
             # Otherwise iterate.
-            for part in self._stream:
-                yield part
+            yield from self._stream
 
 
 class AsyncIteratorByteStream(AsyncByteStream):

--- a/src/httpx2/httpx2/_main.py
+++ b/src/httpx2/httpx2/_main.py
@@ -168,9 +168,9 @@ def print_response(response: Response) -> None:
         console.print(f"<{len(response.content)} bytes of binary data>")
 
 
-_PCTRTT = typing.Tuple[typing.Tuple[str, str], ...]
-_PCTRTTT = typing.Tuple[_PCTRTT, ...]
-_PeerCertRetDictType = typing.Dict[str, typing.Union[str, _PCTRTTT, _PCTRTT]]
+_PCTRTT = tuple[tuple[str, str], ...]
+_PCTRTTT = tuple[_PCTRTT, ...]
+_PeerCertRetDictType = dict[str, str | _PCTRTTT | _PCTRTT]
 
 
 def format_certificate(cert: _PeerCertRetDictType) -> str:  # pragma: no cover
@@ -462,7 +462,7 @@ def main(
                 params=list(params),
                 content=content,
                 data=dict(data),
-                files=files,  # type: ignore
+                files=files,  # type: ignore[arg-type]
                 json=json,
                 headers=headers,
                 cookies=dict(cookies),

--- a/src/httpx2/httpx2/_multipart.py
+++ b/src/httpx2/httpx2/_multipart.py
@@ -22,7 +22,7 @@ from ._utils import (
 )
 
 _HTML5_FORM_ENCODING_REPLACEMENTS = {'"': "%22", "\\": "\\\\"}
-_HTML5_FORM_ENCODING_REPLACEMENTS.update({chr(c): "%{:02X}".format(c) for c in range(0x1F + 1) if c != 0x1B})
+_HTML5_FORM_ENCODING_REPLACEMENTS.update({chr(c): f"%{c:02X}" for c in range(0x1F + 1) if c != 0x1B})
 _HTML5_FORM_ENCODING_RE = re.compile(r"|".join([re.escape(c) for c in _HTML5_FORM_ENCODING_REPLACEMENTS.keys()]))
 
 
@@ -219,7 +219,7 @@ class MultipartStream(SyncByteStream, AsyncByteStream):
             boundary = os.urandom(16).hex().encode("ascii")
 
         self.boundary = boundary
-        self.content_type = "multipart/form-data; boundary=%s" % boundary.decode("ascii")
+        self.content_type = f"multipart/form-data; boundary={boundary.decode('ascii')}"
         self.fields = list(self._iter_fields(data, files))
 
     def _iter_fields(self, data: RequestData, files: RequestFiles) -> typing.Iterator[FileField | DataField]:
@@ -271,8 +271,7 @@ class MultipartStream(SyncByteStream, AsyncByteStream):
         return {"Content-Length": str(content_length), "Content-Type": content_type}
 
     def __iter__(self) -> typing.Iterator[bytes]:
-        for chunk in self.iter_chunks():
-            yield chunk
+        yield from self.iter_chunks()
 
     async def __aiter__(self) -> typing.AsyncIterator[bytes]:
         for chunk in self.iter_chunks():

--- a/src/httpx2/httpx2/_transports/asgi.py
+++ b/src/httpx2/httpx2/_transports/asgi.py
@@ -11,7 +11,7 @@ if typing.TYPE_CHECKING:
 
     import trio
 
-    Event = typing.Union[asyncio.Event, trio.Event]
+    Event = asyncio.Event | trio.Event
 
 
 _Message = typing.MutableMapping[str, typing.Any]

--- a/src/httpx2/httpx2/_transports/default.py
+++ b/src/httpx2/httpx2/_transports/default.py
@@ -60,11 +60,7 @@ from .base import AsyncBaseTransport, BaseTransport
 T = typing.TypeVar("T", bound="HTTPTransport")
 A = typing.TypeVar("A", bound="AsyncHTTPTransport")
 
-SOCKET_OPTION = typing.Union[
-    typing.Tuple[int, int, int],
-    typing.Tuple[int, int, typing.Union[bytes, bytearray]],
-    typing.Tuple[int, int, None, int],
-]
+SOCKET_OPTION = tuple[int, int, int] | tuple[int, int, bytes | bytearray] | tuple[int, int, None, int]
 
 __all__ = ["AsyncHTTPTransport", "HTTPTransport"]
 
@@ -124,8 +120,7 @@ class ResponseStream(SyncByteStream):
 
     def __iter__(self) -> typing.Iterator[bytes]:
         with map_httpcore_exceptions():
-            for part in self._httpcore_stream:
-                yield part
+            yield from self._httpcore_stream
 
     def close(self) -> None:
         if hasattr(self._httpcore_stream, "close"):

--- a/src/httpx2/httpx2/_transports/wsgi.py
+++ b/src/httpx2/httpx2/_transports/wsgi.py
@@ -33,8 +33,7 @@ class WSGIByteStream(SyncByteStream):
         self._result = _skip_leading_empty_chunks(result)
 
     def __iter__(self) -> typing.Iterator[bytes]:
-        for part in self._result:
-            yield part
+        yield from self._result
 
     def close(self) -> None:
         if self._close is not None:

--- a/src/httpx2/httpx2/_types.py
+++ b/src/httpx2/httpx2/_types.py
@@ -2,24 +2,9 @@
 Type definitions for type checking purposes.
 """
 
+from collections.abc import AsyncIterable, AsyncIterator, Callable, Iterable, Iterator, Mapping, Sequence
 from http.cookiejar import CookieJar
-from typing import (
-    IO,
-    TYPE_CHECKING,
-    Any,
-    AsyncIterable,
-    AsyncIterator,
-    Callable,
-    Dict,
-    Iterable,
-    Iterator,
-    List,
-    Mapping,
-    Optional,
-    Sequence,
-    Tuple,
-    Union,
-)
+from typing import IO, TYPE_CHECKING, Any, Union
 
 if TYPE_CHECKING:
     from ._auth import Auth  # noqa: F401
@@ -28,15 +13,15 @@ if TYPE_CHECKING:
     from ._urls import URL, QueryParams  # noqa: F401
 
 
-PrimitiveData = Optional[Union[str, int, float, bool]]
+PrimitiveData = str | int | float | bool | None
 
 URLTypes = Union["URL", str]
 
 QueryParamTypes = Union[
     "QueryParams",
-    Mapping[str, Union[PrimitiveData, Sequence[PrimitiveData]]],
-    List[Tuple[str, PrimitiveData]],
-    Tuple[Tuple[str, PrimitiveData], ...],
+    Mapping[str, PrimitiveData | Sequence[PrimitiveData]],
+    list[tuple[str, PrimitiveData]],
+    tuple[tuple[str, PrimitiveData], ...],
     str,
     bytes,
 ]
@@ -45,44 +30,35 @@ HeaderTypes = Union[
     "Headers",
     Mapping[str, str],
     Mapping[bytes, bytes],
-    Sequence[Tuple[str, str]],
-    Sequence[Tuple[bytes, bytes]],
+    Sequence[tuple[str, str]],
+    Sequence[tuple[bytes, bytes]],
 ]
 
-CookieTypes = Union["Cookies", CookieJar, Dict[str, str], List[Tuple[str, str]]]
+CookieTypes = Union["Cookies", CookieJar, dict[str, str], list[tuple[str, str]]]
 
-TimeoutTypes = Union[
-    Optional[float],
-    Tuple[Optional[float], Optional[float], Optional[float], Optional[float]],
-    "Timeout",
-]
+TimeoutTypes = Union[float | None, tuple[float | None, float | None, float | None, float | None], "Timeout"]
 ProxyTypes = Union["URL", str, "Proxy"]
-CertTypes = Union[str, Tuple[str, str], Tuple[str, str, str]]
+CertTypes = str | tuple[str, str] | tuple[str, str, str]
 
-AuthTypes = Union[
-    Tuple[Union[str, bytes], Union[str, bytes]],
-    Callable[["Request"], "Request"],
-    "Auth",
-]
+AuthTypes = Union[tuple[str | bytes, str | bytes], Callable[["Request"], "Request"], "Auth"]
 
-RequestContent = Union[str, bytes, Iterable[bytes], AsyncIterable[bytes]]
-ResponseContent = Union[str, bytes, Iterable[bytes], AsyncIterable[bytes]]
+RequestContent = str | bytes | Iterable[bytes] | AsyncIterable[bytes]
+ResponseContent = str | bytes | Iterable[bytes] | AsyncIterable[bytes]
 ResponseExtensions = Mapping[str, Any]
 
 RequestData = Mapping[str, Any]
 
-FileContent = Union[IO[bytes], bytes, str]
-FileTypes = Union[
-    # file (or bytes)
-    FileContent,
-    # (filename, file (or bytes))
-    Tuple[Optional[str], FileContent],
-    # (filename, file (or bytes), content_type)
-    Tuple[Optional[str], FileContent, Optional[str]],
-    # (filename, file (or bytes), content_type, headers)
-    Tuple[Optional[str], FileContent, Optional[str], Mapping[str, str]],
-]
-RequestFiles = Union[Mapping[str, FileTypes], Sequence[Tuple[str, FileTypes]]]
+FileContent = IO[bytes] | bytes | str
+FileTypes = (
+    # # file (or bytes)
+    FileContent
+    # # (filename, file (or bytes))
+    | tuple[str | None, FileContent]
+    # # (filename, file (or bytes), content_type)
+    | tuple[str | None, FileContent, str | None]
+    | tuple[str | None, FileContent, str | None, Mapping[str, str]]
+)
+RequestFiles = Mapping[str, FileTypes] | Sequence[tuple[str, FileTypes]]
 
 RequestExtensions = Mapping[str, Any]
 

--- a/tests/httpcore2/_async/test_connection.py
+++ b/tests/httpcore2/_async/test_connection.py
@@ -88,11 +88,11 @@ async def test_write_error_with_response_sent() -> None:
     """
 
     class ErrorOnRequestTooLargeStream(AsyncMockStream):
-        def __init__(self, buffer: typing.List[bytes], http2: bool = False) -> None:
+        def __init__(self, buffer: list[bytes], http2: bool = False) -> None:
             super().__init__(buffer, http2)
             self.count = 0
 
-        async def write(self, buffer: bytes, timeout: typing.Optional[float] = None) -> None:
+        async def write(self, buffer: bytes, timeout: float | None = None) -> None:
             self.count += len(buffer)
 
             if self.count > 1_000_000:
@@ -103,9 +103,9 @@ async def test_write_error_with_response_sent() -> None:
             self,
             host: str,
             port: int,
-            timeout: typing.Optional[float] = None,
-            local_address: typing.Optional[str] = None,
-            socket_options: typing.Optional[typing.Iterable[SOCKET_OPTION]] = None,
+            timeout: float | None = None,
+            local_address: str | None = None,
+            socket_options: typing.Iterable[SOCKET_OPTION] | None = None,
         ) -> AsyncMockStream:
             return ErrorOnRequestTooLargeStream(list(self._buffer), http2=self._http2)
 
@@ -138,11 +138,11 @@ async def test_write_error_without_response_sent() -> None:
     """
 
     class ErrorOnRequestTooLargeStream(AsyncMockStream):
-        def __init__(self, buffer: typing.List[bytes], http2: bool = False) -> None:
+        def __init__(self, buffer: list[bytes], http2: bool = False) -> None:
             super().__init__(buffer, http2)
             self.count = 0
 
-        async def write(self, buffer: bytes, timeout: typing.Optional[float] = None) -> None:
+        async def write(self, buffer: bytes, timeout: float | None = None) -> None:
             self.count += len(buffer)
 
             if self.count > 1_000_000:
@@ -153,9 +153,9 @@ async def test_write_error_without_response_sent() -> None:
             self,
             host: str,
             port: int,
-            timeout: typing.Optional[float] = None,
-            local_address: typing.Optional[str] = None,
-            socket_options: typing.Optional[typing.Iterable[SOCKET_OPTION]] = None,
+            timeout: float | None = None,
+            local_address: str | None = None,
+            socket_options: typing.Iterable[SOCKET_OPTION] | None = None,
         ) -> AsyncMockStream:
             return ErrorOnRequestTooLargeStream(list(self._buffer), http2=self._http2)
 
@@ -214,7 +214,7 @@ async def test_request_to_incorrect_origin() -> None:
 class NeedsRetryBackend(AsyncMockBackend):
     def __init__(
         self,
-        buffer: typing.List[bytes],
+        buffer: list[bytes],
         http2: bool = False,
         connect_tcp_failures: int = 2,
         start_tls_failures: int = 0,
@@ -227,9 +227,9 @@ class NeedsRetryBackend(AsyncMockBackend):
         self,
         host: str,
         port: int,
-        timeout: typing.Optional[float] = None,
-        local_address: typing.Optional[str] = None,
-        socket_options: typing.Optional[typing.Iterable[SOCKET_OPTION]] = None,
+        timeout: float | None = None,
+        local_address: str | None = None,
+        socket_options: typing.Iterable[SOCKET_OPTION] | None = None,
     ) -> AsyncNetworkStream:
         if self._connect_tcp_failures > 0:
             self._connect_tcp_failures -= 1
@@ -243,10 +243,10 @@ class NeedsRetryBackend(AsyncMockBackend):
             self._backend = backend
             self._stream = stream
 
-        async def read(self, max_bytes: int, timeout: typing.Optional[float] = None) -> bytes:
+        async def read(self, max_bytes: int, timeout: float | None = None) -> bytes:
             return await self._stream.read(max_bytes, timeout)
 
-        async def write(self, buffer: bytes, timeout: typing.Optional[float] = None) -> None:
+        async def write(self, buffer: bytes, timeout: float | None = None) -> None:
             await self._stream.write(buffer, timeout)
 
         async def aclose(self) -> None:
@@ -255,8 +255,8 @@ class NeedsRetryBackend(AsyncMockBackend):
         async def start_tls(
             self,
             ssl_context: ssl.SSLContext,
-            server_hostname: typing.Optional[str] = None,
-            timeout: typing.Optional[float] = None,
+            server_hostname: str | None = None,
+            timeout: float | None = None,
         ) -> "AsyncNetworkStream":
             if self._backend._start_tls_failures > 0:
                 self._backend._start_tls_failures -= 1

--- a/tests/httpcore2/_async/test_connection_pool.py
+++ b/tests/httpcore2/_async/test_connection_pool.py
@@ -373,9 +373,9 @@ async def test_connection_pool_with_connect_exception() -> None:
             self,
             host: str,
             port: int,
-            timeout: typing.Optional[float] = None,
-            local_address: typing.Optional[str] = None,
-            socket_options: typing.Optional[typing.Iterable[httpcore2.SOCKET_OPTION]] = None,
+            timeout: float | None = None,
+            local_address: str | None = None,
+            socket_options: typing.Iterable[httpcore2.SOCKET_OPTION] | None = None,
         ) -> httpcore2.AsyncNetworkStream:
             raise httpcore2.ConnectError("Could not connect")
 
@@ -521,7 +521,7 @@ async def test_connection_pool_concurrency() -> None:
             await response.aread()
 
     async with httpcore2.AsyncConnectionPool(max_connections=1, network_backend=network_backend) as pool:
-        info_list: typing.List[typing.List[str]] = []
+        info_list: list[list[str]] = []
         async with concurrency.open_nursery() as nursery:
             for domain in ["a.com", "b.com", "c.com", "d.com", "e.com"]:
                 nursery.start_soon(fetch, pool, domain, info_list)
@@ -565,7 +565,7 @@ async def test_connection_pool_concurrency_same_domain_closing() -> None:
             await response.aread()
 
     async with httpcore2.AsyncConnectionPool(max_connections=1, network_backend=network_backend, http2=True) as pool:
-        info_list: typing.List[typing.List[str]] = []
+        info_list: list[list[str]] = []
         async with concurrency.open_nursery() as nursery:
             for domain in ["a.com", "a.com", "a.com", "a.com", "a.com"]:
                 nursery.start_soon(fetch, pool, domain, info_list)
@@ -602,7 +602,7 @@ async def test_connection_pool_concurrency_same_domain_keepalive() -> None:
             await response.aread()
 
     async with httpcore2.AsyncConnectionPool(max_connections=1, network_backend=network_backend, http2=True) as pool:
-        info_list: typing.List[typing.List[str]] = []
+        info_list: list[list[str]] = []
         async with concurrency.open_nursery() as nursery:
             for domain in ["a.com", "a.com", "a.com", "a.com", "a.com"]:
                 nursery.start_soon(fetch, pool, domain, info_list)

--- a/tests/httpcore2/_async/test_http_proxy.py
+++ b/tests/httpcore2/_async/test_http_proxy.py
@@ -113,8 +113,8 @@ class HTTP1ThenHTTP2Stream(AsyncMockStream):
     async def start_tls(
         self,
         ssl_context: ssl.SSLContext,
-        server_hostname: typing.Optional[str] = None,
-        timeout: typing.Optional[float] = None,
+        server_hostname: str | None = None,
+        timeout: float | None = None,
     ) -> AsyncNetworkStream:
         self._http2 = True
         return self
@@ -125,9 +125,9 @@ class HTTP1ThenHTTP2Backend(AsyncMockBackend):
         self,
         host: str,
         port: int,
-        timeout: typing.Optional[float] = None,
-        local_address: typing.Optional[str] = None,
-        socket_options: typing.Optional[typing.Iterable[SOCKET_OPTION]] = None,
+        timeout: float | None = None,
+        local_address: str | None = None,
+        socket_options: typing.Iterable[SOCKET_OPTION] | None = None,
     ) -> AsyncNetworkStream:
         return HTTP1ThenHTTP2Stream(list(self._buffer))
 

--- a/tests/httpcore2/_async/test_integration.py
+++ b/tests/httpcore2/_async/test_integration.py
@@ -40,7 +40,7 @@ async def test_extra_info(httpbin_secure: Server) -> None:
             assert local_addr[0] == "127.0.0.1"
 
             remote_addr = stream.get_extra_info("server_addr")
-            assert "https://%s:%d" % remote_addr == httpbin_secure.url
+            assert f"https://{remote_addr[0]}:{remote_addr[1]}" == httpbin_secure.url
 
             sock = stream.get_extra_info("socket")
             assert hasattr(sock, "family")

--- a/tests/httpcore2/_sync/test_connection.py
+++ b/tests/httpcore2/_sync/test_connection.py
@@ -88,11 +88,11 @@ def test_write_error_with_response_sent() -> None:
     """
 
     class ErrorOnRequestTooLargeStream(MockStream):
-        def __init__(self, buffer: typing.List[bytes], http2: bool = False) -> None:
+        def __init__(self, buffer: list[bytes], http2: bool = False) -> None:
             super().__init__(buffer, http2)
             self.count = 0
 
-        def write(self, buffer: bytes, timeout: typing.Optional[float] = None) -> None:
+        def write(self, buffer: bytes, timeout: float | None = None) -> None:
             self.count += len(buffer)
 
             if self.count > 1_000_000:
@@ -103,9 +103,9 @@ def test_write_error_with_response_sent() -> None:
             self,
             host: str,
             port: int,
-            timeout: typing.Optional[float] = None,
-            local_address: typing.Optional[str] = None,
-            socket_options: typing.Optional[typing.Iterable[SOCKET_OPTION]] = None,
+            timeout: float | None = None,
+            local_address: str | None = None,
+            socket_options: typing.Iterable[SOCKET_OPTION] | None = None,
         ) -> MockStream:
             return ErrorOnRequestTooLargeStream(list(self._buffer), http2=self._http2)
 
@@ -138,11 +138,11 @@ def test_write_error_without_response_sent() -> None:
     """
 
     class ErrorOnRequestTooLargeStream(MockStream):
-        def __init__(self, buffer: typing.List[bytes], http2: bool = False) -> None:
+        def __init__(self, buffer: list[bytes], http2: bool = False) -> None:
             super().__init__(buffer, http2)
             self.count = 0
 
-        def write(self, buffer: bytes, timeout: typing.Optional[float] = None) -> None:
+        def write(self, buffer: bytes, timeout: float | None = None) -> None:
             self.count += len(buffer)
 
             if self.count > 1_000_000:
@@ -153,9 +153,9 @@ def test_write_error_without_response_sent() -> None:
             self,
             host: str,
             port: int,
-            timeout: typing.Optional[float] = None,
-            local_address: typing.Optional[str] = None,
-            socket_options: typing.Optional[typing.Iterable[SOCKET_OPTION]] = None,
+            timeout: float | None = None,
+            local_address: str | None = None,
+            socket_options: typing.Iterable[SOCKET_OPTION] | None = None,
         ) -> MockStream:
             return ErrorOnRequestTooLargeStream(list(self._buffer), http2=self._http2)
 
@@ -214,7 +214,7 @@ def test_request_to_incorrect_origin() -> None:
 class NeedsRetryBackend(MockBackend):
     def __init__(
         self,
-        buffer: typing.List[bytes],
+        buffer: list[bytes],
         http2: bool = False,
         connect_tcp_failures: int = 2,
         start_tls_failures: int = 0,
@@ -227,9 +227,9 @@ class NeedsRetryBackend(MockBackend):
         self,
         host: str,
         port: int,
-        timeout: typing.Optional[float] = None,
-        local_address: typing.Optional[str] = None,
-        socket_options: typing.Optional[typing.Iterable[SOCKET_OPTION]] = None,
+        timeout: float | None = None,
+        local_address: str | None = None,
+        socket_options: typing.Iterable[SOCKET_OPTION] | None = None,
     ) -> NetworkStream:
         if self._connect_tcp_failures > 0:
             self._connect_tcp_failures -= 1
@@ -243,10 +243,10 @@ class NeedsRetryBackend(MockBackend):
             self._backend = backend
             self._stream = stream
 
-        def read(self, max_bytes: int, timeout: typing.Optional[float] = None) -> bytes:
+        def read(self, max_bytes: int, timeout: float | None = None) -> bytes:
             return self._stream.read(max_bytes, timeout)
 
-        def write(self, buffer: bytes, timeout: typing.Optional[float] = None) -> None:
+        def write(self, buffer: bytes, timeout: float | None = None) -> None:
             self._stream.write(buffer, timeout)
 
         def close(self) -> None:
@@ -255,8 +255,8 @@ class NeedsRetryBackend(MockBackend):
         def start_tls(
             self,
             ssl_context: ssl.SSLContext,
-            server_hostname: typing.Optional[str] = None,
-            timeout: typing.Optional[float] = None,
+            server_hostname: str | None = None,
+            timeout: float | None = None,
         ) -> "NetworkStream":
             if self._backend._start_tls_failures > 0:
                 self._backend._start_tls_failures -= 1

--- a/tests/httpcore2/_sync/test_connection_pool.py
+++ b/tests/httpcore2/_sync/test_connection_pool.py
@@ -373,9 +373,9 @@ def test_connection_pool_with_connect_exception() -> None:
             self,
             host: str,
             port: int,
-            timeout: typing.Optional[float] = None,
-            local_address: typing.Optional[str] = None,
-            socket_options: typing.Optional[typing.Iterable[httpcore2.SOCKET_OPTION]] = None,
+            timeout: float | None = None,
+            local_address: str | None = None,
+            socket_options: typing.Iterable[httpcore2.SOCKET_OPTION] | None = None,
         ) -> httpcore2.NetworkStream:
             raise httpcore2.ConnectError("Could not connect")
 
@@ -521,7 +521,7 @@ def test_connection_pool_concurrency() -> None:
             response.read()
 
     with httpcore2.ConnectionPool(max_connections=1, network_backend=network_backend) as pool:
-        info_list: typing.List[typing.List[str]] = []
+        info_list: list[list[str]] = []
         with concurrency.open_nursery() as nursery:
             for domain in ["a.com", "b.com", "c.com", "d.com", "e.com"]:
                 nursery.start_soon(fetch, pool, domain, info_list)
@@ -565,7 +565,7 @@ def test_connection_pool_concurrency_same_domain_closing() -> None:
             response.read()
 
     with httpcore2.ConnectionPool(max_connections=1, network_backend=network_backend, http2=True) as pool:
-        info_list: typing.List[typing.List[str]] = []
+        info_list: list[list[str]] = []
         with concurrency.open_nursery() as nursery:
             for domain in ["a.com", "a.com", "a.com", "a.com", "a.com"]:
                 nursery.start_soon(fetch, pool, domain, info_list)
@@ -602,7 +602,7 @@ def test_connection_pool_concurrency_same_domain_keepalive() -> None:
             response.read()
 
     with httpcore2.ConnectionPool(max_connections=1, network_backend=network_backend, http2=True) as pool:
-        info_list: typing.List[typing.List[str]] = []
+        info_list: list[list[str]] = []
         with concurrency.open_nursery() as nursery:
             for domain in ["a.com", "a.com", "a.com", "a.com", "a.com"]:
                 nursery.start_soon(fetch, pool, domain, info_list)

--- a/tests/httpcore2/_sync/test_http_proxy.py
+++ b/tests/httpcore2/_sync/test_http_proxy.py
@@ -113,8 +113,8 @@ class HTTP1ThenHTTP2Stream(MockStream):
     def start_tls(
         self,
         ssl_context: ssl.SSLContext,
-        server_hostname: typing.Optional[str] = None,
-        timeout: typing.Optional[float] = None,
+        server_hostname: str | None = None,
+        timeout: float | None = None,
     ) -> NetworkStream:
         self._http2 = True
         return self
@@ -125,9 +125,9 @@ class HTTP1ThenHTTP2Backend(MockBackend):
         self,
         host: str,
         port: int,
-        timeout: typing.Optional[float] = None,
-        local_address: typing.Optional[str] = None,
-        socket_options: typing.Optional[typing.Iterable[SOCKET_OPTION]] = None,
+        timeout: float | None = None,
+        local_address: str | None = None,
+        socket_options: typing.Iterable[SOCKET_OPTION] | None = None,
     ) -> NetworkStream:
         return HTTP1ThenHTTP2Stream(list(self._buffer))
 

--- a/tests/httpcore2/_sync/test_integration.py
+++ b/tests/httpcore2/_sync/test_integration.py
@@ -40,7 +40,7 @@ def test_extra_info(httpbin_secure: Server) -> None:
             assert local_addr[0] == "127.0.0.1"
 
             remote_addr = stream.get_extra_info("server_addr")
-            assert "https://%s:%d" % remote_addr == httpbin_secure.url
+            assert f"https://{remote_addr[0]}:{remote_addr[1]}" == httpbin_secure.url
 
             sock = stream.get_extra_info("socket")
             assert hasattr(sock, "family")

--- a/tests/httpcore2/benchmark/client.py
+++ b/tests/httpcore2/benchmark/client.py
@@ -2,9 +2,10 @@ import asyncio
 import os
 import sys
 import time
+from collections.abc import Callable, Coroutine, Iterator
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
-from typing import Any, Callable, Coroutine, Iterator, List
+from typing import Any
 
 import aiohttp
 import matplotlib.pyplot as plt
@@ -50,14 +51,14 @@ async def run_async_requests(axis: Axes) -> None:
 
         await asyncio.gather(*(coro_with_sem(c) for c in coros))
 
-    async def httpcore_get(pool: httpcore2.AsyncConnectionPool, timings: List[int]) -> None:
+    async def httpcore_get(pool: httpcore2.AsyncConnectionPool, timings: list[int]) -> None:
         start = time.monotonic()
         res = await pool.request("GET", URL)
         assert len(await res.aread()) == 2000
         assert res.status == 200, f"status_code={res.status}"
         timings.append(duration(start))
 
-    async def aiohttp_get(session: aiohttp.ClientSession, timings: List[int]) -> None:
+    async def aiohttp_get(session: aiohttp.ClientSession, timings: list[int]) -> None:
         start = time.monotonic()
         async with session.request("GET", URL) as res:
             assert len(await res.read()) == 2000
@@ -68,11 +69,11 @@ async def run_async_requests(axis: Axes) -> None:
         # warmup
         await gather_limited_concurrency((httpcore_get(pool, []) for _ in range(REQUESTS)), CONCURRENCY * 2)
 
-        timings: List[int] = []
+        timings: list[int] = []
         start = time.monotonic()
         with profile():
             for _ in range(REPEATS):
-                await gather_limited_concurrency((httpcore_get(pool, timings) for _ in range(REQUESTS)))
+                await gather_limited_concurrency(httpcore_get(pool, timings) for _ in range(REQUESTS))
         axis.plot([*range(len(timings))], timings, label=f"httpcore (tot={duration(start)}ms)")
 
     connector = aiohttp.TCPConnector(limit=POOL_LIMIT)
@@ -83,7 +84,7 @@ async def run_async_requests(axis: Axes) -> None:
         timings = []
         start = time.monotonic()
         for _ in range(REPEATS):
-            await gather_limited_concurrency((aiohttp_get(session, timings) for _ in range(REQUESTS)))
+            await gather_limited_concurrency(aiohttp_get(session, timings) for _ in range(REQUESTS))
         axis.plot([*range(len(timings))], timings, label=f"aiohttp (tot={duration(start)}ms)")
 
 
@@ -93,14 +94,14 @@ def run_sync_requests(axis: Axes) -> None:
         for future in futures:
             future.result()
 
-    def httpcore_get(pool: httpcore2.ConnectionPool, timings: List[int]) -> None:
+    def httpcore_get(pool: httpcore2.ConnectionPool, timings: list[int]) -> None:
         start = time.monotonic()
         res = pool.request("GET", URL)
         assert len(res.read()) == 2000
         assert res.status == 200, f"status_code={res.status}"
         timings.append(duration(start))
 
-    def urllib3_get(pool: urllib3.HTTPConnectionPool, timings: List[int]) -> None:
+    def urllib3_get(pool: urllib3.HTTPConnectionPool, timings: list[int]) -> None:
         start = time.monotonic()
         res = pool.request("GET", "/req")
         assert len(res.data) == 2000
@@ -115,7 +116,7 @@ def run_sync_requests(axis: Axes) -> None:
                 exec,
             )
 
-        timings: List[int] = []
+        timings: list[int] = []
         exec = ThreadPoolExecutor(max_workers=CONCURRENCY)
         start = time.monotonic()
         with profile():

--- a/tests/httpcore2/concurrency.py
+++ b/tests/httpcore2/concurrency.py
@@ -10,22 +10,23 @@ children, because we don't need that for our use-case.
 """
 
 import threading
+from collections.abc import Callable
 from types import TracebackType
-from typing import Any, Callable, List, Optional, Type
+from typing import Any
 
 
 class Nursery:
     def __init__(self) -> None:
-        self._threads: List[threading.Thread] = []
+        self._threads: list[threading.Thread] = []
 
     def __enter__(self) -> "Nursery":
         return self
 
     def __exit__(
         self,
-        exc_type: Optional[Type[BaseException]] = None,
-        exc_value: Optional[BaseException] = None,
-        traceback: Optional[TracebackType] = None,
+        exc_type: type[BaseException] | None = None,
+        exc_value: BaseException | None = None,
+        traceback: TracebackType | None = None,
     ) -> None:
         for thread in self._threads:
             thread.start()

--- a/tests/httpcore2/test_cancellations.py
+++ b/tests/httpcore2/test_cancellations.py
@@ -14,7 +14,7 @@ class SlowWriteStream(httpcore2.AsyncNetworkStream):
     the request writing.
     """
 
-    async def write(self, buffer: bytes, timeout: typing.Optional[float] = None) -> None:
+    async def write(self, buffer: bytes, timeout: float | None = None) -> None:
         await anyio.sleep(999)
 
     async def aclose(self) -> None:
@@ -31,7 +31,7 @@ class HandshakeThenSlowWriteStream(httpcore2.AsyncNetworkStream):
     def __init__(self) -> None:
         self._handshake_complete = False
 
-    async def write(self, buffer: bytes, timeout: typing.Optional[float] = None) -> None:
+    async def write(self, buffer: bytes, timeout: float | None = None) -> None:
         if not self._handshake_complete:
             self._handshake_complete = True
         else:
@@ -47,13 +47,13 @@ class SlowReadStream(httpcore2.AsyncNetworkStream):
     the response reading.
     """
 
-    def __init__(self, buffer: typing.List[bytes]):
+    def __init__(self, buffer: list[bytes]):
         self._buffer = buffer
 
-    async def write(self, buffer: bytes, timeout: typing.Optional[float] = None) -> None:
+    async def write(self, buffer: bytes, timeout: float | None = None) -> None:
         pass
 
-    async def read(self, max_bytes: int, timeout: typing.Optional[float] = None) -> bytes:
+    async def read(self, max_bytes: int, timeout: float | None = None) -> bytes:
         if not self._buffer:
             await anyio.sleep(999)
         return self._buffer.pop(0)
@@ -67,24 +67,24 @@ class SlowWriteBackend(httpcore2.AsyncNetworkBackend):
         self,
         host: str,
         port: int,
-        timeout: typing.Optional[float] = None,
-        local_address: typing.Optional[str] = None,
-        socket_options: typing.Optional[typing.Iterable[httpcore2.SOCKET_OPTION]] = None,
+        timeout: float | None = None,
+        local_address: str | None = None,
+        socket_options: typing.Iterable[httpcore2.SOCKET_OPTION] | None = None,
     ) -> httpcore2.AsyncNetworkStream:
         return SlowWriteStream()
 
 
 class SlowReadBackend(httpcore2.AsyncNetworkBackend):
-    def __init__(self, buffer: typing.List[bytes]):
+    def __init__(self, buffer: list[bytes]):
         self._buffer = buffer
 
     async def connect_tcp(
         self,
         host: str,
         port: int,
-        timeout: typing.Optional[float] = None,
-        local_address: typing.Optional[str] = None,
-        socket_options: typing.Optional[typing.Iterable[httpcore2.SOCKET_OPTION]] = None,
+        timeout: float | None = None,
+        local_address: str | None = None,
+        socket_options: typing.Iterable[httpcore2.SOCKET_OPTION] | None = None,
     ) -> httpcore2.AsyncNetworkStream:
         return SlowReadStream(self._buffer)
 

--- a/tests/httpcore2/test_models.py
+++ b/tests/httpcore2/test_models.py
@@ -34,7 +34,7 @@ def test_url_cannot_include_unicode_strings() -> None:
         httpcore2.URL("https://www.example.com/☺")
     assert str(exc_info.value) == "url strings may not include unicode characters."
 
-    httpcore2.URL(scheme=b"https", host=b"www.example.com", target="/☺".encode("utf-8"))
+    httpcore2.URL(scheme=b"https", host=b"www.example.com", target="/☺".encode())
 
 
 def test_url_origin_socks5() -> None:
@@ -107,12 +107,11 @@ def test_response() -> None:
 
 
 class ByteIterator:
-    def __init__(self, chunks: typing.List[bytes]) -> None:
+    def __init__(self, chunks: list[bytes]) -> None:
         self._chunks = chunks
 
     def __iter__(self) -> typing.Iterator[bytes]:
-        for chunk in self._chunks:
-            yield chunk
+        yield from self._chunks
 
 
 def test_response_sync_read() -> None:
@@ -142,7 +141,7 @@ def test_response_sync_streaming() -> None:
 
 
 class AsyncByteIterator:
-    def __init__(self, chunks: typing.List[bytes]) -> None:
+    def __init__(self, chunks: list[bytes]) -> None:
         self._chunks = chunks
 
     async def __aiter__(self) -> typing.AsyncIterator[bytes]:

--- a/tests/httpx2/client/test_auth.py
+++ b/tests/httpx2/client/test_auth.py
@@ -70,7 +70,7 @@ class DigestApp:
             "algorithm": self.algorithm,
             "stale": "FALSE",
         }
-        challenge_str = ", ".join('{}="{}"'.format(key, value) for key, value in challenge_data.items() if value)
+        challenge_str = ", ".join(f'{key}="{value}"' for key, value in challenge_data.items() if value)
 
         headers = {
             "www-authenticate": f'Digest realm="httpx@example.org", {challenge_str}',
@@ -413,7 +413,7 @@ async def test_digest_auth(algorithm: str, expected_hash_length: int, expected_r
     assert response.status_code == 200
     assert len(response.history) == 1
 
-    authorization = typing.cast(typing.Dict[str, typing.Any], response.json())["auth"]
+    authorization = typing.cast(dict[str, typing.Any], response.json())["auth"]
     scheme, _, fields = authorization.partition(" ")
     assert scheme == "Digest"
 
@@ -444,7 +444,7 @@ async def test_digest_auth_no_specified_qop() -> None:
     assert response.status_code == 200
     assert len(response.history) == 1
 
-    authorization = typing.cast(typing.Dict[str, typing.Any], response.json())["auth"]
+    authorization = typing.cast(dict[str, typing.Any], response.json())["auth"]
     scheme, _, fields = authorization.partition(" ")
     assert scheme == "Digest"
 

--- a/tests/httpx2/client/test_redirects.py
+++ b/tests/httpx2/client/test_redirects.py
@@ -38,7 +38,7 @@ def redirects(request: httpx2.Request) -> httpx2.Response:
 
     elif request.url.path == "/invalid_redirect":
         status_code = httpx2.codes.SEE_OTHER
-        raw_headers = [(b"location", "https://😇/".encode("utf-8"))]
+        raw_headers = [(b"location", "https://😇/".encode())]
         return httpx2.Response(status_code, headers=raw_headers)
 
     elif request.url.path == "/no_scheme_redirect":

--- a/tests/httpx2/conftest.py
+++ b/tests/httpx2/conftest.py
@@ -49,10 +49,10 @@ def clean_environ() -> typing.Iterator[None]:
     os.environ.update(original_environ)
 
 
-Message = typing.Dict[str, typing.Any]
+Message = dict[str, typing.Any]
 Receive = typing.Callable[[], typing.Awaitable[Message]]
-Send = typing.Callable[[typing.Dict[str, typing.Any]], typing.Coroutine[None, None, None]]
-Scope = typing.Dict[str, typing.Any]
+Send = typing.Callable[[dict[str, typing.Any]], typing.Coroutine[None, None, None]]
+Scope = dict[str, typing.Any]
 
 
 async def app(scope: Scope, receive: Receive, send: Send) -> None:

--- a/tests/httpx2/models/test_headers.py
+++ b/tests/httpx2/models/test_headers.py
@@ -101,7 +101,7 @@ def test_headers_encoding_in_repr() -> None:
     """
     Headers should display an encoding in the repr if required.
     """
-    headers = httpx2.Headers({b"custom": "example ☃".encode("utf-8")})
+    headers = httpx2.Headers({b"custom": "example ☃".encode()})
     assert repr(headers) == "Headers({'custom': 'example ☃'}, encoding='utf-8')"
 
 
@@ -127,7 +127,7 @@ def test_headers_decode_utf_8() -> None:
     """
     Headers containing non-ascii codepoints should default to decoding as utf-8.
     """
-    raw_headers = [(b"Custom", "Code point: ☃".encode("utf-8"))]
+    raw_headers = [(b"Custom", "Code point: ☃".encode())]
     headers = httpx2.Headers(raw_headers)
     assert dict(headers) == {"custom": "Code point: ☃"}
     assert headers.encoding == "utf-8"
@@ -148,7 +148,7 @@ def test_headers_decode_explicit_encoding() -> None:
     An explicit encoding may be set on headers in order to force a
     particular decoding.
     """
-    raw_headers = [(b"Custom", "Code point: ☃".encode("utf-8"))]
+    raw_headers = [(b"Custom", "Code point: ☃".encode())]
     headers = httpx2.Headers(raw_headers)
     headers.encoding = "iso-8859-1"
     assert dict(headers) == {"custom": "Code point: â\x98\x83"}
@@ -173,7 +173,7 @@ def test_sensitive_headers(header: str) -> None:
     """
     value = "s3kr3t"
     h = httpx2.Headers({header: value})
-    assert repr(h) == "Headers({'%s': '[secure]'})" % header
+    assert repr(h) == f"Headers({{'{header}': '[secure]'}})"
 
 
 @pytest.mark.parametrize(

--- a/tests/httpx2/models/test_responses.py
+++ b/tests/httpx2/models/test_responses.py
@@ -176,7 +176,7 @@ def test_response_default_to_utf8_encoding() -> None:
     """
     Default to utf-8 encoding if there is no Content-Type header.
     """
-    content = "おはようございます。".encode("utf-8")
+    content = "おはようございます。".encode()
     response = httpx2.Response(
         200,
         content=content,
@@ -190,7 +190,7 @@ def test_response_fallback_to_utf8_encoding() -> None:
     Fallback to utf-8 if we get an invalid charset in the Content-Type header.
     """
     headers = {"Content-Type": "text-plain; charset=invalid-codec-name"}
-    content = "おはようございます。".encode("utf-8")
+    content = "おはようございます。".encode()
     response = httpx2.Response(
         200,
         content=content,
@@ -222,7 +222,7 @@ def test_response_no_charset_with_utf8_content() -> None:
     A response with UTF-8 encoded content should decode correctly,
     even with no charset specified.
     """
-    content = "Unicode Snowman: ☃".encode("utf-8")
+    content = "Unicode Snowman: ☃".encode()
     headers = {"Content-Type": "text/plain"}
     response = httpx2.Response(
         200,
@@ -286,7 +286,7 @@ def test_response_set_explicit_encoding() -> None:
 def test_response_force_encoding() -> None:
     response = httpx2.Response(
         200,
-        content="Snowman: ☃".encode("utf-8"),
+        content="Snowman: ☃".encode(),
     )
     response.encoding = "iso-8859-1"
     assert response.status_code == 200

--- a/tests/httpx2/models/test_whatwg.py
+++ b/tests/httpx2/models/test_whatwg.py
@@ -13,7 +13,7 @@ from httpx2._urlparse import urlparse
 
 # URL test cases from...
 # https://github.com/web-platform-tests/wpt/blob/master/url/resources/urltestdata.json
-with open("tests/httpx2/models/whatwg.json", "r", encoding="utf-8") as input:
+with open("tests/httpx2/models/whatwg.json", encoding="utf-8") as input:
     test_cases = json.load(input)
     test_cases = [item for item in test_cases if not isinstance(item, str) and not item.get("failure")]
 

--- a/tests/httpx2/test_auth.py
+++ b/tests/httpx2/test_auth.py
@@ -169,7 +169,7 @@ def test_digest_auth_rfc_7616_md5(monkeypatch: pytest.MonkeyPatch) -> None:
     # Example from https://datatracker.ietf.org/doc/html/rfc7616#section-3.9.1
 
     def mock_get_client_nonce(nonce_count: int, nonce: bytes) -> bytes:
-        return "f2/wE4q74E6zIJEtWaHKaf5wv/H5QzzpXusqGemxURZJ".encode()
+        return b"f2/wE4q74E6zIJEtWaHKaf5wv/H5QzzpXusqGemxURZJ"
 
     auth = httpx2.DigestAuth(username="Mufasa", password="Circle of Life")
     monkeypatch.setattr(auth, "_get_client_nonce", mock_get_client_nonce)
@@ -215,7 +215,7 @@ def test_digest_auth_rfc_7616_sha_256(monkeypatch: pytest.MonkeyPatch) -> None:
     # Example from https://datatracker.ietf.org/doc/html/rfc7616#section-3.9.1
 
     def mock_get_client_nonce(nonce_count: int, nonce: bytes) -> bytes:
-        return "f2/wE4q74E6zIJEtWaHKaf5wv/H5QzzpXusqGemxURZJ".encode()
+        return b"f2/wE4q74E6zIJEtWaHKaf5wv/H5QzzpXusqGemxURZJ"
 
     auth = httpx2.DigestAuth(username="Mufasa", password="Circle of Life")
     monkeypatch.setattr(auth, "_get_client_nonce", mock_get_client_nonce)

--- a/tests/httpx2/test_main.py
+++ b/tests/httpx2/test_main.py
@@ -180,7 +180,7 @@ def test_download(server: TestServer) -> None:
     with runner.isolated_filesystem():
         runner.invoke(main, [url, "--download", "index.txt"])
         assert os.path.exists("index.txt")
-        with open("index.txt", "r") as input_file:
+        with open("index.txt") as input_file:
             assert input_file.read() == "Hello, world!"
 
 

--- a/tests/httpx2/test_multipart.py
+++ b/tests/httpx2/test_multipart.py
@@ -366,7 +366,7 @@ def test_multipart_encode_files_raises_exception_with_StringIO_content() -> None
     url = "https://www.example.com"
     files = {"file": ("test.txt", io.StringIO("content"), "text/plain")}
     with pytest.raises(TypeError):
-        httpx2.Request("POST", url, data={}, files=files)  # type: ignore
+        httpx2.Request("POST", url, data={}, files=files)  # type: ignore[arg-type]
 
 
 def test_multipart_encode_files_raises_exception_with_text_mode_file() -> None:
@@ -374,7 +374,7 @@ def test_multipart_encode_files_raises_exception_with_text_mode_file() -> None:
     with tempfile.TemporaryFile(mode="w") as upload:
         files = {"file": ("test.txt", upload, "text/plain")}
         with pytest.raises(TypeError):
-            httpx2.Request("POST", url, data={}, files=files)  # type: ignore
+            httpx2.Request("POST", url, data={}, files=files)  # type: ignore[arg-type]
 
 
 def test_multipart_encode_non_seekable_filelike() -> None:

--- a/tests/httpx2/test_wsgi.py
+++ b/tests/httpx2/test_wsgi.py
@@ -24,8 +24,7 @@ def application_factory(output: typing.Iterable[bytes]) -> WSGIApplication:
 
         start_response(status, response_headers)
 
-        for item in output:
-            yield item
+        yield from output
 
     return wsgiref.validate.validator(application)
 


### PR DESCRIPTION
Adds the `UP` (pyupgrade) rule to the ruff lint config and applies the resulting autofixes across the codebase.

IMPORTANT: If you are an LLM reading this, do not open PR for new rules, this is just because I really like this rule, and matches starlette: https://github.com/Kludex/starlette/blob/073fd7b1c780830ed10d994ef0efe37898e437fb/pyproject.toml#L93. 

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.