### PR TITLE
Version 2.4.0

### DIFF
--- a/src/httpcore2/CHANGELOG.md
+++ b/src/httpcore2/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2.4.0 (June 11th, 2026)
+
+### Fixed
+
+* Move HTTP/2 stream events cleanup inside `_state_lock`. ([#1013](https://github.com/pydantic/httpx2/pull/1013))
+* Release the HTTP/2 semaphore permit on `NoAvailableStreamIDError`. ([#1012](https://github.com/pydantic/httpx2/pull/1012))
+* Use `RLock` instead of `Lock` to prevent a thread deadlock. ([#1008](https://github.com/pydantic/httpx2/pull/1008))
+
 ## 2.3.0 (June 1st, 2026)
 
 ### Changed

--- a/src/httpx2/CHANGELOG.md
+++ b/src/httpx2/CHANGELOG.md
@@ -13,7 +13,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 * Limit the number of chained `Content-Encoding` decoders to 5. ([#1027](https://github.com/pydantic/httpx2/pull/1027))
-* Bump `chardet` to `6.0.0.post1`. ([#1017](https://github.com/pydantic/httpx2/pull/1017))
 * Allow version 15 of `rich` in the `cli` extra. ([#1015](https://github.com/pydantic/httpx2/pull/1015))
 
 ### Fixed

--- a/src/httpx2/CHANGELOG.md
+++ b/src/httpx2/CHANGELOG.md
@@ -4,11 +4,22 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
+## 2.4.0 (June 11th, 2026)
+
+### Added
+
+* Add `HTTPXDeprecationWarning`, a `UserWarning` subclass shown by default so deprecations are visible without enabling warnings. ([#1029](https://github.com/pydantic/httpx2/pull/1029))
 
 ### Changed
 
-* Limit the number of chained `Content-Encoding` decoders to 5.
+* Limit the number of chained `Content-Encoding` decoders to 5. ([#1027](https://github.com/pydantic/httpx2/pull/1027))
+* Bump `chardet` to `6.0.0.post1`. ([#1017](https://github.com/pydantic/httpx2/pull/1017))
+* Allow version 15 of `rich` in the `cli` extra. ([#1015](https://github.com/pydantic/httpx2/pull/1015))
+
+### Fixed
+
+* Parse an empty `Digest` auth realm without crashing. ([#1023](https://github.com/pydantic/httpx2/pull/1023))
+* Decode IDNA labels in non-leading host positions. ([#1018](https://github.com/pydantic/httpx2/pull/1018))
 
 ## 2.3.0 (June 1st, 2026)
 


### PR DESCRIPTION
Release `httpx2` and `httpcore2` `2.4.0`.

### `httpx2`

* Add `HTTPXDeprecationWarning`, a `UserWarning` subclass shown by default. (#1029)
* Limit the number of chained `Content-Encoding` decoders to 5. (#1027)
* Allow version 15 of `rich` in the `cli` extra. (#1015)
* Parse an empty `Digest` auth realm without crashing. (#1023)
* Decode IDNA labels in non-leading host positions. (#1018)

### `httpcore2`

* Move HTTP/2 stream events cleanup inside `_state_lock`. (#1013)
* Release the HTTP/2 semaphore permit on `NoAvailableStreamIDError`. (#1012)
* Use `RLock` instead of `Lock` to prevent a thread deadlock. (#1008)

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
