### PR TITLE
Document server-sent events support

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -44,6 +44,7 @@
         - patch
         - delete
         - stream
+        - sse
         - build_request
         - send
         - close
@@ -66,6 +67,7 @@
         - patch
         - delete
         - stream
+        - sse
         - build_request
         - send
         - aclose
@@ -197,3 +199,21 @@ what gets sent over the wire.*
 * `.auth` - **tuple[str, str]**
 * `.headers` - **Headers**
 * `.ssl_context` - **SSLContext**
+
+## `EventSource`
+
+::: httpx2.EventSource
+    options:
+      members:
+        - response
+
+## `ServerSentEvent`
+
+::: httpx2.ServerSentEvent
+    options:
+      members:
+        - event
+        - data
+        - id
+        - retry
+        - json

--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -24,6 +24,7 @@ For an overview of how to work with HTTPX exceptions, see [Exceptions (Quickstar
                 * RemoteProtocolError
             * ProxyError
             * UnsupportedProtocol
+            * SSEError
         * DecodingError
         * TooManyRedirects
     * HTTPStatusError
@@ -74,6 +75,8 @@ For an overview of how to work with HTTPX exceptions, see [Exceptions (Quickstar
 ::: httpx2.ProxyError
 
 ::: httpx2.UnsupportedProtocol
+
+::: httpx2.SSEError
 
 ::: httpx2.DecodingError
 

--- a/docs/sse.md
+++ b/docs/sse.md
@@ -1,0 +1,77 @@
+# Server-Sent Events
+
+[Server-sent events][mdn] (SSE) let a server push a stream of events to the client over a single long-lived HTTP response with the `text/event-stream` content type. HTTPX has native support for consuming them through `client.sse()`.
+
+## Consuming events
+
+`client.sse()` is a context manager that yields an `EventSource`. Iterating the `EventSource` decodes the stream and yields a `ServerSentEvent` for each event:
+
+```pycon
+>>> with httpx2.Client() as client:
+...     with client.sse("https://example.com/sse") as source:
+...         for event in source:
+...             print(event.event, event.data)
+```
+
+It works the same way with the async client, using `async with` and `async for`:
+
+```pycon
+>>> async with httpx2.AsyncClient() as client:
+...     async with client.sse("https://example.com/sse") as source:
+...         async for event in source:
+...             print(event.event, event.data)
+```
+
+`sse()` issues a `GET` request by default. Some APIs stream events in response to a `POST` - pass `method="POST"` along with the usual request arguments:
+
+```pycon
+>>> with client.sse("https://example.com/sse", method="POST", json={"query": "..."}) as source:
+...     for event in source:
+...         print(event.data)
+```
+
+The `Accept: text/event-stream` and `Cache-Control: no-store` headers are set for you; any headers you pass take precedence.
+
+## The `ServerSentEvent`
+
+Each event exposes the fields defined by the SSE specification:
+
+| Attribute | Description |
+| --------- | ----------- |
+| `event`   | The event type. Defaults to `"message"`. |
+| `data`    | The event payload. Multiple `data:` lines are joined with `\n`. |
+| `id`      | The last event ID, which persists across events until changed. |
+| `retry`   | The reconnection time in milliseconds, or `None`. |
+
+When the payload is JSON, `event.json()` decodes `event.data` for you:
+
+```pycon
+>>> with client.sse("https://example.com/sse") as source:
+...     for event in source:
+...         print(event.json())
+```
+
+## Accessing the response
+
+The underlying [`Response`](api.md#response) is available as `source.response`, which is useful for inspecting the status code or headers before iterating:
+
+```pycon
+>>> with client.sse("https://example.com/sse") as source:
+...     source.response.raise_for_status()
+...     for event in source:
+...         print(event.data)
+```
+
+## Error handling
+
+If the response does not have a `text/event-stream` content type, iterating the `EventSource` raises `SSEError`:
+
+```pycon
+>>> with client.sse("https://example.com/not-an-event-stream") as source:
+...     for event in source:  # raises httpx2.SSEError
+...         ...
+```
+
+`SSEError` is a subclass of [`TransportError`](exceptions.md), so it is also caught by `except httpx2.TransportError`.
+
+[mdn]: https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,7 @@ nav:
     - Guides:
         - Async Support: 'async.md'
         - HTTP/2 Support: 'http2.md'
+        - Server-Sent Events: 'sse.md'
         - Logging: 'logging.md'
         - Requests Compatibility: 'compatibility.md'
         - Troubleshooting: 'troubleshooting.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,8 +37,8 @@ nav:
     - Guides:
         - Async Support: 'async.md'
         - HTTP/2 Support: 'http2.md'
-        - Server-Sent Events: 'sse.md'
         - Logging: 'logging.md'
+        - Server-Sent Events: 'sse.md'
         - Requests Compatibility: 'compatibility.md'
         - Troubleshooting: 'troubleshooting.md'
     - API Reference:


### PR DESCRIPTION
Documents the server-sent events feature added in [#1046](https://github.com/pydantic/httpx2/pull/1046).

- New **Server-Sent Events** guide (`docs/sse.md`), added to the nav under Guides. Covers `client.sse()` for sync and async, `POST` streaming, the `ServerSentEvent` fields and `.json()`, accessing the underlying response, and `SSEError`.
- `api.md`: `sse` added to the `Client` / `AsyncClient` member lists, with new `EventSource` and `ServerSentEvent` reference sections.
- `exceptions.md`: `SSEError` added to the hierarchy (under `TransportError`) and the class listing.

`zensical build` produces no new warnings.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1050?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

