### PR TITLE
Support `|` and `|=` operators for `Headers`

### DIFF
--- a/src/httpx2/httpx2/_models.py
+++ b/src/httpx2/httpx2/_models.py
@@ -277,6 +277,26 @@ class Headers(typing.MutableMapping[str, str]):
     def copy(self) -> Headers:
         return Headers(self, encoding=self.encoding)
 
+    def __or__(self, other: Mapping[str, str]) -> Headers:
+        if not isinstance(other, Mapping):
+            return NotImplemented
+        merged = self.copy()
+        merged.update(other)
+        return merged
+
+    def __ror__(self, other: Mapping[str, str]) -> Headers:
+        if not isinstance(other, Mapping):
+            return NotImplemented
+        merged = Headers(other)
+        merged.update(self)
+        return merged
+
+    def __ior__(self, other: Mapping[str, str]) -> Headers:
+        if not isinstance(other, Mapping):
+            return NotImplemented
+        self.update(other)
+        return self
+
     def __getitem__(self, key: str) -> str:
         """
         Return a single header value.

--- a/src/httpx2/httpx2/_models.py
+++ b/src/httpx2/httpx2/_models.py
@@ -291,9 +291,7 @@ class Headers(typing.MutableMapping[str, str]):
         merged.update(self)
         return merged
 
-    def __ior__(self, other: Mapping[str, str]) -> Headers:
-        if not isinstance(other, Mapping):
-            return NotImplemented
+    def __ior__(self, other: HeaderTypes) -> Headers:
         self.update(other)
         return self
 

--- a/tests/httpx2/models/test_headers.py
+++ b/tests/httpx2/models/test_headers.py
@@ -100,9 +100,9 @@ def test_headers_ior_accepts_update_inputs() -> None:
 
 def test_headers_or_unsupported_type() -> None:
     with pytest.raises(TypeError):
-        httpx2.Headers({"a": "1"}) | [("b", "2")]
+        httpx2.Headers({"a": "1"}) | [("b", "2")]  # type: ignore[operator]
     with pytest.raises(TypeError):
-        [("b", "2")] | httpx2.Headers({"a": "1"})
+        [("b", "2")] | httpx2.Headers({"a": "1"})  # type: ignore[operator]
 
 
 def test_headers_insert_retains_ordering() -> None:

--- a/tests/httpx2/models/test_headers.py
+++ b/tests/httpx2/models/test_headers.py
@@ -65,6 +65,40 @@ def test_copy_headers_init() -> None:
     assert headers == headers_copy
 
 
+def test_headers_or() -> None:
+    left = httpx2.Headers({"a": "1", "b": "2"})
+    merged = left | {"b": "3", "c": "4"}
+    assert isinstance(merged, httpx2.Headers)
+    assert dict(merged) == {"a": "1", "b": "3", "c": "4"}
+    assert dict(left) == {"a": "1", "b": "2"}
+
+
+def test_headers_or_with_headers() -> None:
+    merged = httpx2.Headers({"a": "1"}) | httpx2.Headers({"a": "2"})
+    assert dict(merged) == {"a": "2"}
+
+
+def test_headers_ror() -> None:
+    merged = {"a": "1", "b": "2"} | httpx2.Headers({"b": "3"})
+    assert isinstance(merged, httpx2.Headers)
+    assert dict(merged) == {"a": "1", "b": "3"}
+
+
+def test_headers_ior() -> None:
+    headers = httpx2.Headers({"a": "1"})
+    original = headers
+    headers |= {"a": "2", "b": "3"}
+    assert headers is original
+    assert dict(headers) == {"a": "2", "b": "3"}
+
+
+def test_headers_or_unsupported_type() -> None:
+    with pytest.raises(TypeError):
+        httpx2.Headers({"a": "1"}) | ["b", "2"]
+    with pytest.raises(TypeError):
+        ["b", "2"] | httpx2.Headers({"a": "1"})
+
+
 def test_headers_insert_retains_ordering() -> None:
     headers = httpx2.Headers({"a": "a", "b": "b", "c": "c"})
     headers["b"] = "123"

--- a/tests/httpx2/models/test_headers.py
+++ b/tests/httpx2/models/test_headers.py
@@ -92,11 +92,17 @@ def test_headers_ior() -> None:
     assert dict(headers) == {"a": "2", "b": "3"}
 
 
+def test_headers_ior_accepts_update_inputs() -> None:
+    headers = httpx2.Headers({"a": "1"})
+    headers |= [("a", "2"), ("b", "3")]
+    assert dict(headers) == {"a": "2", "b": "3"}
+
+
 def test_headers_or_unsupported_type() -> None:
     with pytest.raises(TypeError):
-        httpx2.Headers({"a": "1"}) | ["b", "2"]
+        httpx2.Headers({"a": "1"}) | [("b", "2")]
     with pytest.raises(TypeError):
-        ["b", "2"] | httpx2.Headers({"a": "1"})
+        [("b", "2")] | httpx2.Headers({"a": "1"})
 
 
 def test_headers_insert_retains_ordering() -> None:


### PR DESCRIPTION
Adds `|` and `|=` operators to `Headers`, matching the dict merge operators from [PEP 584](https://peps.python.org/pep-0584/).

```python
headers = httpx2.Headers({"Accept": "text/event-stream"})
merged = headers | {"Accept": "application/json", "Cache-Control": "no-store"}
# Headers({'Accept': 'application/json', 'Cache-Control': 'no-store'})

headers |= {"Authorization": "Bearer ..."}  # in-place
```

- `__or__` / `__ror__` return a new `Headers`; the right-hand operand wins on key collisions, consistent with `dict`.
- `__ior__` merges in place (same as `update`) and returns `self`.
- Only `Mapping` operands are accepted; anything else returns `NotImplemented` so Python raises `TypeError`, mirroring `dict` behavior.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

