### PR TITLE
Add real async iterator for ByteStreams

### DIFF
--- a/src/httpx2/httpx2/_content.py
+++ b/src/httpx2/httpx2/_content.py
@@ -31,8 +31,25 @@ class ByteStream(AsyncByteStream, SyncByteStream):
     def __iter__(self) -> Iterator[bytes]:
         yield self._stream
 
-    async def __aiter__(self) -> AsyncIterator[bytes]:
-        yield self._stream
+    def __aiter__(self) -> AsyncIterator[bytes]:
+        return _ByteStreamAsyncIterator(self._stream)
+
+
+class _ByteStreamAsyncIterator:
+    __slots__ = ("_stream",)
+
+    def __init__(self, stream: bytes) -> None:
+        self._stream: bytes | None = stream
+
+    def __aiter__(self) -> _ByteStreamAsyncIterator:
+        return self
+
+    async def __anext__(self) -> bytes:
+        stream = self._stream
+        if stream is None:
+            raise StopAsyncIteration
+        self._stream = None  # Consumed.
+        return stream
 
 
 class IteratorByteStream(SyncByteStream):

--- a/tests/httpx2/test_content.py
+++ b/tests/httpx2/test_content.py
@@ -32,6 +32,10 @@ async def test_bytes_content() -> None:
     sync_content = b"".join(list(request.stream))
     async_content = b"".join([part async for part in request.stream])
 
+    # The async iterator returned by __aiter__ is itself an async iterator.
+    async_iterator = request.stream.__aiter__()
+    assert async_iterator.__aiter__() is async_iterator
+
     assert request.headers == {"Host": "www.example.com", "Content-Length": "13"}
     assert sync_content == b"Hello, world!"
     assert async_content == b"Hello, world!"


### PR DESCRIPTION
# Summary

Previously, `__aiter__` was implemented as a generator function, and as such could get garbage collected when not completely exhausted in a way that has recent versions of `trio` complaining.

Using a real, if trivial, object to do this causes less complaints.

Port of my PR https://github.com/encode/httpx/pull/3777

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
  - No need to.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

