### PR TITLE
Preserve the response when a redirect has an invalid Location and redirects are not followed

### DIFF
--- a/src/httpx2/httpx2/_client.py
+++ b/src/httpx2/httpx2/_client.py
@@ -1054,13 +1054,18 @@ class Client(BaseClient):
                 if not response.has_redirect_location:
                     return response
 
-                request = self._build_redirect_request(request, response)
-                history = history + [response]
-
                 if follow_redirects:
+                    request = self._build_redirect_request(request, response)
+                    history = history + [response]
                     response.read()
                 else:
-                    response.next_request = request
+                    # When not following redirects, building the next request is
+                    # best-effort: a malformed 'Location' must not discard the
+                    # response and its headers. Leave next_request as None.
+                    try:
+                        response.next_request = self._build_redirect_request(request, response)
+                    except (InvalidURL, RemoteProtocolError):
+                        pass
                     return response
 
             except BaseException as exc:
@@ -1892,13 +1897,18 @@ class AsyncClient(BaseClient):
                 if not response.has_redirect_location:
                     return response
 
-                request = self._build_redirect_request(request, response)
-                history = history + [response]
-
                 if follow_redirects:
+                    request = self._build_redirect_request(request, response)
+                    history = history + [response]
                     await response.aread()
                 else:
-                    response.next_request = request
+                    # When not following redirects, building the next request is
+                    # best-effort: a malformed 'Location' must not discard the
+                    # response and its headers. Leave next_request as None.
+                    try:
+                        response.next_request = self._build_redirect_request(request, response)
+                    except (InvalidURL, RemoteProtocolError):
+                        pass
                     return response
 
             except BaseException as exc:

--- a/tests/httpx2/client/test_redirects.py
+++ b/tests/httpx2/client/test_redirects.py
@@ -208,6 +208,17 @@ def test_invalid_redirect() -> None:
         client.get("http://example.org/invalid_redirect", follow_redirects=True)
 
 
+def test_invalid_redirect_not_followed() -> None:
+    # A malformed 'Location' must not discard the response when we are not
+    # following redirects: the response and its headers are returned as-is,
+    # with next_request left as None.
+    client = httpx2.Client(transport=httpx2.MockTransport(redirects))
+    response = client.get("http://example.org/invalid_redirect", follow_redirects=False)
+    assert response.status_code == httpx2.codes.SEE_OTHER
+    assert response.headers["location"] == "https://😇/"
+    assert response.next_request is None
+
+
 def test_no_scheme_redirect() -> None:
     client = httpx2.Client(transport=httpx2.MockTransport(redirects))
     response = client.get("https://example.org/no_scheme_redirect", follow_redirects=True)
@@ -458,3 +469,12 @@ async def test_async_invalid_redirect() -> None:
     async with httpx2.AsyncClient(transport=httpx2.MockTransport(redirects)) as client:
         with pytest.raises(httpx2.RemoteProtocolError):
             await client.get("http://example.org/invalid_redirect", follow_redirects=True)
+
+
+@pytest.mark.anyio
+async def test_async_invalid_redirect_not_followed() -> None:
+    async with httpx2.AsyncClient(transport=httpx2.MockTransport(redirects)) as client:
+        response = await client.get("http://example.org/invalid_redirect", follow_redirects=False)
+        assert response.status_code == httpx2.codes.SEE_OTHER
+        assert response.headers["location"] == "https://😇/"
+        assert response.next_request is None


### PR DESCRIPTION
### Description

When `follow_redirects=False` and a 3XX response carries a malformed `Location` header (e.g. a `data:` URI), `_send_handling_redirects` builds the redirect request *before* checking `follow_redirects`, so `_redirect_url` raises `RemoteProtocolError` and the response — along with its headers — is discarded. A caller that only wants to **inspect** the redirect without following it never gets the response.

This is a real-world need: the [Wapiti](https://github.com/wapiti-scanner/wapiti) web scanner reads the `Location` header of such responses to detect reflected payloads, and currently cannot — see wapiti-scanner/wapiti#690. A malformed `Location` is still part of an otherwise valid HTTP response; not following the redirect shouldn't mean losing the response.

The same fix was proposed upstream in encode/httpx#3706 (still open, refs discussion encode/httpx#3179) and is already shipped by the `httpxyz` fork.

### The fix

Defer building the redirect request to the branch that actually follows redirects. When not following, building `next_request` is best-effort: a malformed `Location` leaves `next_request=None` and the response is returned intact. Applied to both the sync and async `_send_handling_redirects`.

```python
response = httpx2.get(url, follow_redirects=False)  # url 302s to a data: URI
assert response.status_code == 302
assert response.headers["location"] == "data:..."   # header preserved
assert response.next_request is None
```

Following redirects (`follow_redirects=True`) still raises `RemoteProtocolError` on an invalid `Location`, unchanged.

### Tests

Adds sync and async regression tests (`test_invalid_redirect_not_followed`) reusing the existing `/invalid_redirect` mock endpoint. `scripts/check` (ruff format, mypy, ruff check, unasync) and the redirect test suite pass.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

