### PR TITLE
Add native server-sent events support via `client.sse()`

### DIFF
--- a/src/httpx2/httpx2/__init__.py
+++ b/src/httpx2/httpx2/__init__.py
@@ -6,6 +6,7 @@ from ._config import *
 from ._content import *
 from ._exceptions import *
 from ._models import *
+from ._sse import *
 from ._status_codes import *
 from ._transports import *
 from ._types import *
@@ -35,6 +36,7 @@ __all__ = [
     "DecodingError",
     "delete",
     "DigestAuth",
+    "EventSource",
     "FunctionAuth",
     "get",
     "head",
@@ -66,6 +68,8 @@ __all__ = [
     "RequestNotRead",
     "Response",
     "ResponseNotRead",
+    "ServerSentEvent",
+    "SSEError",
     "stream",
     "StreamClosed",
     "StreamConsumed",

--- a/src/httpx2/httpx2/_client.py
+++ b/src/httpx2/httpx2/_client.py
@@ -28,6 +28,7 @@ from ._exceptions import (
     request_context,
 )
 from ._models import Cookies, Headers, Request, Response
+from ._sse import EventSource
 from ._status_codes import codes
 from ._transports.base import AsyncBaseTransport, BaseTransport
 from ._transports.default import AsyncHTTPTransport, HTTPTransport
@@ -58,6 +59,15 @@ __all__ = ["USE_CLIENT_DEFAULT", "AsyncClient", "Client"]
 # https://www.python.org/dev/peps/pep-0484/#annotating-instance-and-class-methods
 T = typing.TypeVar("T", bound="Client")
 U = typing.TypeVar("U", bound="AsyncClient")
+
+
+def _merge_sse_headers(headers: HeaderTypes | None) -> Headers:
+    merged = Headers(headers)
+    if "Accept" not in merged:
+        merged["Accept"] = "text/event-stream"
+    if "Cache-Control" not in merged:
+        merged["Cache-Control"] = "no-store"
+    return merged
 
 
 def _is_https_redirect(url: URL, location: URL) -> bool:
@@ -845,6 +855,48 @@ class Client(BaseClient):
         finally:
             response.close()
 
+    @contextmanager
+    def sse(
+        self,
+        url: URL | str,
+        *,
+        method: str = "GET",
+        content: RequestContent | None = None,
+        data: RequestData | None = None,
+        files: RequestFiles | None = None,
+        json: typing.Any | None = None,
+        params: QueryParamTypes | None = None,
+        headers: HeaderTypes | None = None,
+        cookies: CookieTypes | None = None,
+        auth: AuthTypes | UseClientDefault | None = USE_CLIENT_DEFAULT,
+        follow_redirects: bool | UseClientDefault = USE_CLIENT_DEFAULT,
+        timeout: TimeoutTypes | UseClientDefault = USE_CLIENT_DEFAULT,
+        extensions: RequestExtensions | None = None,
+    ) -> Generator[EventSource]:
+        """
+        Connect to a server-sent events endpoint and yield an `EventSource`.
+
+        Iterating the `EventSource` yields `ServerSentEvent` instances.
+
+        **Parameters**: See `httpx2.request`.
+        """
+        with self.stream(
+            method,
+            url,
+            content=content,
+            data=data,
+            files=files,
+            json=json,
+            params=params,
+            headers=_merge_sse_headers(headers),
+            cookies=cookies,
+            auth=auth,
+            follow_redirects=follow_redirects,
+            timeout=timeout,
+            extensions=extensions,
+        ) as response:
+            yield EventSource(response)
+
     def send(
         self,
         request: Request,
@@ -1547,6 +1599,48 @@ class AsyncClient(BaseClient):
             yield response
         finally:
             await response.aclose()
+
+    @asynccontextmanager
+    async def sse(
+        self,
+        url: URL | str,
+        *,
+        method: str = "GET",
+        content: RequestContent | None = None,
+        data: RequestData | None = None,
+        files: RequestFiles | None = None,
+        json: typing.Any | None = None,
+        params: QueryParamTypes | None = None,
+        headers: HeaderTypes | None = None,
+        cookies: CookieTypes | None = None,
+        auth: AuthTypes | UseClientDefault | None = USE_CLIENT_DEFAULT,
+        follow_redirects: bool | UseClientDefault = USE_CLIENT_DEFAULT,
+        timeout: TimeoutTypes | UseClientDefault = USE_CLIENT_DEFAULT,
+        extensions: RequestExtensions | None = None,
+    ) -> AsyncGenerator[EventSource]:
+        """
+        Connect to a server-sent events endpoint and yield an `EventSource`.
+
+        Iterating the `EventSource` yields `ServerSentEvent` instances.
+
+        **Parameters**: See `httpx2.request`.
+        """
+        async with self.stream(
+            method,
+            url,
+            content=content,
+            data=data,
+            files=files,
+            json=json,
+            params=params,
+            headers=_merge_sse_headers(headers),
+            cookies=cookies,
+            auth=auth,
+            follow_redirects=follow_redirects,
+            timeout=timeout,
+            extensions=extensions,
+        ) as response:
+            yield EventSource(response)
 
     async def send(
         self,

--- a/src/httpx2/httpx2/_sse.py
+++ b/src/httpx2/httpx2/_sse.py
@@ -1,3 +1,9 @@
+"""
+Server-sent events support, derived from httpx-sse (https://github.com/florimondmanca/httpx-sse).
+
+Copyright (c) 2022 Florimond Manca, MIT License (https://github.com/florimondmanca/httpx-sse/blob/master/LICENSE).
+"""
+
 from __future__ import annotations
 
 import json as jsonlib

--- a/src/httpx2/httpx2/_sse.py
+++ b/src/httpx2/httpx2/_sse.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import json as jsonlib
+from collections.abc import AsyncIterator, Iterator
+from dataclasses import dataclass
+
+from ._exceptions import TransportError
+from ._models import Response
+
+__all__ = ["EventSource", "SSEError", "ServerSentEvent"]
+
+
+class SSEError(TransportError):
+    """
+    An error that occurred while connecting to a server-sent events endpoint.
+    """
+
+
+@dataclass(frozen=True)
+class ServerSentEvent:
+    event: str = "message"
+    data: str = ""
+    id: str = ""
+    retry: int | None = None
+
+    def json(self) -> object:
+        return jsonlib.loads(self.data)
+
+
+class _SSEDecoder:
+    def __init__(self) -> None:
+        self._event = ""
+        self._data: list[str] = []
+        self._last_event_id = ""
+        self._retry: int | None = None
+
+    def decode(self, line: str) -> ServerSentEvent | None:
+        if not line:
+            if not self._event and not self._data and not self._last_event_id and self._retry is None:
+                return None
+
+            sse = ServerSentEvent(
+                event=self._event or "message",
+                data="\n".join(self._data),
+                id=self._last_event_id,
+                retry=self._retry,
+            )
+            self._event = ""
+            self._data = []
+            self._retry = None
+            return sse
+
+        if line.startswith(":"):
+            return None
+
+        fieldname, _, value = line.partition(":")
+        value = value[1:] if value.startswith(" ") else value
+
+        if fieldname == "event":
+            self._event = value
+        elif fieldname == "data":
+            self._data.append(value)
+        elif fieldname == "id":
+            if "\0" not in value:
+                self._last_event_id = value
+        elif fieldname == "retry":
+            try:
+                self._retry = int(value)
+            except ValueError:
+                pass
+
+        return None
+
+
+class _SSELineDecoder:
+    def __init__(self) -> None:
+        self._buffer = ""
+        self._trailing_cr = False
+
+    def decode(self, text: str) -> list[str]:
+        if self._trailing_cr:
+            text = "\r" + text
+            self._trailing_cr = False
+        if text.endswith("\r"):
+            self._trailing_cr = True
+            text = text[:-1]
+
+        text = self._buffer + text.replace("\r\n", "\n").replace("\r", "\n")
+        lines = text.split("\n")
+        self._buffer = lines.pop()
+        return lines
+
+    def flush(self) -> list[str]:
+        if self._trailing_cr:
+            self._buffer += "\n"
+            self._trailing_cr = False
+        if not self._buffer:
+            return []
+        lines = self._buffer.split("\n")
+        self._buffer = ""
+        return lines
+
+
+class EventSource:
+    def __init__(self, response: Response) -> None:
+        self._response = response
+
+    @property
+    def response(self) -> Response:
+        return self._response
+
+    def _check_content_type(self) -> None:
+        content_type, _, _ = self._response.headers.get("content-type", "").partition(";")
+        if content_type.strip() != "text/event-stream":
+            raise SSEError(
+                f"Expected response with content type 'text/event-stream', got {content_type.strip()!r}.",
+                request=self._response.request,
+            )
+
+    def __iter__(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = _SSEDecoder()
+        lines = _SSELineDecoder()
+        for chunk in self._response.iter_text():
+            for line in lines.decode(chunk):
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+        for line in lines.flush():
+            sse = decoder.decode(line)
+            if sse is not None:
+                yield sse
+
+    async def __aiter__(self) -> AsyncIterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = _SSEDecoder()
+        lines = _SSELineDecoder()
+        async for chunk in self._response.aiter_text():
+            for line in lines.decode(chunk):
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+        for line in lines.flush():
+            sse = decoder.decode(line)
+            if sse is not None:
+                yield sse

--- a/tests/httpx2/test_sse.py
+++ b/tests/httpx2/test_sse.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator
+
+import pytest
+
+import httpx2
+
+SSE_BODY = b": this is a comment\nevent: ping\ndata: hello\nid: 1\nretry: 500\n\ndata: first\ndata: second\n\n"
+
+
+def sse_handler(request: httpx2.Request) -> httpx2.Response:
+    return httpx2.Response(200, content=SSE_BODY, headers={"Content-Type": "text/event-stream"})
+
+
+def test_sse_sync() -> None:
+    with httpx2.Client(transport=httpx2.MockTransport(sse_handler)) as client:
+        with client.sse("http://testserver/sse") as source:
+            events = list(source)
+
+    assert events == [
+        httpx2.ServerSentEvent(event="ping", data="hello", id="1", retry=500),
+        httpx2.ServerSentEvent(event="message", data="first\nsecond", id="1"),
+    ]
+
+
+@pytest.mark.anyio
+async def test_sse_async() -> None:
+    async with httpx2.AsyncClient(transport=httpx2.MockTransport(sse_handler)) as client:
+        async with client.sse("http://testserver/sse") as source:
+            events = [event async for event in source]
+
+    assert events == [
+        httpx2.ServerSentEvent(event="ping", data="hello", id="1", retry=500),
+        httpx2.ServerSentEvent(event="message", data="first\nsecond", id="1"),
+    ]
+
+
+def test_default_event_is_message() -> None:
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(200, content=b"data: hi\n\n", headers={"Content-Type": "text/event-stream"})
+
+    with httpx2.Client(transport=httpx2.MockTransport(handler)) as client:
+        with client.sse("http://testserver/sse") as source:
+            (event,) = list(source)
+
+    assert event.event == "message"
+    assert event.data == "hi"
+    assert event.id == ""
+    assert event.retry is None
+
+
+def test_json() -> None:
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(200, content=b'data: {"x": 1}\n\n', headers={"Content-Type": "text/event-stream"})
+
+    with httpx2.Client(transport=httpx2.MockTransport(handler)) as client:
+        with client.sse("http://testserver/sse") as source:
+            (event,) = list(source)
+
+    assert event.json() == {"x": 1}
+
+
+def test_invalid_retry_is_ignored() -> None:
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        body = b"retry: not-a-number\ndata: hi\n\n"
+        return httpx2.Response(200, content=body, headers={"Content-Type": "text/event-stream"})
+
+    with httpx2.Client(transport=httpx2.MockTransport(handler)) as client:
+        with client.sse("http://testserver/sse") as source:
+            (event,) = list(source)
+
+    assert event.retry is None
+
+
+def test_id_with_null_is_ignored() -> None:
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        body = b"id: a\0b\ndata: hi\n\n"
+        return httpx2.Response(200, content=body, headers={"Content-Type": "text/event-stream"})
+
+    with httpx2.Client(transport=httpx2.MockTransport(handler)) as client:
+        with client.sse("http://testserver/sse") as source:
+            (event,) = list(source)
+
+    assert event.id == ""
+
+
+def test_field_without_value() -> None:
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(200, content=b"data\n\n", headers={"Content-Type": "text/event-stream"})
+
+    with httpx2.Client(transport=httpx2.MockTransport(handler)) as client:
+        with client.sse("http://testserver/sse") as source:
+            (event,) = list(source)
+
+    assert event.data == ""
+
+
+def test_last_event_id_persists() -> None:
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        body = b"id: 1\ndata: a\n\ndata: b\n\n"
+        return httpx2.Response(200, content=body, headers={"Content-Type": "text/event-stream"})
+
+    with httpx2.Client(transport=httpx2.MockTransport(handler)) as client:
+        with client.sse("http://testserver/sse") as source:
+            events = list(source)
+
+    assert [event.id for event in events] == ["1", "1"]
+
+
+@pytest.mark.parametrize("content_type", ["text/event-stream", "text/event-stream; charset=utf-8"])
+def test_content_type_accepted(content_type: str) -> None:
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(200, content=b"data: hi\n\n", headers={"Content-Type": content_type})
+
+    with httpx2.Client(transport=httpx2.MockTransport(handler)) as client:
+        with client.sse("http://testserver/sse") as source:
+            (event,) = list(source)
+
+    assert event.data == "hi"
+
+
+def test_content_type_mismatch_raises() -> None:
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(200, content=b"data: hi\n\n", headers={"Content-Type": "application/json"})
+
+    with httpx2.Client(transport=httpx2.MockTransport(handler)) as client:
+        with client.sse("http://testserver/sse") as source:
+            with pytest.raises(httpx2.SSEError, match="text/event-stream"):
+                list(source)
+
+
+@pytest.mark.anyio
+async def test_content_type_mismatch_raises_async() -> None:
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(200, content=b"data: hi\n\n", headers={"Content-Type": "application/json"})
+
+    async with httpx2.AsyncClient(transport=httpx2.MockTransport(handler)) as client:
+        async with client.sse("http://testserver/sse") as source:
+            with pytest.raises(httpx2.SSEError, match="text/event-stream"):
+                [event async for event in source]
+
+
+def test_sets_sse_headers() -> None:
+    captured: dict[str, str] = {}
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        captured.update(request.headers)
+        return httpx2.Response(200, content=b"data: hi\n\n", headers={"Content-Type": "text/event-stream"})
+
+    with httpx2.Client(transport=httpx2.MockTransport(handler)) as client:
+        with client.sse("http://testserver/sse") as source:
+            list(source)
+
+    assert captured["accept"] == "text/event-stream"
+    assert captured["cache-control"] == "no-store"
+
+
+def test_user_headers_take_precedence() -> None:
+    captured: dict[str, str] = {}
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        captured.update(request.headers)
+        return httpx2.Response(200, content=b"data: hi\n\n", headers={"Content-Type": "text/event-stream"})
+
+    with httpx2.Client(transport=httpx2.MockTransport(handler)) as client:
+        with client.sse("http://testserver/sse", headers={"Accept": "text/event-stream, application/json"}) as source:
+            list(source)
+
+    assert captured["accept"] == "text/event-stream, application/json"
+
+
+def test_response_is_accessible() -> None:
+    with httpx2.Client(transport=httpx2.MockTransport(sse_handler)) as client:
+        with client.sse("http://testserver/sse") as source:
+            assert isinstance(source.response, httpx2.Response)
+            assert source.response.status_code == 200
+
+
+def test_post_method() -> None:
+    captured: list[str] = []
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        captured.append(request.method)
+        return httpx2.Response(200, content=b"data: hi\n\n", headers={"Content-Type": "text/event-stream"})
+
+    with httpx2.Client(transport=httpx2.MockTransport(handler)) as client:
+        with client.sse("http://testserver/sse", method="POST", json={"q": 1}) as source:
+            list(source)
+
+    assert captured == ["POST"]
+
+
+def test_chunk_boundaries_and_crlf_sync() -> None:
+    def chunks() -> Iterator[bytes]:
+        yield b"data: he"
+        yield b"llo\r\n\r"
+        yield b"\ndata: wor"
+        yield b"ld\r\n\r\n"
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(200, content=chunks(), headers={"Content-Type": "text/event-stream"})
+
+    with httpx2.Client(transport=httpx2.MockTransport(handler)) as client:
+        with client.sse("http://testserver/sse") as source:
+            events = list(source)
+
+    assert [event.data for event in events] == ["hello", "world"]
+
+
+@pytest.mark.anyio
+async def test_chunk_boundaries_and_crlf_async() -> None:
+    async def chunks() -> AsyncIterator[bytes]:
+        yield b"data: he"
+        yield b"llo\r\n\r"
+        yield b"\ndata: wor"
+        yield b"ld\r\n\r\n"
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(200, content=chunks(), headers={"Content-Type": "text/event-stream"})
+
+    async with httpx2.AsyncClient(transport=httpx2.MockTransport(handler)) as client:
+        async with client.sse("http://testserver/sse") as source:
+            events = [event async for event in source]
+
+    assert [event.data for event in events] == ["hello", "world"]
+
+
+def test_event_without_trailing_blank_line() -> None:
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(200, content=b"data: hi", headers={"Content-Type": "text/event-stream"})
+
+    with httpx2.Client(transport=httpx2.MockTransport(handler)) as client:
+        with client.sse("http://testserver/sse") as source:
+            events = list(source)
+
+    assert events == []
+
+
+def test_leading_blank_line_is_ignored() -> None:
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(200, content=b"\ndata: hi\n\n", headers={"Content-Type": "text/event-stream"})
+
+    with httpx2.Client(transport=httpx2.MockTransport(handler)) as client:
+        with client.sse("http://testserver/sse") as source:
+            (event,) = list(source)
+
+    assert event.data == "hi"
+
+
+def test_event_dispatched_at_eof_on_trailing_cr_sync() -> None:
+    def chunks() -> Iterator[bytes]:
+        yield b"data: hi\n"
+        yield b"\r"
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(200, content=chunks(), headers={"Content-Type": "text/event-stream"})
+
+    with httpx2.Client(transport=httpx2.MockTransport(handler)) as client:
+        with client.sse("http://testserver/sse") as source:
+            (event,) = list(source)
+
+    assert event.data == "hi"
+
+
+@pytest.mark.anyio
+async def test_event_dispatched_at_eof_on_trailing_cr_async() -> None:
+    async def chunks() -> AsyncIterator[bytes]:
+        yield b"data: hi\n"
+        yield b"\r"
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(200, content=chunks(), headers={"Content-Type": "text/event-stream"})
+
+    async with httpx2.AsyncClient(transport=httpx2.MockTransport(handler)) as client:
+        async with client.sse("http://testserver/sse") as source:
+            events = [event async for event in source]
+
+    assert [event.data for event in events] == ["hi"]


### PR DESCRIPTION
Adds native server-sent events support, so the client has a first-class method for SSE instead of needing a companion library.

## API

```python
with httpx2.Client() as client:
    with client.sse("http://localhost:8000/sse") as source:
        for event in source:
            print(event.event, event.data, event.json())
```

- `Client.sse()` / `AsyncClient.sse()` - same name on both clients (like `stream`), `url`-first with `method="GET"` default. A context manager yielding an `EventSource`.
- `EventSource` - iterate it directly (`for event in source` / `async for event in source`) to get `ServerSentEvent` instances; `source.response` exposes the underlying `Response`.
- `ServerSentEvent` - frozen dataclass with `event`, `data`, `id`, `retry: int | None`, and `.json()`.
- `SSEError(TransportError)` - raised when the response `Content-Type` is not `text/event-stream`.

The method sets `Accept: text/event-stream` and `Cache-Control: no-store` (user-supplied headers win), and is built on top of `client.stream()`.

## Notes

- Always-on, no extra and no third-party dependency - the parser is implemented over `response.iter_text()`.
- Uses a spec-compliant line splitter (`\r\n` / `\r` / `\n` only) rather than `iter_lines()`, which over-splits on exotic Unicode separators that SSE treats as data.
- New `tests/httpx2/test_sse.py` covers parsing, multi-line data, comments, `id`/`retry`/null handling, last-event-id persistence, content-type validation, header defaults/override, POST, and chunk-boundary/CRLF splitting (sync + async). `_sse.py` is at 100% coverage.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

