### PR TITLE
Inline SSE header defaults using the `Headers` union operator

### DIFF
--- a/src/httpx2/httpx2/_client.py
+++ b/src/httpx2/httpx2/_client.py
@@ -61,15 +61,6 @@ T = typing.TypeVar("T", bound="Client")
 U = typing.TypeVar("U", bound="AsyncClient")
 
 
-def _merge_sse_headers(headers: HeaderTypes | None) -> Headers:
-    merged = Headers(headers)
-    if "Accept" not in merged:
-        merged["Accept"] = "text/event-stream"
-    if "Cache-Control" not in merged:
-        merged["Cache-Control"] = "no-store"
-    return merged
-
-
 def _is_https_redirect(url: URL, location: URL) -> bool:
     """
     Return 'True' if 'location' is a HTTPS upgrade of 'url'
@@ -888,7 +879,7 @@ class Client(BaseClient):
             files=files,
             json=json,
             params=params,
-            headers=_merge_sse_headers(headers),
+            headers={"Accept": "text/event-stream", "Cache-Control": "no-store"} | Headers(headers),
             cookies=cookies,
             auth=auth,
             follow_redirects=follow_redirects,
@@ -1633,7 +1624,7 @@ class AsyncClient(BaseClient):
             files=files,
             json=json,
             params=params,
-            headers=_merge_sse_headers(headers),
+            headers={"Accept": "text/event-stream", "Cache-Control": "no-store"} | Headers(headers),
             cookies=cookies,
             auth=auth,
             follow_redirects=follow_redirects,


### PR DESCRIPTION
Now that `Headers` supports `|` ([#1047](https://github.com/pydantic/httpx2/pull/1047)), the `_merge_sse_headers` helper is no longer needed. The SSE methods inline the defaults directly:

```python
headers={"Accept": "text/event-stream", "Cache-Control": "no-store"} | Headers(headers)
```

The defaults are on the left and the caller's headers (wrapped in `Headers` to normalize `HeaderTypes`/`None` into a `Mapping`) override them on the right via `__ror__`, so user-supplied values still win. Behavior is unchanged - the existing `test_sets_sse_headers` and `test_user_headers_take_precedence` cover both directions.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

