### PR TITLE
Filter caplog to httpx2 records and require pytest >= 9.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dev = [
   "chardet==6.0.0.post1",
   "coverage[toml]==7.10.6",
   "cryptography==46.0.7",
-  "pytest>=9.0.3",
+  "pytest>=9.1.0",
   "pytest-codspeed>=4.1.1",
   "pytest-httpbin==2.0.0",
   "pytest-trio==0.8.0",

--- a/tests/httpx2/test_utils.py
+++ b/tests/httpx2/test_utils.py
@@ -62,7 +62,8 @@ def test_logging_request(server: TestServer, caplog: pytest.LogCaptureFixture) -
         response = client.get(server.url)
         assert response.status_code == 200
 
-    assert caplog.record_tuples == [
+    httpx2_records = [r for r in caplog.record_tuples if r[0] == "httpx2"]
+    assert httpx2_records == [
         (
             "httpx2",
             logging.INFO,
@@ -78,7 +79,8 @@ def test_logging_redirect_chain(server: TestServer, caplog: pytest.LogCaptureFix
         response = client.get(redirect_url)
         assert response.status_code == 200
 
-    assert caplog.record_tuples == [
+    httpx2_records = [r for r in caplog.record_tuples if r[0] == "httpx2"]
+    assert httpx2_records == [
         (
             "httpx2",
             logging.INFO,

--- a/uv.lock
+++ b/uv.lock
@@ -36,7 +36,7 @@ dev = [
     { name = "httpcore2", extras = ["asyncio", "trio", "http2", "socks"], editable = "src/httpcore2" },
     { name = "httpx2", extras = ["brotli", "cli", "http2", "socks", "zstd"], editable = "src/httpx2" },
     { name = "mypy", specifier = "==1.17.1" },
-    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest", specifier = ">=9.1.0" },
     { name = "pytest-codspeed", specifier = ">=4.1.1" },
     { name = "pytest-httpbin", specifier = "==2.0.0" },
     { name = "pytest-trio", specifier = "==0.8.0" },
@@ -2731,7 +2731,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -2742,9 +2742,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX2! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

pytest 9.1.0 (gh#pytest-dev/pytest#3697) now captures log records from non-propagating loggers, causing uvicorn.access records to appear in caplog.record_tuples. Filter to only httpx2 records in assertions.

Assisted-by: Claude Opus 4.6

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

