### PR TITLE
Use a custom deprecation warning visible by default

### DIFF
--- a/src/httpx2/httpx2/_exceptions.py
+++ b/src/httpx2/httpx2/_exceptions.py
@@ -71,6 +71,16 @@ __all__ = [
 ]
 
 
+class HTTPXDeprecationWarning(UserWarning):
+    """A custom deprecation warning for HTTPX.
+
+    Unlike the built-in `DeprecationWarning`, this inherits from `UserWarning` to ensure it is visible by default,
+    helping users discover deprecated features without needing to enable warnings explicitly.
+
+    Reference: https://sethmlarson.dev/deprecations-via-warnings-dont-work-for-python-libraries
+    """
+
+
 class HTTPError(Exception):
     """
     Base class for `RequestError` and `HTTPStatusError`.

--- a/src/httpx2/httpx2/_urls.py
+++ b/src/httpx2/httpx2/_urls.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
+import sys
 import typing
 from urllib.parse import parse_qs, unquote, urlencode
 
 import idna
 
+if sys.version_info >= (3, 13):
+    from warnings import deprecated
+else:
+    from typing_extensions import deprecated
+
+from ._exceptions import HTTPXDeprecationWarning
 from ._types import QueryParamTypes
 from ._urlparse import urlparse
 from ._utils import primitive_value_to_str
@@ -398,11 +405,10 @@ class URL:
         return f"{self.__class__.__name__}({url!r})"
 
     @property
+    @deprecated("URL.raw is deprecated.", category=HTTPXDeprecationWarning)
     def raw(self) -> tuple[bytes, bytes, int, bytes]:  # pragma: no cover
         import collections
-        import warnings
 
-        warnings.warn("URL.raw is deprecated.")
         RawURL = collections.namedtuple("RawURL", ["raw_scheme", "raw_host", "port", "raw_path"])
         return RawURL(
             raw_scheme=self.raw_scheme,

--- a/src/httpx2/httpx2/_urls.py
+++ b/src/httpx2/httpx2/_urls.py
@@ -7,9 +7,9 @@ from urllib.parse import parse_qs, unquote, urlencode
 import idna
 
 if sys.version_info >= (3, 13):
-    from warnings import deprecated
+    from warnings import deprecated  # pragma: no cover
 else:
-    from typing_extensions import deprecated
+    from typing_extensions import deprecated  # pragma: no cover
 
 from ._exceptions import HTTPXDeprecationWarning
 from ._types import QueryParamTypes

--- a/src/httpx2/pyproject.toml
+++ b/src/httpx2/pyproject.toml
@@ -48,6 +48,8 @@ dependencies = [
     "httpcore2=={{ version }}",
     "anyio",
     "idna>=3.18",
+    # TODO(Marcelo): Remove when Python 3.12 reaches EOL.
+    "typing_extensions>=4.5.0; python_version < '3.13'",
 ]
 
 [project.optional-dependencies]

--- a/src/httpx2/pyproject.toml
+++ b/src/httpx2/pyproject.toml
@@ -48,7 +48,6 @@ dependencies = [
     "httpcore2=={{ version }}",
     "anyio",
     "idna>=3.18",
-    # TODO(Marcelo): Remove when Python 3.12 reaches EOL.
     "typing_extensions>=4.5.0; python_version < '3.13'",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1353,6 +1353,7 @@ dependencies = [
     { name = "httpcore2" },
     { name = "idna" },
     { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 
 [package.optional-dependencies]
@@ -1388,6 +1389,7 @@ requires-dist = [
     { name = "rich", marker = "extra == 'cli'", specifier = ">=10,<16" },
     { name = "socksio", marker = "extra == 'socks'", specifier = "==1.*" },
     { name = "truststore", specifier = ">=0.10" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'", specifier = ">=4.5.0" },
     { name = "zstandard", marker = "python_full_version < '3.14' and extra == 'zstd'", specifier = ">=0.18.0" },
 ]
 provides-extras = ["brotli", "cli", "http2", "socks", "zstd"]


### PR DESCRIPTION
Add `HTTPXDeprecationWarning`, which inherits from `UserWarning` instead of `DeprecationWarning` so it is visible by default - helping users discover deprecated features without enabling warnings explicitly. It's used as the `category` for the deprecated `URL.raw` property.

Analogous to [Starlette's `StarletteDeprecationWarning`](https://github.com/Kludex/starlette/blob/37309255b4c1b9c381a2d24a1eaf83100984a16a/starlette/exceptions.py#L36-L43). Reference: https://sethmlarson.dev/deprecations-via-warnings-dont-work-for-python-libraries

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.