### PR TITLE
Suppress empty SSE keepalive events and accept case-insensitive content type

### DIFF
--- a/src/httpx2/httpx2/_sse.py
+++ b/src/httpx2/httpx2/_sse.py
@@ -39,10 +39,11 @@ class _SSEDecoder:
         self._data: list[str] = []
         self._last_event_id = ""
         self._retry: int | None = None
+        self._pending = False
 
     def decode(self, line: str) -> ServerSentEvent | None:
         if not line:
-            if not self._event and not self._data and not self._last_event_id and self._retry is None:
+            if not self._pending:
                 return None
 
             sse = ServerSentEvent(
@@ -54,6 +55,7 @@ class _SSEDecoder:
             self._event = ""
             self._data = []
             self._retry = None
+            self._pending = False
             return sse
 
         if line.startswith(":"):
@@ -64,14 +66,18 @@ class _SSEDecoder:
 
         if fieldname == "event":
             self._event = value
+            self._pending = True
         elif fieldname == "data":
             self._data.append(value)
+            self._pending = True
         elif fieldname == "id":
             if "\0" not in value:
                 self._last_event_id = value
+                self._pending = True
         elif fieldname == "retry":
             try:
                 self._retry = int(value)
+                self._pending = True
             except ValueError:
                 pass
 
@@ -117,7 +123,7 @@ class EventSource:
 
     def _check_content_type(self) -> None:
         content_type, _, _ = self._response.headers.get("content-type", "").partition(";")
-        if content_type.strip() != "text/event-stream":
+        if content_type.strip().lower() != "text/event-stream":
             raise SSEError(
                 f"Expected response with content type 'text/event-stream', got {content_type.strip()!r}.",
                 request=self._response.request,

--- a/tests/httpx2/test_sse.py
+++ b/tests/httpx2/test_sse.py
@@ -108,7 +108,34 @@ def test_last_event_id_persists() -> None:
     assert [event.id for event in events] == ["1", "1"]
 
 
-@pytest.mark.parametrize("content_type", ["text/event-stream", "text/event-stream; charset=utf-8"])
+def test_blank_lines_after_id_do_not_dispatch() -> None:
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        body = b"id: 1\ndata: a\n\n\n\ndata: b\n\n"
+        return httpx2.Response(200, content=body, headers={"Content-Type": "text/event-stream"})
+
+    with httpx2.Client(transport=httpx2.MockTransport(handler)) as client:
+        with client.sse("http://testserver/sse") as source:
+            events = list(source)
+
+    assert [event.data for event in events] == ["a", "b"]
+
+
+def test_id_only_block_is_dispatched() -> None:
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(200, content=b"id: 1\n\n", headers={"Content-Type": "text/event-stream"})
+
+    with httpx2.Client(transport=httpx2.MockTransport(handler)) as client:
+        with client.sse("http://testserver/sse") as source:
+            (event,) = list(source)
+
+    assert event.id == "1"
+    assert event.data == ""
+
+
+@pytest.mark.parametrize(
+    "content_type",
+    ["text/event-stream", "text/event-stream; charset=utf-8", "Text/Event-Stream", "TEXT/EVENT-STREAM"],
+)
 def test_content_type_accepted(content_type: str) -> None:
     def handler(request: httpx2.Request) -> httpx2.Response:
         return httpx2.Response(200, content=b"data: hi\n\n", headers={"Content-Type": content_type})


### PR DESCRIPTION
Addresses the two review findings on [#1046](https://github.com/pydantic/httpx2/pull/1046), now that it has merged into `main`.

## [P2] Suppress spurious empty events on keepalive streams

The dispatch condition fired whenever any of `_event` / `_data` / `_last_event_id` / `_retry` was set. Since `_last_event_id` persists across blocks (per spec), once an endpoint had sent an `id:` field, every later blank keepalive line re-dispatched a `ServerSentEvent(data="")`.

Fixed with a per-block `_pending` flag that is set when the current block processes any field and reset on dispatch. Genuine `id`-only, `event`-only and `retry`-only blocks still dispatch; blank keepalive lines no longer do.

## [P3] Accept case-insensitive `Content-Type`

`_check_content_type` compared the media type exactly, so a server returning `Text/Event-Stream` raised `SSEError`. HTTP media types are case-insensitive ([RFC 9110](https://www.rfc-editor.org/rfc/rfc9110#name-media-type)), so the parsed type is now lowercased before comparison.

## Tests

- `test_blank_lines_after_id_do_not_dispatch` - `id: 1\ndata: a\n\n\n\ndata: b\n\n` yields 2 events, not 4.
- `test_id_only_block_is_dispatched` - an `id:`-only block still emits an event.
- `test_content_type_accepted` extended with `Text/Event-Stream` and `TEXT/EVENT-STREAM`.

`_sse.py` stays at 100% coverage.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
