### PR TITLE
Read _expire_at only once in has_expired()

### DIFF
--- a/src/httpcore2/httpcore2/_async/http11.py
+++ b/src/httpcore2/httpcore2/_async/http11.py
@@ -251,7 +251,10 @@ class AsyncHTTP11Connection(AsyncConnectionInterface):
 
     def has_expired(self) -> bool:
         now = time.monotonic()
-        keepalive_expired = self._expire_at is not None and now > self._expire_at
+        # Read `_expire_at` once into a local: on free-threaded builds another
+        # thread may reset it to `None` between the check and the comparison.
+        expire_at = self._expire_at
+        keepalive_expired = expire_at is not None and now > expire_at
 
         # If the HTTP connection is idle but the socket is readable, then the
         # only valid state is that the socket is about to return b"", indicating

--- a/src/httpcore2/httpcore2/_async/http2.py
+++ b/src/httpcore2/httpcore2/_async/http2.py
@@ -484,7 +484,10 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
 
     def has_expired(self) -> bool:
         now = time.monotonic()
-        return self._expire_at is not None and now > self._expire_at
+        # Read `_expire_at` once into a local: on free-threaded builds another
+        # thread may reset it to `None` between the check and the comparison.
+        expire_at = self._expire_at
+        return expire_at is not None and now > expire_at
 
     def is_idle(self) -> bool:
         return self._state == HTTPConnectionState.IDLE

--- a/src/httpcore2/httpcore2/_sync/http11.py
+++ b/src/httpcore2/httpcore2/_sync/http11.py
@@ -251,7 +251,10 @@ class HTTP11Connection(ConnectionInterface):
 
     def has_expired(self) -> bool:
         now = time.monotonic()
-        keepalive_expired = self._expire_at is not None and now > self._expire_at
+        # Read `_expire_at` once into a local: on free-threaded builds another
+        # thread may reset it to `None` between the check and the comparison.
+        expire_at = self._expire_at
+        keepalive_expired = expire_at is not None and now > expire_at
 
         # If the HTTP connection is idle but the socket is readable, then the
         # only valid state is that the socket is about to return b"", indicating

--- a/src/httpcore2/httpcore2/_sync/http2.py
+++ b/src/httpcore2/httpcore2/_sync/http2.py
@@ -484,7 +484,10 @@ class HTTP2Connection(ConnectionInterface):
 
     def has_expired(self) -> bool:
         now = time.monotonic()
-        return self._expire_at is not None and now > self._expire_at
+        # Read `_expire_at` once into a local: on free-threaded builds another
+        # thread may reset it to `None` between the check and the comparison.
+        expire_at = self._expire_at
+        return expire_at is not None and now > expire_at
 
     def is_idle(self) -> bool:
         return self._state == HTTPConnectionState.IDLE


### PR DESCRIPTION
Backport of https://github.com/encode/httpcore/pull/1090.


<!-- Thanks for contributing to HTTPX2! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

In has_expired() the _expire_at attribute was read twice: once for the `is not None` guard and once for the comparison. On free-threaded builds another thread may reset it to None between the two reads, raising a TypeError. Read it once into a local instead.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1045?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

