### PR TITLE
Make the code more strictly typed without changing the type checker

### DIFF
--- a/src/httpcore2/httpcore2/_api.py
+++ b/src/httpcore2/httpcore2/_api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import typing
+from collections.abc import Generator
 
 from ._models import URL, Extensions, HeaderTypes, Response
 from ._sync.connection_pool import ConnectionPool
@@ -55,7 +56,7 @@ def stream(
     headers: HeaderTypes = None,
     content: bytes | typing.Iterator[bytes] | None = None,
     extensions: Extensions | None = None,
-) -> typing.Iterator[Response]:
+) -> Generator[Response]:
     """
     Sends an HTTP request, returning the response within a content manager.
 

--- a/src/httpcore2/httpcore2/_async/http2.py
+++ b/src/httpcore2/httpcore2/_async/http2.py
@@ -14,11 +14,7 @@ import h2.exceptions
 import h2.settings
 
 from .._backends.base import AsyncNetworkStream
-from .._exceptions import (
-    ConnectionNotAvailable,
-    LocalProtocolError,
-    RemoteProtocolError,
-)
+from .._exceptions import ConnectionNotAvailable, LocalProtocolError, RemoteProtocolError
 from .._models import Origin, Request, Response
 from .._synchronization import AsyncLock, AsyncSemaphore, AsyncShieldCancellation
 from .._trace import Trace
@@ -29,7 +25,7 @@ logger = logging.getLogger("httpcore2.http2")
 
 
 def has_body_headers(request: Request) -> bool:
-    return any(k.lower() == b"content-length" or k.lower() == b"transfer-encoding" for k, v in request.headers)
+    return any(k.lower() == b"content-length" or k.lower() == b"transfer-encoding" for k, _v in request.headers)
 
 
 class HTTPConnectionState(enum.IntEnum):
@@ -276,7 +272,7 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
                 break
 
         status_code = 200
-        headers = []
+        headers: list[tuple[bytes, bytes]] = []
         assert event.headers is not None
         for k, v in event.headers:
             if k == b":status":

--- a/src/httpcore2/httpcore2/_async/http_proxy.py
+++ b/src/httpcore2/httpcore2/_async/http_proxy.py
@@ -42,7 +42,7 @@ def merge_headers(
     """
     default_headers = [] if default_headers is None else list(default_headers)
     override_headers = [] if override_headers is None else list(override_headers)
-    has_override = set(key.lower() for key, value in override_headers)
+    has_override = set(key.lower() for key, _value in override_headers)
     default_headers = [(key, value) for key, value in default_headers if key.lower() not in has_override]
     return default_headers + override_headers
 

--- a/src/httpcore2/httpcore2/_backends/anyio.py
+++ b/src/httpcore2/httpcore2/_backends/anyio.py
@@ -4,6 +4,8 @@ import ssl
 import typing
 
 import anyio
+import anyio.abc
+import anyio.streams.tls
 
 from .._exceptions import (
     ConnectError,
@@ -23,7 +25,7 @@ class AnyIOStream(AsyncNetworkStream):
         self._stream = stream
 
     async def read(self, max_bytes: int, timeout: float | None = None) -> bytes:
-        exc_map = {
+        exc_map: dict[type[Exception], type[Exception]] = {
             TimeoutError: ReadTimeout,
             anyio.BrokenResourceError: ReadError,
             anyio.ClosedResourceError: ReadError,
@@ -40,7 +42,7 @@ class AnyIOStream(AsyncNetworkStream):
         if not buffer:
             return
 
-        exc_map = {
+        exc_map: dict[type[Exception], type[Exception]] = {
             TimeoutError: WriteTimeout,
             anyio.BrokenResourceError: WriteError,
             anyio.ClosedResourceError: WriteError,
@@ -58,7 +60,7 @@ class AnyIOStream(AsyncNetworkStream):
         server_hostname: str | None = None,
         timeout: float | None = None,
     ) -> AsyncNetworkStream:
-        exc_map = {
+        exc_map: dict[type[Exception], type[Exception]] = {
             TimeoutError: ConnectTimeout,
             anyio.BrokenResourceError: ConnectError,
             anyio.EndOfStream: ConnectError,
@@ -105,7 +107,7 @@ class AnyIOBackend(AsyncNetworkBackend):
     ) -> AsyncNetworkStream:  # pragma: no cover
         if socket_options is None:
             socket_options = []
-        exc_map = {
+        exc_map: dict[type[Exception], type[Exception]] = {
             TimeoutError: ConnectTimeout,
             OSError: ConnectError,
             anyio.BrokenResourceError: ConnectError,
@@ -130,7 +132,7 @@ class AnyIOBackend(AsyncNetworkBackend):
     ) -> AsyncNetworkStream:  # pragma: no cover
         if socket_options is None:
             socket_options = []
-        exc_map = {
+        exc_map: dict[type[Exception], type[Exception]] = {
             TimeoutError: ConnectTimeout,
             OSError: ConnectError,
             anyio.BrokenResourceError: ConnectError,

--- a/src/httpcore2/httpcore2/_exceptions.py
+++ b/src/httpcore2/httpcore2/_exceptions.py
@@ -1,11 +1,14 @@
+from __future__ import annotations
+
 import contextlib
 import typing
+from collections.abc import Generator
 
 ExceptionMapping = typing.Mapping[type[Exception], type[Exception]]
 
 
 @contextlib.contextmanager
-def map_exceptions(map: ExceptionMapping) -> typing.Iterator[None]:
+def map_exceptions(map: ExceptionMapping) -> Generator[None]:
     try:
         yield
     except Exception as exc:  # noqa: PIE786

--- a/src/httpcore2/httpcore2/_models.py
+++ b/src/httpcore2/httpcore2/_models.py
@@ -113,7 +113,7 @@ def include_request_headers(
     url: URL,
     content: None | bytes | typing.Iterable[bytes] | typing.AsyncIterable[bytes],
 ) -> list[tuple[bytes, bytes]]:
-    headers_set = {k.lower() for k, v in headers}
+    headers_set = {k.lower() for k, _v in headers}
 
     if b"host" not in headers_set:
         default_port = DEFAULT_PORTS.get(url.scheme)

--- a/src/httpcore2/httpcore2/_sync/http2.py
+++ b/src/httpcore2/httpcore2/_sync/http2.py
@@ -14,11 +14,7 @@ import h2.exceptions
 import h2.settings
 
 from .._backends.base import NetworkStream
-from .._exceptions import (
-    ConnectionNotAvailable,
-    LocalProtocolError,
-    RemoteProtocolError,
-)
+from .._exceptions import ConnectionNotAvailable, LocalProtocolError, RemoteProtocolError
 from .._models import Origin, Request, Response
 from .._synchronization import Lock, Semaphore, ShieldCancellation
 from .._trace import Trace
@@ -29,7 +25,7 @@ logger = logging.getLogger("httpcore2.http2")
 
 
 def has_body_headers(request: Request) -> bool:
-    return any(k.lower() == b"content-length" or k.lower() == b"transfer-encoding" for k, v in request.headers)
+    return any(k.lower() == b"content-length" or k.lower() == b"transfer-encoding" for k, _v in request.headers)
 
 
 class HTTPConnectionState(enum.IntEnum):
@@ -276,7 +272,7 @@ class HTTP2Connection(ConnectionInterface):
                 break
 
         status_code = 200
-        headers = []
+        headers: list[tuple[bytes, bytes]] = []
         assert event.headers is not None
         for k, v in event.headers:
             if k == b":status":

--- a/src/httpcore2/httpcore2/_sync/http_proxy.py
+++ b/src/httpcore2/httpcore2/_sync/http_proxy.py
@@ -42,7 +42,7 @@ def merge_headers(
     """
     default_headers = [] if default_headers is None else list(default_headers)
     override_headers = [] if override_headers is None else list(override_headers)
-    has_override = set(key.lower() for key, value in override_headers)
+    has_override = set(key.lower() for key, _value in override_headers)
     default_headers = [(key, value) for key, value in default_headers if key.lower() not in has_override]
     return default_headers + override_headers
 

--- a/src/httpx2/httpx2/_api.py
+++ b/src/httpx2/httpx2/_api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import typing
+from collections.abc import Generator
 from contextlib import contextmanager
 
 from ._client import Client
@@ -125,7 +126,7 @@ def stream(
     follow_redirects: bool = False,
     verify: ssl.SSLContext | str | bool = True,
     trust_env: bool = True,
-) -> typing.Iterator[Response]:
+) -> Generator[Response]:
     """
     Alternative to `httpx2.request()` that streams the response body
     instead of loading it into memory at once.

--- a/src/httpx2/httpx2/_client.py
+++ b/src/httpx2/httpx2/_client.py
@@ -6,6 +6,7 @@ import logging
 import time
 import typing
 import warnings
+from collections.abc import AsyncGenerator, Generator
 from contextlib import asynccontextmanager, contextmanager
 from types import TracebackType
 
@@ -809,7 +810,7 @@ class Client(BaseClient):
         follow_redirects: bool | UseClientDefault = USE_CLIENT_DEFAULT,
         timeout: TimeoutTypes | UseClientDefault = USE_CLIENT_DEFAULT,
         extensions: RequestExtensions | None = None,
-    ) -> typing.Iterator[Response]:
+    ) -> Generator[Response]:
         """
         Alternative to `httpx2.request()` that streams the response body
         instead of loading it into memory at once.
@@ -1512,7 +1513,7 @@ class AsyncClient(BaseClient):
         follow_redirects: bool | UseClientDefault = USE_CLIENT_DEFAULT,
         timeout: TimeoutTypes | UseClientDefault = USE_CLIENT_DEFAULT,
         extensions: RequestExtensions | None = None,
-    ) -> typing.AsyncIterator[Response]:
+    ) -> AsyncGenerator[Response]:
         """
         Alternative to `httpx2.request()` that streams the response body
         instead of loading it into memory at once.

--- a/src/httpx2/httpx2/_config.py
+++ b/src/httpx2/httpx2/_config.py
@@ -89,6 +89,11 @@ class Timeout:
                                 # 5s timeout elsewhere.
     """
 
+    connect: float | None
+    read: float | None
+    write: float | None
+    pool: float | None
+
     def __init__(
         self,
         timeout: TimeoutTypes | UnsetType = UNSET,
@@ -104,10 +109,10 @@ class Timeout:
             assert read is UNSET
             assert write is UNSET
             assert pool is UNSET
-            self.connect = timeout.connect  # type: typing.Optional[float]
-            self.read = timeout.read  # type: typing.Optional[float]
-            self.write = timeout.write  # type: typing.Optional[float]
-            self.pool = timeout.pool  # type: typing.Optional[float]
+            self.connect = timeout.connect
+            self.read = timeout.read
+            self.write = timeout.write
+            self.pool = timeout.pool
         elif isinstance(timeout, tuple):
             # Passed as a tuple.
             self.connect = timeout[0]

--- a/src/httpx2/httpx2/_content.py
+++ b/src/httpx2/httpx2/_content.py
@@ -128,10 +128,8 @@ def encode_content(
     raise TypeError(f"Unexpected type for 'content', {type(content)!r}")
 
 
-def encode_urlencoded_data(
-    data: RequestData,
-) -> tuple[dict[str, str], ByteStream]:
-    plain_data = []
+def encode_urlencoded_data(data: RequestData) -> tuple[dict[str, str], ByteStream]:
+    plain_data: list[tuple[str, str]] = []
     for key, value in data.items():
         if isinstance(value, (list, tuple)):
             plain_data.extend([(key, primitive_value_to_str(item)) for item in value])

--- a/src/httpx2/httpx2/_decoders.py
+++ b/src/httpx2/httpx2/_decoders.py
@@ -39,7 +39,7 @@ if typing.TYPE_CHECKING:
 
         ZstdDecompressor = functools.partial(_ZstdDecompressor().decompressobj)
 
-    _zstandard_installed: bool
+    _zstandard_installed: bool = False
 else:  # pragma: no cover
     _zstandard_installed = False
     try:
@@ -241,7 +241,7 @@ class MultiDecoder(ContentDecoder):
         if len(codings) > self.max_decode_links:
             raise DecodingError(f"Cannot apply more than {self.max_decode_links} content encodings.")
         # Note that we reverse the order for decoding.
-        self.children = [SUPPORTED_DECODERS[coding]() for coding in reversed(codings)]
+        self.children: list[ContentDecoder] = [SUPPORTED_DECODERS[coding]() for coding in reversed(codings)]
 
     def decode(self, data: bytes) -> bytes:
         for child in self.children:
@@ -402,7 +402,7 @@ class LineDecoder:
         return lines
 
 
-SUPPORTED_DECODERS = {
+SUPPORTED_DECODERS: dict[str, type[ContentDecoder]] = {
     "identity": IdentityDecoder,
     "gzip": GZipDecoder,
     "deflate": DeflateDecoder,

--- a/src/httpx2/httpx2/_exceptions.py
+++ b/src/httpx2/httpx2/_exceptions.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import contextlib
 import typing
+from collections.abc import Generator
 
 if typing.TYPE_CHECKING:
     from ._models import Request, Response  # pragma: no cover
@@ -356,9 +357,7 @@ class RequestNotRead(StreamError):
 
 
 @contextlib.contextmanager
-def request_context(
-    request: Request | None = None,
-) -> typing.Iterator[None]:
+def request_context(request: Request | None = None) -> Generator[None]:
     """
     A context manager that can be used to attach the given request context
     to any `RequestError` exceptions that are raised within the block.

--- a/src/httpx2/httpx2/_main.py
+++ b/src/httpx2/httpx2/_main.py
@@ -174,7 +174,7 @@ _PeerCertRetDictType = dict[str, str | _PCTRTTT | _PCTRTT]
 
 
 def format_certificate(cert: _PeerCertRetDictType) -> str:  # pragma: no cover
-    lines = []
+    lines: list[str] = []
     for key, value in cert.items():
         if isinstance(value, (list, tuple)):
             lines.append(f"*   {key}:")

--- a/src/httpx2/httpx2/_models.py
+++ b/src/httpx2/httpx2/_models.py
@@ -145,7 +145,7 @@ class Headers(typing.MutableMapping[str, str]):
         headers: HeaderTypes | None = None,
         encoding: str | None = None,
     ) -> None:
-        self._list = []  # type: typing.List[typing.Tuple[bytes, bytes, bytes]]
+        self._list: list[tuple[bytes, bytes, bytes]] = []
 
         if isinstance(headers, Headers):
             self._list = list(headers._list)
@@ -199,7 +199,7 @@ class Headers(typing.MutableMapping[str, str]):
         return [(raw_key, value) for raw_key, _, value in self._list]
 
     def keys(self) -> typing.KeysView[str]:
-        return {key.decode(self.encoding): None for _, key, value in self._list}.keys()
+        return {key.decode(self.encoding): None for _, key, _value in self._list}.keys()
 
     def values(self) -> typing.ValuesView[str]:
         values_dict: dict[str, str] = {}
@@ -262,7 +262,7 @@ class Headers(typing.MutableMapping[str, str]):
         if not split_commas:
             return values
 
-        split_values = []
+        split_values: list[str] = []
         for value in values:
             split_values.extend([item.strip() for item in value.split(",")])
         return split_values
@@ -1153,7 +1153,7 @@ class Cookies(typing.MutableMapping[str, str]):
         Delete all cookies. Optionally include a domain and path in
         order to only delete a subset of all the cookies.
         """
-        args = []
+        args: list[str] = []
         if domain is not None:
             args.append(domain)
         if path is not None:
@@ -1210,9 +1210,9 @@ class Cookies(typing.MutableMapping[str, str]):
             )
             self.request = request
 
-        def add_unredirected_header(self, key: str, value: str) -> None:
-            super().add_unredirected_header(key, value)
-            self.request.headers[key] = value
+        def add_unredirected_header(self, key: str, val: str) -> None:
+            super().add_unredirected_header(key, val)
+            self.request.headers[key] = val
 
     class _CookieCompatResponse:
         """

--- a/src/httpx2/httpx2/_transports/default.py
+++ b/src/httpx2/httpx2/_transports/default.py
@@ -28,12 +28,13 @@ from __future__ import annotations
 
 import contextlib
 import typing
+from collections.abc import Generator
 from types import TracebackType
 
-if typing.TYPE_CHECKING:
-    import ssl  # pragma: no cover
+if typing.TYPE_CHECKING:  # pragma: no cover
+    import ssl
 
-    import httpx2  # pragma: no cover
+    import httpx2
 
 from .._config import DEFAULT_LIMITS, Limits, Proxy, create_ssl_context
 from .._exceptions import (
@@ -89,7 +90,7 @@ def _load_httpcore_exceptions() -> dict[type[Exception], type[httpx2.HTTPError]]
 
 
 @contextlib.contextmanager
-def map_httpcore_exceptions() -> typing.Iterator[None]:
+def map_httpcore_exceptions() -> Generator[None]:
     global HTTPCORE_EXC_MAP
     if len(HTTPCORE_EXC_MAP) == 0:
         HTTPCORE_EXC_MAP = _load_httpcore_exceptions()

--- a/src/httpx2/httpx2/_urlparse.py
+++ b/src/httpx2/httpx2/_urlparse.py
@@ -480,7 +480,7 @@ def quote(string: str, safe: str) -> str:
         need to be escaped. Unreserved characters are always treated as safe.
         See: https://www.rfc-editor.org/rfc/rfc3986#section-2.3
     """
-    parts = []
+    parts: list[str] = []
     current_position = 0
     for match in re.finditer(PERCENT_ENCODED_REGEX, string):
         start_position, end_position = match.start(), match.end()

--- a/tests/httpcore2/_async/test_connection_pool.py
+++ b/tests/httpcore2/_async/test_connection_pool.py
@@ -230,7 +230,7 @@ async def test_trace_request() -> None:
         ]
     )
 
-    called = []
+    called: list[str] = []
 
     async def trace(name: str, kwargs: dict[str, typing.Any]) -> None:
         called.append(name)
@@ -332,7 +332,7 @@ async def test_connection_pool_with_http_exception() -> None:
     """
     network_backend = httpcore2.AsyncMockBackend([b"Wait, this isn't valid HTTP!"])
 
-    called = []
+    called: list[str] = []
 
     async def trace(name: str, kwargs: dict[str, typing.Any]) -> None:
         called.append(name)
@@ -381,7 +381,7 @@ async def test_connection_pool_with_connect_exception() -> None:
 
     network_backend = FailedConnectBackend([])
 
-    called = []
+    called: list[str] = []
 
     async def trace(name: str, kwargs: dict[str, typing.Any]) -> None:
         called.append(name)
@@ -758,7 +758,7 @@ async def test_http11_upgrade_connection() -> None:
         ]
     )
 
-    called = []
+    called: list[str] = []
 
     async def trace(name: str, kwargs: dict[str, typing.Any]) -> None:
         called.append(name)

--- a/tests/httpcore2/_sync/test_connection_pool.py
+++ b/tests/httpcore2/_sync/test_connection_pool.py
@@ -230,7 +230,7 @@ def test_trace_request() -> None:
         ]
     )
 
-    called = []
+    called: list[str] = []
 
     def trace(name: str, kwargs: dict[str, typing.Any]) -> None:
         called.append(name)
@@ -332,7 +332,7 @@ def test_connection_pool_with_http_exception() -> None:
     """
     network_backend = httpcore2.MockBackend([b"Wait, this isn't valid HTTP!"])
 
-    called = []
+    called: list[str] = []
 
     def trace(name: str, kwargs: dict[str, typing.Any]) -> None:
         called.append(name)
@@ -381,7 +381,7 @@ def test_connection_pool_with_connect_exception() -> None:
 
     network_backend = FailedConnectBackend([])
 
-    called = []
+    called: list[str] = []
 
     def trace(name: str, kwargs: dict[str, typing.Any]) -> None:
         called.append(name)
@@ -758,7 +758,7 @@ def test_http11_upgrade_connection() -> None:
         ]
     )
 
-    called = []
+    called: list[str] = []
 
     def trace(name: str, kwargs: dict[str, typing.Any]) -> None:
         called.append(name)

--- a/tests/httpcore2/benchmark/client.py
+++ b/tests/httpcore2/benchmark/client.py
@@ -2,7 +2,7 @@ import asyncio
 import os
 import sys
 import time
-from collections.abc import Callable, Coroutine, Iterator
+from collections.abc import Callable, Coroutine, Generator, Iterator
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from typing import Any
@@ -30,7 +30,7 @@ def duration(start: float) -> int:
 
 
 @contextmanager
-def profile() -> Iterator[None]:
+def profile() -> Generator[None]:
     if not PROFILE:
         yield
         return
@@ -149,7 +149,7 @@ def main() -> None:
     mode = sys.argv[1] if len(sys.argv) == 2 else None
     assert mode in ("async", "sync"), "Usage: python client.py <async|sync>"
 
-    fig, ax = plt.subplots()
+    _fig, ax = plt.subplots()
 
     if mode == "async":
         asyncio.run(run_async_requests(ax))

--- a/tests/httpcore2/test_cancellations.py
+++ b/tests/httpcore2/test_cancellations.py
@@ -2,7 +2,7 @@ import typing
 
 import anyio
 import hpack
-import hyperframe
+import hyperframe.frame
 import pytest
 
 import httpcore2

--- a/tests/httpx2/client/test_auth.py
+++ b/tests/httpx2/client/test_auth.py
@@ -92,7 +92,7 @@ class RepeatAuth(httpx2.Auth):
         self.repeat = repeat
 
     def auth_flow(self, request: httpx2.Request) -> typing.Generator[httpx2.Request, httpx2.Response, None]:
-        nonces = []
+        nonces: list[str] = []
 
         for index in range(self.repeat):
             request.headers["Authorization"] = f"Repeat {index}"

--- a/tests/httpx2/client/test_proxies.py
+++ b/tests/httpx2/client/test_proxies.py
@@ -106,9 +106,9 @@ def test_transport_for_request(url: str, proxies: dict[str, str], expected: str 
 @pytest.mark.anyio
 @pytest.mark.network
 async def test_async_proxy_close() -> None:
+    transport = httpx2.AsyncHTTPTransport(proxy=PROXY_URL)
+    client = httpx2.AsyncClient(mounts={"https://": transport})
     try:
-        transport = httpx2.AsyncHTTPTransport(proxy=PROXY_URL)
-        client = httpx2.AsyncClient(mounts={"https://": transport})
         await client.get("http://example.com")
     finally:
         await client.aclose()
@@ -116,9 +116,9 @@ async def test_async_proxy_close() -> None:
 
 @pytest.mark.network
 def test_sync_proxy_close() -> None:
+    transport = httpx2.HTTPTransport(proxy=PROXY_URL)
+    client = httpx2.Client(mounts={"https://": transport})
     try:
-        transport = httpx2.HTTPTransport(proxy=PROXY_URL)
-        client = httpx2.Client(mounts={"https://": transport})
         client.get("http://example.com")
     finally:
         client.close()

--- a/tests/httpx2/models/test_cookies.py
+++ b/tests/httpx2/models/test_cookies.py
@@ -1,4 +1,4 @@
-import http
+import http.cookiejar
 
 import pytest
 


### PR DESCRIPTION
Cleans up typing across `httpx2` and `httpcore2` so the strict type checker and linter pass without inline workarounds:

- Add explicit annotations to empty collections that were previously inferred as `list[Any]`/`dict[Any, Any]`.
- Replace inline `# type:` comments with class- and variable-level annotations.
- Return `collections.abc.Generator` from context managers instead of `typing.Iterator`.
- Import submodules explicitly (`anyio.abc`, `hyperframe.frame`, `http.cookiejar`).
- Rename unused loop variables to `_`-prefixed.

`httpcore2` sync changes are made in the `_async` sources and regenerated via unasync.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.