### PR TITLE
Do not wait forever for test server to start or stop

### DIFF
--- a/tests/httpx2/conftest.py
+++ b/tests/httpx2/conftest.py
@@ -261,11 +261,28 @@ class TestServer(Server):
 
 
 def serve_in_thread(server: TestServer) -> typing.Iterator[TestServer]:
-    thread = threading.Thread(target=server.run)
+    server_exception = None
+    server_caught_exception = threading.Event()
+
+    def _run_server() -> None:
+        nonlocal server_exception
+        try:
+            server.run()
+        except BaseException as exc:  # pragma: nocover
+            # BaseException as we need to catch SystemExit too;
+            # `uvicorn` calls `sys.exit(1)` at failure.
+            server_exception = exc
+            server_caught_exception.set()
+
+    thread = threading.Thread(target=_run_server)
     thread.start()
+
     try:
         while not server.started:
-            time.sleep(1e-3)
+            if server_caught_exception.wait(1e-3):
+                raise RuntimeError(
+                    f"Server failed to start: {server_exception!r}",
+                ) from server_exception
         yield server
     finally:
         server.should_exit = True

--- a/tests/httpx2/conftest.py
+++ b/tests/httpx2/conftest.py
@@ -260,7 +260,11 @@ class TestServer(Server):
             await self.startup()
 
 
-def serve_in_thread(server: TestServer) -> typing.Iterator[TestServer]:
+def serve_in_thread(
+    server: TestServer,
+    *,
+    timeout: float = 10.0,
+) -> typing.Iterator[TestServer]:
     server_exception = None
     server_caught_exception = threading.Event()
 
@@ -278,15 +282,21 @@ def serve_in_thread(server: TestServer) -> typing.Iterator[TestServer]:
     thread.start()
 
     try:
-        while not server.started:
-            if server_caught_exception.wait(1e-3):
+        start_time = time.time()
+        while True:
+            if server.started:
+                break
+            if server_caught_exception.wait(1e-3):  # pragma: nocover
                 raise RuntimeError(
                     f"Server failed to start: {server_exception!r}",
                 ) from server_exception
+            if time.time() - start_time > timeout:  # pragma: nocover
+                raise TimeoutError("Server did not start in time")
+            time.sleep(1e-3)
         yield server
     finally:
         server.should_exit = True
-        thread.join()
+        thread.join(timeout=timeout)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
# Summary

I was wondering why the test suite just hung forever, and finally with `pytest tests/ -vvvx --log-cli-level=DEBUG -s` I found that:

```
[Errno 48] error while attempting to bind on address ('127.0.0.1', 8000): [errno 48] address already in use
```

– yep, I was working on something else on port 8000 – and so, `server.running` never becomes `True`, and tests just hang.

This PR:

* Makes sure errors from `server.run()` (in the secondary thread) are caught and propagated immediately to the controlling loop
* Adds timeouts, so even if something even more unexpected happens, the suite will error out instead of hanging forever.

Port of PR https://github.com/encode/httpx/pull/3775

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
  - No separate tests for testing the test fixture 😄  
- [ ] I've updated the documentation accordingly.
  - No user-facing or developer documentation changes needed. (Noting that port 8000 must not be in use is a separate thing to maybe document, I think...)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1037?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

