### PR TITLE
Version 2.5.0

### DIFF
--- a/src/httpcore2/CHANGELOG.md
+++ b/src/httpcore2/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2.5.0 (June 25th, 2026)
+
+### Fixed
+
+* Propagate the timeout through the SOCKS5 handshake. ([#1009](https://github.com/pydantic/httpx2/pull/1009))
+
 ## 2.4.0 (June 11th, 2026)
 
 ### Fixed

--- a/src/httpx2/CHANGELOG.md
+++ b/src/httpx2/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Add native server-sent events support via `client.sse()`. ([#1046](https://github.com/pydantic/httpx2/pull/1046))
 * Support `|` and `|=` operators for `Headers`. ([#1047](https://github.com/pydantic/httpx2/pull/1047))
 
+### Fixed
+
+* Allow IPv6 CIDR notation in `no_proxy`. ([#967](https://github.com/pydantic/httpx2/pull/967))
+
 ## 2.4.0 (June 11th, 2026)
 
 ### Added

--- a/src/httpx2/CHANGELOG.md
+++ b/src/httpx2/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2.5.0 (June 25th, 2026)
+
+### Added
+
+* Add native server-sent events support via `client.sse()`. ([#1046](https://github.com/pydantic/httpx2/pull/1046))
+* Support `|` and `|=` operators for `Headers`. ([#1047](https://github.com/pydantic/httpx2/pull/1047))
+
 ## 2.4.0 (June 11th, 2026)
 
 ### Added


### PR DESCRIPTION
Bumps both packages to 2.5.0, covering everything merged since 2.4.0.

### httpx2
- **Added**: native server-sent events support via `client.sse()` ([#1046](https://github.com/pydantic/httpx2/pull/1046), with keepalive/content-type fixes from [#1048](https://github.com/pydantic/httpx2/pull/1048)); `|` and `|=` operators for `Headers` ([#1047](https://github.com/pydantic/httpx2/pull/1047)).
- **Fixed**: allow IPv6 CIDR notation in `no_proxy` ([#967](https://github.com/pydantic/httpx2/pull/967)).

### httpcore2
- **Fixed**: propagate the timeout through the SOCKS5 handshake ([#1009](https://github.com/pydantic/httpx2/pull/1009)).

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
