### PR TITLE
Update vendored httpx-ws to upstream v0.9.0

### DIFF
--- a/docs/websockets.md
+++ b/docs/websockets.md
@@ -66,7 +66,7 @@ The `receive` methods block until a message is available. Pass a `timeout` in se
 >>> ws.receive_text(timeout=2.0)
 ```
 
-If no message arrives in time, the sync session raises `queue.Empty`, while the async session raises `TimeoutError`.
+If no message arrives in time, `TimeoutError` is raised.
 
 If the received message doesn't match the expected type, `WebSocketInvalidTypeReceived` is raised.
 

--- a/src/httpx2/httpx2/websockets/__init__.py
+++ b/src/httpx2/httpx2/websockets/__init__.py
@@ -4,7 +4,13 @@ WebSocket support, derived from httpx-ws (https://github.com/frankie567/httpx-ws
 Copyright (c) 2021 François Voron, MIT License (https://github.com/frankie567/httpx-ws/blob/main/LICENSE).
 """
 
-from ._api import AsyncWebSocketSession, JSONMode, WebSocketSession
+from ._api import (
+    AsyncWebSocketClient,
+    AsyncWebSocketSession,
+    JSONMode,
+    WebSocketClient,
+    WebSocketSession,
+)
 from ._exceptions import (
     HTTPXWSException,
     WebSocketDisconnect,
@@ -16,9 +22,11 @@ from ._transport import ASGIWebSocketTransport
 
 __all__ = [
     "ASGIWebSocketTransport",
+    "AsyncWebSocketClient",
     "AsyncWebSocketSession",
     "HTTPXWSException",
     "JSONMode",
+    "WebSocketClient",
     "WebSocketDisconnect",
     "WebSocketInvalidTypeReceived",
     "WebSocketNetworkError",

--- a/src/httpx2/httpx2/websockets/_api.py
+++ b/src/httpx2/httpx2/websockets/_api.py
@@ -6,12 +6,19 @@ import contextlib
 import json
 import queue
 import secrets
+import sys
 import threading
 import typing
 from types import TracebackType
 
+if sys.version_info >= (3, 13):
+    from typing import TypeVar  # pragma: no cover
+else:
+    from typing_extensions import TypeVar  # pragma: no cover
+
 import anyio
 import wsproto
+import wsproto.utilities
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from wsproto.frame_protocol import CloseReason
 
@@ -50,9 +57,15 @@ if typing.TYPE_CHECKING:
 JSONMode = typing.Literal["text", "binary"]
 TaskFunction = typing.TypeVar("TaskFunction")
 TaskResult = typing.TypeVar("TaskResult")
+SyncSession = TypeVar("SyncSession", bound="WebSocketSession", default="WebSocketSession")
+AsyncSession = TypeVar("AsyncSession", bound="AsyncWebSocketSession", default="AsyncWebSocketSession")
 
 
 class ShouldClose(Exception):
+    pass
+
+
+class EndOfStream(Exception):
     pass
 
 
@@ -92,6 +105,7 @@ class WebSocketSession:
 
         self._ping_manager = PingManager()
         self._should_close = threading.Event()
+        self._write_lock = threading.Lock()
         self._should_close_task: concurrent.futures.Future[bool] | None = None
         self._executor: concurrent.futures.ThreadPoolExecutor | None = None
 
@@ -190,7 +204,8 @@ class WebSocketSession:
 
         try:
             data = self.connection.send(event)
-            self.stream.write(data)
+            with self._write_lock:
+                self.stream.write(data)
         except httpcore2.WriteError as e:
             self.close(CloseReason.INTERNAL_ERROR, "Stream write error")
             raise WebSocketNetworkError() from e
@@ -275,7 +290,7 @@ class WebSocketSession:
             A raw [wsproto.events.Event][wsproto.events.Event].
 
         Raises:
-            queue.Empty: No event was received before the timeout delay.
+            TimeoutError: No event was received before the timeout delay.
             WebSocketDisconnect: The server closed the websocket.
             WebSocketNetworkError: A network error occured.
 
@@ -291,12 +306,15 @@ class WebSocketSession:
 
                 try:
                     event = ws.receive(timeout=2.)
-                except queue.Empty:
+                except TimeoutError:
                     print("No event received.")
                 except WebSocketDisconnect:
                     print("Connection closed")
         """
-        event = self._events.get(block=True, timeout=timeout)
+        try:
+            event = self._events.get(block=True, timeout=timeout)
+        except queue.Empty as e:
+            raise TimeoutError from e
         if isinstance(event, HTTPXWSException):
             raise event
         if isinstance(event, wsproto.events.CloseConnection):
@@ -316,7 +334,7 @@ class WebSocketSession:
             Text data.
 
         Raises:
-            queue.Empty: No event was received before the timeout delay.
+            TimeoutError: No event was received before the timeout delay.
             WebSocketDisconnect: The server closed the websocket.
             WebSocketNetworkError: A network error occured.
             WebSocketInvalidTypeReceived: The received event was not a text message.
@@ -333,7 +351,7 @@ class WebSocketSession:
 
                 try:
                     event = ws.receive_text(timeout=2.)
-                except queue.Empty:
+                except TimeoutError:
                     print("No text received.")
                 except WebSocketDisconnect:
                     print("Connection closed")
@@ -356,7 +374,7 @@ class WebSocketSession:
             Bytes data.
 
         Raises:
-            queue.Empty: No event was received before the timeout delay.
+            TimeoutError: No event was received before the timeout delay.
             WebSocketDisconnect: The server closed the websocket.
             WebSocketNetworkError: A network error occured.
             WebSocketInvalidTypeReceived: The received event was not a bytes message.
@@ -373,7 +391,7 @@ class WebSocketSession:
 
                 try:
                     data = ws.receive_bytes(timeout=2.)
-                except queue.Empty:
+                except TimeoutError:
                     print("No data received.")
                 except WebSocketDisconnect:
                     print("Connection closed")
@@ -400,7 +418,7 @@ class WebSocketSession:
             Parsed JSON data.
 
         Raises:
-            queue.Empty: No event was received before the timeout delay.
+            TimeoutError: No event was received before the timeout delay.
             WebSocketDisconnect: The server closed the websocket.
             WebSocketNetworkError: A network error occured.
             WebSocketInvalidTypeReceived: The received event
@@ -418,7 +436,7 @@ class WebSocketSession:
 
                 try:
                     data = ws.receive_json(timeout=2.)
-                except queue.Empty:
+                except TimeoutError:
                     print("No data received.")
                 except WebSocketDisconnect:
                     print("Connection closed")
@@ -463,7 +481,8 @@ class WebSocketSession:
             event = wsproto.events.CloseConnection(code, reason)
             data = self.connection.send(event)
             try:
-                self.stream.write(data)
+                with self._write_lock:
+                    self.stream.write(data)
             except httpcore2.WriteError:
                 pass
         self.stream.close()
@@ -487,12 +506,13 @@ class WebSocketSession:
         partial_message_buffer: str | bytes | None = None
         try:
             while not self._should_close.is_set():
-                data = self._wait_until_closed(self.stream.read, max_bytes)
+                data = self._wait_until_closed(self._read_stream, max_bytes)
                 self.connection.receive_data(data)
                 for event in self.connection.events():
                     if isinstance(event, wsproto.events.Ping):
                         data = self.connection.send(event.response())
-                        self.stream.write(data)
+                        with self._write_lock:
+                            self.stream.write(data)
                         continue
                     if isinstance(event, wsproto.events.Pong):
                         self._ping_manager.ack(event.payload)
@@ -517,7 +537,7 @@ class WebSocketSession:
                             self._events.put(full_message_event)
                         continue
                     self._events.put(event)
-        except (httpcore2.ReadError, httpcore2.WriteError):
+        except (httpcore2.ReadError, httpcore2.WriteError, EndOfStream):
             self.close(CloseReason.INTERNAL_ERROR, "Stream error")
             self._events.put(WebSocketNetworkError())
         except ShouldClose:
@@ -557,10 +577,38 @@ class WebSocketSession:
             result = todo_task.result()
         return result
 
+    def _read_stream(self, max_bytes: int) -> bytes:
+        data = self.stream.read(max_bytes)
+        if data == b"":
+            raise EndOfStream()
+        return data
 
-class AsyncWebSocketSession:
+
+class AsyncWebSocketSession(anyio.AsyncContextManagerMixin):
     """
     Async context manager representing an opened WebSocket session.
+
+    Internally, this session uses an anyio task group to manage background tasks.
+    As a result, exceptions that are not caught inside the context manager
+    and propagate out of the `async with` block will be wrapped
+    in an [ExceptionGroup][ExceptionGroup].
+
+    To handle them, use the `except*` syntax:
+
+        async with AsyncWebSocketSession(stream) as ws:
+            try:
+                data = await ws.receive_text()
+            except WebSocketDisconnect:
+                # Caught inside the context manager: plain exception.
+                print("Connection closed")
+
+        # If not caught inside:
+        try:
+            async with AsyncWebSocketSession(stream) as ws:
+                data = await ws.receive_text()
+        except* WebSocketDisconnect:
+            # Propagated out of the context manager: wrapped in ExceptionGroup.
+            print("Connection closed")
 
     Attributes:
         subprotocol (typing.Optional[str]):
@@ -594,6 +642,7 @@ class AsyncWebSocketSession:
 
         self._ping_manager = AsyncPingManager()
         self._should_close = anyio.Event()
+        self._write_lock = anyio.Lock()
 
         self._max_message_size_bytes = max_message_size_bytes
         self._queue_size = queue_size
@@ -606,17 +655,14 @@ class AsyncWebSocketSession:
             self._keepalive_ping_interval_seconds = keepalive_ping_interval_seconds
             self._keepalive_ping_timeout_seconds = keepalive_ping_timeout_seconds
 
-    async def __aenter__(self) -> AsyncWebSocketSession:
-        async with contextlib.AsyncExitStack() as exit_stack:
-            self._send_event, self._receive_event = anyio.create_memory_object_stream[
-                wsproto.events.Event | HTTPXWSException
-            ]()
-            exit_stack.enter_context(self._send_event)
-            exit_stack.enter_context(self._receive_event)
+    @contextlib.asynccontextmanager
+    async def __asynccontextmanager__(self) -> typing.AsyncGenerator[AsyncWebSocketSession, None]:
+        self._send_event, self._receive_event = anyio.create_memory_object_stream[
+            wsproto.events.Event | HTTPXWSException
+        ]()
+        self._background_task_group = anyio.create_task_group()
 
-            self._background_task_group = anyio.create_task_group()
-            await exit_stack.enter_async_context(self._background_task_group)
-
+        async with self._send_event, self._receive_event, self._background_task_group:
             self._background_task_group.start_soon(self._background_receive, self._max_message_size_bytes)
             if self._keepalive_ping_interval_seconds is not None:
                 self._background_task_group.start_soon(
@@ -625,19 +671,12 @@ class AsyncWebSocketSession:
                     self._keepalive_ping_timeout_seconds,
                 )
 
-            exit_stack.callback(self._background_task_group.cancel_scope.cancel)
-            exit_stack.push_async_callback(self.close)
-            self._exit_stack = exit_stack.pop_all()
-
-        return self
-
-    async def __aexit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc: BaseException | None,
-        tb: TracebackType | None,
-    ) -> None:
-        await self._exit_stack.aclose()
+            try:
+                yield self
+            finally:
+                self._background_task_group.cancel_scope.cancel()
+                with anyio.CancelScope(shield=True):
+                    await self.close()
 
     async def ping(self, payload: bytes = b"") -> anyio.Event:
         """
@@ -680,6 +719,11 @@ class AsyncWebSocketSession:
         Raises:
             WebSocketNetworkError: A network error occured.
 
+        Note:
+            Exceptions not caught inside the context manager will be
+            wrapped in an [ExceptionGroup][ExceptionGroup]. Use `except*` to catch them
+            outside the `async with` block.
+
         Examples:
             Send an event.
 
@@ -690,7 +734,8 @@ class AsyncWebSocketSession:
 
         try:
             data = self.connection.send(event)
-            await self.stream.write(data)
+            async with self._write_lock:
+                await self.stream.write(data)
         except httpcore2.WriteError as e:
             await self.close(CloseReason.INTERNAL_ERROR, "Stream write error")
             raise WebSocketNetworkError() from e
@@ -704,6 +749,11 @@ class AsyncWebSocketSession:
 
         Raises:
             WebSocketNetworkError: A network error occured.
+
+        Note:
+            Exceptions not caught inside the context manager will be
+            wrapped in an [ExceptionGroup][ExceptionGroup]. Use `except*` to catch them
+            outside the `async with` block.
 
         Examples:
             Send a text message.
@@ -722,6 +772,11 @@ class AsyncWebSocketSession:
 
         Raises:
             WebSocketNetworkError: A network error occured.
+
+        Note:
+            Exceptions not caught inside the context manager will be
+            wrapped in an [ExceptionGroup][ExceptionGroup]. Use `except*` to catch them
+            outside the `async with` block.
 
         Examples:
             Send a bytes message.
@@ -743,6 +798,11 @@ class AsyncWebSocketSession:
 
         Raises:
             WebSocketNetworkError: A network error occured.
+
+        Note:
+            Exceptions not caught inside the context manager will be
+            wrapped in an [ExceptionGroup][ExceptionGroup]. Use `except*` to catch them
+            outside the `async with` block.
 
         Examples:
             Send JSON data.
@@ -778,6 +838,11 @@ class AsyncWebSocketSession:
             TimeoutError: No event was received before the timeout delay.
             WebSocketDisconnect: The server closed the websocket.
             WebSocketNetworkError: A network error occured.
+
+        Note:
+            Exceptions not caught inside the context manager will be
+            wrapped in an [ExceptionGroup][ExceptionGroup]. Use `except*` to catch them
+            outside the `async with` block.
 
         Examples:
             Wait for an event until one is available.
@@ -822,6 +887,11 @@ class AsyncWebSocketSession:
             WebSocketNetworkError: A network error occured.
             WebSocketInvalidTypeReceived: The received event was not a text message.
 
+        Note:
+            Exceptions not caught inside the context manager will be
+            wrapped in an [ExceptionGroup][ExceptionGroup]. Use `except*` to catch them
+            outside the `async with` block.
+
         Examples:
             Wait for text until available.
 
@@ -861,6 +931,11 @@ class AsyncWebSocketSession:
             WebSocketDisconnect: The server closed the websocket.
             WebSocketNetworkError: A network error occured.
             WebSocketInvalidTypeReceived: The received event was not a bytes message.
+
+        Note:
+            Exceptions not caught inside the context manager will be
+            wrapped in an [ExceptionGroup][ExceptionGroup]. Use `except*` to catch them
+            outside the `async with` block.
 
         Examples:
             Wait for bytes until available.
@@ -906,6 +981,11 @@ class AsyncWebSocketSession:
             WebSocketNetworkError: A network error occured.
             WebSocketInvalidTypeReceived: The received event
                 didn't correspond to the specified mode.
+
+        Note:
+            Exceptions not caught inside the context manager will be
+            wrapped in an [ExceptionGroup][ExceptionGroup]. Use `except*` to catch them
+            outside the `async with` block.
 
         Examples:
             Wait for data until available.
@@ -962,7 +1042,8 @@ class AsyncWebSocketSession:
             event = wsproto.events.CloseConnection(code, reason)
             data = self.connection.send(event)
             try:
-                await self.stream.write(data)
+                async with self._write_lock:
+                    await self.stream.write(data)
             except httpcore2.WriteError:
                 pass
         await self.stream.aclose()
@@ -986,12 +1067,13 @@ class AsyncWebSocketSession:
         partial_message_buffer: str | bytes | None = None
         try:
             while not self._should_close.is_set():
-                data = await self.stream.read(max_bytes=max_bytes)
+                data = await self._read_stream(max_bytes)
                 self.connection.receive_data(data)
                 for event in self.connection.events():
                     if isinstance(event, wsproto.events.Ping):
                         data = self.connection.send(event.response())
-                        await self.stream.write(data)
+                        async with self._write_lock:
+                            await self.stream.write(data)
                         continue
                     if isinstance(event, wsproto.events.Pong):
                         self._ping_manager.ack(event.payload)
@@ -1016,16 +1098,20 @@ class AsyncWebSocketSession:
                             await self._send_event.send(full_message_event)
                         continue
                     await self._send_event.send(event)
-        except (httpcore2.ReadError, httpcore2.WriteError):
+        except (httpcore2.ReadError, httpcore2.WriteError, EndOfStream):
             await self.close(CloseReason.INTERNAL_ERROR, "Stream error")
             await self._send_event.send(WebSocketNetworkError())
 
     async def _background_keepalive_ping(self, interval_seconds: float, timeout_seconds: float | None = None) -> None:
         while not self._should_close.is_set():
             await anyio.sleep(interval_seconds)
-            if self._should_close.is_set():
+
+            try:
+                pong_callback = await self.ping()
+            # Connection is closing, exit the task
+            except wsproto.utilities.LocalProtocolError:
                 return
-            pong_callback = await self.ping()
+
             if timeout_seconds is not None:
                 try:
                     with anyio.fail_after(timeout_seconds):
@@ -1033,6 +1119,12 @@ class AsyncWebSocketSession:
                 except TimeoutError:
                     await self.close(CloseReason.INTERNAL_ERROR, "Keepalive ping timeout")
                     await self._send_event.send(WebSocketNetworkError())
+
+    async def _read_stream(self, max_bytes: int) -> bytes:
+        data = await self.stream.read(max_bytes)
+        if data == b"":
+            raise EndOfStream()
+        return data
 
 
 def _get_headers(
@@ -1049,47 +1141,133 @@ def _get_headers(
     return headers
 
 
-@contextlib.contextmanager
-def _connect_ws(
-    url: str,
-    client: Client,
-    *,
-    max_message_size_bytes: int = DEFAULT_MAX_MESSAGE_SIZE_BYTES,
-    queue_size: int = DEFAULT_QUEUE_SIZE,
-    keepalive_ping_interval_seconds: float | None = DEFAULT_KEEPALIVE_PING_INTERVAL_SECONDS,
-    keepalive_ping_timeout_seconds: float | None = DEFAULT_KEEPALIVE_PING_TIMEOUT_SECONDS,
-    subprotocols: list[str] | None = None,
-    params: QueryParamTypes | None = None,
-    headers: HeaderTypes | None = None,
-    cookies: CookieTypes | None = None,
-    auth: AuthTypes | UseClientDefault | None = USE_CLIENT_DEFAULT,
-    follow_redirects: bool | UseClientDefault = USE_CLIENT_DEFAULT,
-    timeout: TimeoutTypes | UseClientDefault = USE_CLIENT_DEFAULT,
-    extensions: RequestExtensions | None = None,
-) -> typing.Generator[WebSocketSession, None, None]:
-    with client.stream(
-        "GET",
-        url,
-        params=params,
-        headers=Headers(headers) | _get_headers(subprotocols),
-        cookies=cookies,
-        auth=auth,
-        follow_redirects=follow_redirects,
-        timeout=timeout,
-        extensions=extensions,
-    ) as response:
-        if response.status_code != 101:
-            raise WebSocketUpgradeError(response)
+class WebSocketClient(typing.Generic[SyncSession]):
+    """
+    A sync WebSocket client.
 
-        with WebSocketSession(
-            response.extensions["network_stream"],
-            max_message_size_bytes=max_message_size_bytes,
-            queue_size=queue_size,
-            keepalive_ping_interval_seconds=keepalive_ping_interval_seconds,
-            keepalive_ping_timeout_seconds=keepalive_ping_timeout_seconds,
-            response=response,
-        ) as session:
-            yield session
+    This class provides an API for connecting to WebSocket.
+
+    Attributes:
+        client:
+            HTTPX client to use.
+        max_message_size_bytes:
+            Message size in bytes to receive from the server.
+            Defaults to 65 KiB.
+        queue_size:
+            Size of the queue where the received messages will be held
+            until they are consumed.
+            If the queue is full, the client will stop receive messages
+            from the server until the queue has room available.
+            Defaults to 512.
+        keepalive_ping_interval_seconds:
+            Interval at which the client will automatically send a Ping event
+            to keep the connection alive. Set it to `None` to disable this mechanism.
+            Defaults to 20 seconds.
+        keepalive_ping_timeout_seconds:
+            Maximum delay the client will wait for an answer to its Ping event.
+            If the delay is exceeded,
+            [WebSocketNetworkError][httpx_ws.WebSocketNetworkError]
+            will be raised and the connection closed.
+            Defaults to 20 seconds.
+        session_class:
+            The session class to use.
+            Defaults to [WebSocketSession][httpx_ws.WebSocketSession].
+    """
+
+    def __init__(
+        self,
+        client: Client,
+        *,
+        max_message_size_bytes: int = DEFAULT_MAX_MESSAGE_SIZE_BYTES,
+        queue_size: int = DEFAULT_QUEUE_SIZE,
+        keepalive_ping_interval_seconds: float | None = DEFAULT_KEEPALIVE_PING_INTERVAL_SECONDS,
+        keepalive_ping_timeout_seconds: float | None = DEFAULT_KEEPALIVE_PING_TIMEOUT_SECONDS,
+        session_class: type[SyncSession] = WebSocketSession,  # type: ignore[assignment]
+    ) -> None:
+        self.client = client
+        self.max_message_size_bytes = max_message_size_bytes
+        self.queue_size = queue_size
+        self.keepalive_ping_interval_seconds = keepalive_ping_interval_seconds
+        self.keepalive_ping_timeout_seconds = keepalive_ping_timeout_seconds
+        self.session_class = session_class
+
+    @contextlib.contextmanager
+    def connect(
+        self,
+        url: str,
+        *,
+        subprotocols: list[str] | None = None,
+        params: QueryParamTypes | None = None,
+        headers: HeaderTypes | None = None,
+        cookies: CookieTypes | None = None,
+        auth: AuthTypes | UseClientDefault | None = USE_CLIENT_DEFAULT,
+        follow_redirects: bool | UseClientDefault = USE_CLIENT_DEFAULT,
+        timeout: TimeoutTypes | UseClientDefault = USE_CLIENT_DEFAULT,
+        extensions: RequestExtensions | None = None,
+    ) -> typing.Generator[SyncSession, None, None]:
+        """
+        Start a sync WebSocket session.
+
+        It returns a context manager that'll automatically
+        call [close()][httpx_ws.WebSocketSession.close] when exiting.
+
+        Args:
+            url: The WebSocket URL.
+            subprotocols:
+                Optional list of subprotocols to negotiate with the server.
+            params:
+                Query parameters to include in the handshake request.
+            headers:
+                Headers to include in the handshake request.
+            cookies:
+                Cookies to include in the handshake request.
+            auth:
+                Authentication to use for the handshake request.
+            follow_redirects:
+                Whether to follow redirects on the handshake request.
+            timeout:
+                Timeout configuration for the handshake request.
+            extensions:
+                Request extensions for the handshake request.
+
+        Returns:
+            A [context manager][contextlib.AbstractContextManager]
+                for [WebSocketSession][httpx_ws.WebSocketSession].
+
+        Examples:
+            Initialize the client and connect to a WebSocket.
+
+                with httpx2.Client() as client:
+                    ws_client = WebSocketClient(client)
+                    with ws_client.connect("http://localhost:8000/ws") as ws:
+                        message = ws.receive_text()
+                        print(message)
+                        ws.send_text("Hello!")
+        """
+        with self.client.stream(
+            "GET",
+            url,
+            params=params,
+            headers=Headers(headers) | _get_headers(subprotocols),
+            cookies=cookies,
+            auth=auth,
+            follow_redirects=follow_redirects,
+            timeout=timeout,
+            extensions=extensions,
+        ) as response:
+            if response.status_code != 101:
+                raise WebSocketUpgradeError(response)
+
+            session = self.session_class(
+                response.extensions["network_stream"],
+                max_message_size_bytes=self.max_message_size_bytes,
+                queue_size=self.queue_size,
+                keepalive_ping_interval_seconds=self.keepalive_ping_interval_seconds,
+                keepalive_ping_timeout_seconds=self.keepalive_ping_timeout_seconds,
+                response=response,
+            )
+            with session:
+                yield session
 
 
 @contextlib.contextmanager
@@ -1141,7 +1319,7 @@ def connect_ws(
             will be raised and the connection closed.
             Defaults to 20 seconds.
         subprotocols:
-            Optional list of suprotocols to negotiate with the server.
+            Optional list of subprotocols to negotiate with the server.
         params:
             Query parameters to include in the handshake request.
         headers:
@@ -1185,13 +1363,15 @@ def connect_ws(
         owned_client = contextlib.nullcontext(client)
 
     with owned_client as client:
-        with _connect_ws(
-            url,
+        ws_client = WebSocketClient(
             client=client,
             max_message_size_bytes=max_message_size_bytes,
             queue_size=queue_size,
             keepalive_ping_interval_seconds=keepalive_ping_interval_seconds,
             keepalive_ping_timeout_seconds=keepalive_ping_timeout_seconds,
+        )
+        with ws_client.connect(
+            url,
             subprotocols=subprotocols,
             params=params,
             headers=headers,
@@ -1204,47 +1384,133 @@ def connect_ws(
             yield websocket
 
 
-@contextlib.asynccontextmanager
-async def _aconnect_ws(
-    url: str,
-    client: AsyncClient,
-    *,
-    max_message_size_bytes: int = DEFAULT_MAX_MESSAGE_SIZE_BYTES,
-    queue_size: int = DEFAULT_QUEUE_SIZE,
-    keepalive_ping_interval_seconds: float | None = DEFAULT_KEEPALIVE_PING_INTERVAL_SECONDS,
-    keepalive_ping_timeout_seconds: float | None = DEFAULT_KEEPALIVE_PING_TIMEOUT_SECONDS,
-    subprotocols: list[str] | None = None,
-    params: QueryParamTypes | None = None,
-    headers: HeaderTypes | None = None,
-    cookies: CookieTypes | None = None,
-    auth: AuthTypes | UseClientDefault | None = USE_CLIENT_DEFAULT,
-    follow_redirects: bool | UseClientDefault = USE_CLIENT_DEFAULT,
-    timeout: TimeoutTypes | UseClientDefault = USE_CLIENT_DEFAULT,
-    extensions: RequestExtensions | None = None,
-) -> typing.AsyncGenerator[AsyncWebSocketSession, None]:
-    async with client.stream(
-        "GET",
-        url,
-        params=params,
-        headers=Headers(headers) | _get_headers(subprotocols),
-        cookies=cookies,
-        auth=auth,
-        follow_redirects=follow_redirects,
-        timeout=timeout,
-        extensions=extensions,
-    ) as response:
-        if response.status_code != 101:
-            raise WebSocketUpgradeError(response)
+class AsyncWebSocketClient(typing.Generic[AsyncSession]):
+    """
+    An async WebSocket client.
 
-        async with AsyncWebSocketSession(
-            response.extensions["network_stream"],
-            max_message_size_bytes=max_message_size_bytes,
-            queue_size=queue_size,
-            keepalive_ping_interval_seconds=keepalive_ping_interval_seconds,
-            keepalive_ping_timeout_seconds=keepalive_ping_timeout_seconds,
-            response=response,
-        ) as session:
-            yield session
+    This class provides an API for connecting to WebSocket.
+
+    Attributes:
+        client:
+            HTTPX client to use.
+        max_message_size_bytes:
+            Message size in bytes to receive from the server.
+            Defaults to 65 KiB.
+        queue_size:
+            Size of the queue where the received messages will be held
+            until they are consumed.
+            If the queue is full, the client will stop receive messages
+            from the server until the queue has room available.
+            Defaults to 512.
+        keepalive_ping_interval_seconds:
+            Interval at which the client will automatically send a Ping event
+            to keep the connection alive. Set it to `None` to disable this mechanism.
+            Defaults to 20 seconds.
+        keepalive_ping_timeout_seconds:
+            Maximum delay the client will wait for an answer to its Ping event.
+            If the delay is exceeded,
+            [WebSocketNetworkError][httpx_ws.WebSocketNetworkError]
+            will be raised in an [ExceptionGroup][ExceptionGroup] and the connection closed.
+            Defaults to 20 seconds.
+        session_class:
+            The session class to use.
+            Defaults to [AsyncWebSocketSession][httpx_ws.AsyncWebSocketSession].
+    """
+
+    def __init__(
+        self,
+        client: AsyncClient,
+        *,
+        max_message_size_bytes: int = DEFAULT_MAX_MESSAGE_SIZE_BYTES,
+        queue_size: int = DEFAULT_QUEUE_SIZE,
+        keepalive_ping_interval_seconds: float | None = DEFAULT_KEEPALIVE_PING_INTERVAL_SECONDS,
+        keepalive_ping_timeout_seconds: float | None = DEFAULT_KEEPALIVE_PING_TIMEOUT_SECONDS,
+        session_class: type[AsyncSession] = AsyncWebSocketSession,  # type: ignore[assignment]
+    ) -> None:
+        self.client = client
+        self.max_message_size_bytes = max_message_size_bytes
+        self.queue_size = queue_size
+        self.keepalive_ping_interval_seconds = keepalive_ping_interval_seconds
+        self.keepalive_ping_timeout_seconds = keepalive_ping_timeout_seconds
+        self.session_class = session_class
+
+    @contextlib.asynccontextmanager
+    async def connect(
+        self,
+        url: str,
+        *,
+        subprotocols: list[str] | None = None,
+        params: QueryParamTypes | None = None,
+        headers: HeaderTypes | None = None,
+        cookies: CookieTypes | None = None,
+        auth: AuthTypes | UseClientDefault | None = USE_CLIENT_DEFAULT,
+        follow_redirects: bool | UseClientDefault = USE_CLIENT_DEFAULT,
+        timeout: TimeoutTypes | UseClientDefault = USE_CLIENT_DEFAULT,
+        extensions: RequestExtensions | None = None,
+    ) -> typing.AsyncGenerator[AsyncSession, None]:
+        """
+        Start an async WebSocket session.
+
+        It returns an async context manager that'll automatically
+        call [close()][httpx_ws.AsyncWebSocketSession.close] when exiting.
+
+        Args:
+            url: The WebSocket URL.
+            subprotocols:
+                Optional list of subprotocols to negotiate with the server.
+            params:
+                Query parameters to include in the handshake request.
+            headers:
+                Headers to include in the handshake request.
+            cookies:
+                Cookies to include in the handshake request.
+            auth:
+                Authentication to use for the handshake request.
+            follow_redirects:
+                Whether to follow redirects on the handshake request.
+            timeout:
+                Timeout configuration for the handshake request.
+            extensions:
+                Request extensions for the handshake request.
+
+        Returns:
+            An [async context manager][contextlib.AbstractAsyncContextManager]
+                for [AsyncWebSocketSession][httpx_ws.AsyncWebSocketSession].
+
+        Examples:
+            Initialize the client and connect to a WebSocket.
+
+                async with httpx2.AsyncClient() as client:
+                    ws_client = AsyncWebSocketClient(client)
+                    async with ws_client.connect("http://localhost:8000/ws") as ws:
+                        message = await ws.receive_text()
+                        print(message)
+                        await ws.send_text("Hello!")
+        """
+        async with self.client.stream(
+            "GET",
+            url,
+            params=params,
+            headers=Headers(headers) | _get_headers(subprotocols),
+            cookies=cookies,
+            auth=auth,
+            follow_redirects=follow_redirects,
+            timeout=timeout,
+            extensions=extensions,
+        ) as response:
+            if response.status_code != 101:
+                raise WebSocketUpgradeError(response)
+
+            session = self.session_class(
+                response.extensions["network_stream"],
+                max_message_size_bytes=self.max_message_size_bytes,
+                queue_size=self.queue_size,
+                keepalive_ping_interval_seconds=self.keepalive_ping_interval_seconds,
+                keepalive_ping_timeout_seconds=self.keepalive_ping_timeout_seconds,
+                response=response,
+            )
+            async with session:
+                yield session
 
 
 @contextlib.asynccontextmanager
@@ -1293,10 +1559,10 @@ async def aconnect_ws(
             Maximum delay the client will wait for an answer to its Ping event.
             If the delay is exceeded,
             [WebSocketNetworkError][httpx_ws.WebSocketNetworkError]
-            will be raised and the connection closed.
+            will be raised in an [ExceptionGroup][ExceptionGroup] and the connection closed.
             Defaults to 20 seconds.
         subprotocols:
-            Optional list of suprotocols to negotiate with the server.
+            Optional list of subprotocols to negotiate with the server.
         params:
             Query parameters to include in the handshake request.
         headers:
@@ -1340,13 +1606,15 @@ async def aconnect_ws(
         owned_client = contextlib.nullcontext(client)
 
     async with owned_client as client:
-        async with _aconnect_ws(
-            url,
+        ws_client = AsyncWebSocketClient(
             client=client,
             max_message_size_bytes=max_message_size_bytes,
             queue_size=queue_size,
             keepalive_ping_interval_seconds=keepalive_ping_interval_seconds,
             keepalive_ping_timeout_seconds=keepalive_ping_timeout_seconds,
+        )
+        async with ws_client.connect(
+            url,
             subprotocols=subprotocols,
             params=params,
             headers=headers,

--- a/src/httpx2/httpx2/websockets/_transport.py
+++ b/src/httpx2/httpx2/websockets/_transport.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import contextlib
-import queue
+import math
 import typing
-from concurrent.futures import Future
+from types import TracebackType
 
 import anyio
 import wsproto
@@ -12,7 +12,7 @@ from wsproto.frame_protocol import CloseReason
 from .._models import Request, Response
 from .._transports.asgi import ASGITransport, _ASGIApp
 from .._types import AsyncByteStream
-from ._exceptions import WebSocketDisconnect
+from ._exceptions import WebSocketDisconnect, WebSocketUpgradeError
 
 Scope = dict[str, typing.Any]
 Message = dict[str, typing.Any]
@@ -36,33 +36,77 @@ class UnhandledWebSocketEvent(ASGIWebSocketTransportError):
 
 
 class ASGIWebSocketAsyncNetworkStream:
-    def __init__(self, app: ASGIApp, scope: Scope) -> None:
+    def __init__(
+        self,
+        app: ASGIApp,
+        scope: Scope,
+        task_group: anyio.abc.TaskGroup,
+        initial_receive_timeout: float = 1.0,
+    ) -> None:
         self.app = app
         self.scope = scope
-        self._receive_queue: queue.Queue[Message] = queue.Queue()
-        self._send_queue: queue.Queue[Message] = queue.Queue()
+        self._receive_queue = anyio.streams.stapled.StapledObjectStream(
+            *anyio.create_memory_object_stream[Message](max_buffer_size=math.inf)
+        )
+        self._send_queue = anyio.streams.stapled.StapledObjectStream(
+            *anyio.create_memory_object_stream[Message](max_buffer_size=math.inf)
+        )
+        self._task_group = task_group
+        self._initial_receive_timeout = initial_receive_timeout
         self.connection = wsproto.WSConnection(wsproto.ConnectionType.SERVER)
         self.connection.initiate_upgrade_connection(scope["headers"], scope["path"])
+        self._aentered = False
 
     async def __aenter__(
         self,
     ) -> tuple[ASGIWebSocketAsyncNetworkStream, bytes]:
-        self.exit_stack = contextlib.ExitStack()
-        self.portal = self.exit_stack.enter_context(anyio.from_thread.start_blocking_portal("asyncio"))
-        _: Future[None] = self.portal.start_task_soon(self._run)
+        if self._aentered:
+            raise RuntimeError("Cannot use ASGIWebSocketAsyncNetworkStream in a context manager twice")
+        self._aentered = True
+        self._task_group.start_soon(self._run)
+        async with contextlib.AsyncExitStack() as stack:
+            stack.push_async_callback(self.aclose)
+            await self.send({"type": "websocket.connect"})
 
-        await self.send({"type": "websocket.connect"})
-        message = await self.receive()
+            try:
+                message = await self.receive(self._initial_receive_timeout)
+            except TimeoutError as e:
+                raise RuntimeError(
+                    "WebSocket didn't accept the connection in time. Did you forget to call accept()?"
+                ) from e
 
-        if message["type"] == "websocket.close":
-            await self.aclose()
-            raise WebSocketDisconnect(message["code"], message.get("reason"))
+            if message["type"] == "websocket.close":
+                await stack.aclose()
+                raise WebSocketDisconnect(message["code"], message.get("reason"))
 
-        assert message["type"] == "websocket.accept"
-        return self, self._build_accept_response(message)
+            # Websocket Denial Response extension
+            # Ref: https://asgi.readthedocs.io/en/latest/extensions.html#websocket-denial-response
+            if message["type"] == "websocket.http.response.start":
+                status_code: int = message["status"]
+                headers: list[tuple[bytes, bytes]] = message["headers"]
+                body: list[bytes] = []
+                while True:
+                    message = await self.receive()
+                    assert message["type"] == "websocket.http.response.body"
+                    body.append(message["body"])
+                    if not message.get("more_body", False):
+                        break
 
-    async def __aexit__(self, *args: typing.Any) -> None:
-        await self.aclose()
+                await stack.aclose()
+                raise WebSocketUpgradeError(Response(status_code, headers=headers, content=b"".join(body)))
+
+            assert message["type"] == "websocket.accept"
+            retval = self, self._build_accept_response(message)
+            self._exit_stack = stack.pop_all()
+        return retval
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> bool | None:
+        return await self._exit_stack.__aexit__(exc_type, exc_val, exc_tb)
 
     async def read(self, max_bytes: int, timeout: float | None = None) -> bytes:
         message: Message = await self.receive(timeout=timeout)
@@ -92,7 +136,7 @@ class ASGIWebSocketAsyncNetworkStream:
             elif isinstance(event, wsproto.events.CloseConnection):
                 await self.send(
                     {
-                        "type": "websocket.close",
+                        "type": "websocket.disconnect",
                         "code": event.code,
                         "reason": event.reason,
                     }
@@ -105,24 +149,27 @@ class ASGIWebSocketAsyncNetworkStream:
                 raise UnhandledWebSocketEvent(event)
 
     async def aclose(self) -> None:
-        await self.send({"type": "websocket.close"})
-        self.exit_stack.close()
+        with contextlib.suppress(anyio.ClosedResourceError):
+            await self.send({"type": "websocket.disconnect"})
+        await self._receive_queue.aclose()
+        await self._send_queue.aclose()
 
     async def send(self, message: Message) -> None:
-        self._receive_queue.put(message)
+        await self._receive_queue.send(message)
 
     async def receive(self, timeout: float | None = None) -> Message:
-        while self._send_queue.empty():
-            await anyio.sleep(0)
-        return self._send_queue.get(timeout=timeout)
+        if timeout is None:
+            timeout = math.inf
+        with anyio.fail_after(timeout):
+            return await self._send_queue.receive()
 
     async def _run(self) -> None:
         """
         The sub-thread in which the websocket session runs.
         """
         scope = self.scope
-        receive = self._asgi_receive
-        send = self._asgi_send
+        receive = self._receive_queue.receive
+        send = self._send_queue.send
         try:
             await self.app(scope, receive, send)
         except Exception as e:
@@ -131,15 +178,8 @@ class ASGIWebSocketAsyncNetworkStream:
                 "code": CloseReason.INTERNAL_ERROR,
                 "reason": str(e),
             }
-            await self._asgi_send(message)
-
-    async def _asgi_receive(self) -> Message:
-        while self._receive_queue.empty():
-            await anyio.sleep(0)
-        return self._receive_queue.get()
-
-    async def _asgi_send(self, message: Message) -> None:
-        self._send_queue.put(message)
+            with contextlib.suppress(anyio.ClosedResourceError):
+                await send(message)
 
     def _build_accept_response(self, message: Message) -> bytes:
         subprotocol = message.get("subprotocol", None)
@@ -159,9 +199,28 @@ class ASGIWebSocketTransport(ASGITransport):
         raise_app_exceptions: bool = True,
         root_path: str = "",
         client: tuple[str, int] = ("127.0.0.1", 123),
+        initial_receive_timeout: float = 1.0,
     ) -> None:
         super().__init__(app, raise_app_exceptions, root_path, client)
-        self.exit_stack: contextlib.AsyncExitStack | None = None
+        self._exit_stack: contextlib.AsyncExitStack | None = None
+        self._initial_receive_timeout = initial_receive_timeout
+
+    async def __aenter__(self) -> ASGIWebSocketTransport:
+        async with contextlib.AsyncExitStack() as stack:
+            self._task_group = await stack.enter_async_context(anyio.create_task_group())
+            self._exit_stack = stack.pop_all()
+
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None = None,
+        exc_val: BaseException | None = None,
+        exc_tb: TracebackType | None = None,
+    ) -> None:
+        await super().__aexit__(exc_type, exc_val, exc_tb)
+        assert self._exit_stack is not None
+        await self._exit_stack.__aexit__(exc_type, exc_val, exc_tb)
 
     async def handle_async_request(self, request: Request) -> Response:
         scheme = request.url.scheme
@@ -188,6 +247,21 @@ class ASGIWebSocketTransport(ASGITransport):
 
         return await super().handle_async_request(request)
 
+    async def _create_asgi_websocket_async_network_stream(
+        self,
+        *,
+        task_status: anyio.abc.TaskStatus[tuple[ASGIWebSocketAsyncNetworkStream, bytes]],
+    ) -> None:
+        stream = ASGIWebSocketAsyncNetworkStream(
+            self.app,  # type: ignore[arg-type]
+            self.scope,
+            self._task_group,
+            self._initial_receive_timeout,
+        )
+        assert self._exit_stack is not None
+        result = await self._exit_stack.enter_async_context(stream)
+        task_status.started(result)
+
     async def _handle_ws_request(
         self,
         request: Request,
@@ -196,11 +270,7 @@ class ASGIWebSocketTransport(ASGITransport):
         assert isinstance(request.stream, AsyncByteStream)
 
         self.scope = scope
-        self.exit_stack = contextlib.AsyncExitStack()
-        stream, accept_response = await self.exit_stack.enter_async_context(
-            ASGIWebSocketAsyncNetworkStream(self.app, self.scope)  # type: ignore[arg-type]
-        )
-
+        stream, accept_response = await self._task_group.start(self._create_asgi_websocket_async_network_stream)
         accept_response_lines = accept_response.decode("utf-8").splitlines()
         headers = [
             typing.cast(tuple[str, str], line.split(": ", 1))
@@ -213,7 +283,3 @@ class ASGIWebSocketTransport(ASGITransport):
             headers=headers,
             extensions={"network_stream": stream},
         )
-
-    async def aclose(self) -> None:
-        if self.exit_stack:
-            await self.exit_stack.aclose()

--- a/src/httpx2/pyproject.toml
+++ b/src/httpx2/pyproject.toml
@@ -46,7 +46,7 @@ dynamic = ["readme", "version", "dependencies"]
 dependencies = [
     "truststore>=0.10",
     "httpcore2=={{ version }}",
-    "anyio",
+    "anyio>=4.10",
     "idna>=3.18",
     "typing_extensions>=4.5.0; python_version < '3.13'",
 ]

--- a/tests/httpx2/websockets/test_api.py
+++ b/tests/httpx2/websockets/test_api.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import contextlib
+import concurrent.futures
 import queue
 import threading
 import time
@@ -16,8 +16,10 @@ import httpx2 as httpx
 from httpcore2 import AsyncNetworkStream, NetworkStream
 from httpx2.websockets import _api
 from httpx2.websockets._api import (
+    AsyncWebSocketClient,
     AsyncWebSocketSession,
     JSONMode,
+    WebSocketClient,
     WebSocketSession,
     aconnect_ws,
     connect_ws,
@@ -89,7 +91,7 @@ class TestSend:
                 self._should_close = True
 
         stream = AsyncMockNetworkStream()
-        with pytest.raises(WebSocketNetworkError):
+        with pytest.RaisesGroup(WebSocketNetworkError):
             async with AsyncWebSocketSession(stream) as websocket_session:
                 await websocket_session.send(wsproto.events.Ping())
 
@@ -108,18 +110,12 @@ class TestSend:
 
         with server_factory(websocket_endpoint) as socket:
             with httpx.Client(transport=httpx.HTTPTransport(uds=socket)) as client:
-                try:
-                    with connect_ws("http://socket/ws", client) as ws:
-                        ws.send(wsproto.events.TextMessage(data="CLIENT_MESSAGE"))
-                except WebSocketDisconnect:  # pragma: no cover
-                    pass
+                with connect_ws("http://socket/ws", client) as ws:
+                    ws.send(wsproto.events.TextMessage(data="CLIENT_MESSAGE"))
 
             async with httpx.AsyncClient(transport=httpx.AsyncHTTPTransport(uds=socket)) as aclient:
-                try:
-                    async with aconnect_ws("http://socket/ws", aclient) as aws:
-                        await aws.send(wsproto.events.TextMessage(data="CLIENT_MESSAGE"))
-                except WebSocketDisconnect:  # pragma: no cover
-                    pass
+                async with aconnect_ws("http://socket/ws", aclient) as aws:
+                    await aws.send(wsproto.events.TextMessage(data="CLIENT_MESSAGE"))
 
         on_receive_message.assert_has_calls([call("CLIENT_MESSAGE"), call("CLIENT_MESSAGE")])
 
@@ -138,18 +134,12 @@ class TestSend:
 
         with server_factory(websocket_endpoint) as socket:
             with httpx.Client(transport=httpx.HTTPTransport(uds=socket)) as client:
-                try:
-                    with connect_ws("http://socket/ws", client) as ws:
-                        ws.send_text("CLIENT_MESSAGE")
-                except WebSocketDisconnect:  # pragma: no cover
-                    pass
+                with connect_ws("http://socket/ws", client) as ws:
+                    ws.send_text("CLIENT_MESSAGE")
 
             async with httpx.AsyncClient(transport=httpx.AsyncHTTPTransport(uds=socket)) as aclient:
-                try:
-                    async with aconnect_ws("http://socket/ws", aclient) as aws:
-                        await aws.send_text("CLIENT_MESSAGE")
-                except WebSocketDisconnect:  # pragma: no cover
-                    pass
+                async with aconnect_ws("http://socket/ws", aclient) as aws:
+                    await aws.send_text("CLIENT_MESSAGE")
 
         on_receive_message.assert_has_calls([call("CLIENT_MESSAGE"), call("CLIENT_MESSAGE")])
 
@@ -168,18 +158,12 @@ class TestSend:
 
         with server_factory(websocket_endpoint) as socket:
             with httpx.Client(transport=httpx.HTTPTransport(uds=socket)) as client:
-                try:
-                    with connect_ws("http://socket/ws", client) as ws:
-                        ws.send_bytes(b"CLIENT_MESSAGE")
-                except WebSocketDisconnect:  # pragma: no cover
-                    pass
+                with connect_ws("http://socket/ws", client) as ws:
+                    ws.send_bytes(b"CLIENT_MESSAGE")
 
             async with httpx.AsyncClient(transport=httpx.AsyncHTTPTransport(uds=socket)) as aclient:
-                try:
-                    async with aconnect_ws("http://socket/ws", aclient) as aws:
-                        await aws.send_bytes(b"CLIENT_MESSAGE")
-                except WebSocketDisconnect:  # pragma: no cover
-                    pass
+                async with aconnect_ws("http://socket/ws", aclient) as aws:
+                    await aws.send_bytes(b"CLIENT_MESSAGE")
 
         on_receive_message.assert_has_calls([call(b"CLIENT_MESSAGE"), call(b"CLIENT_MESSAGE")])
 
@@ -200,18 +184,12 @@ class TestSend:
 
         with server_factory(websocket_endpoint) as socket:
             with httpx.Client(transport=httpx.HTTPTransport(uds=socket)) as client:
-                try:
-                    with connect_ws("http://socket/ws", client) as ws:
-                        ws.send_json({"message": "CLIENT_MESSAGE"}, mode=mode)
-                except WebSocketDisconnect:  # pragma: no cover
-                    pass
+                with connect_ws("http://socket/ws", client) as ws:
+                    ws.send_json({"message": "CLIENT_MESSAGE"}, mode=mode)
 
             async with httpx.AsyncClient(transport=httpx.AsyncHTTPTransport(uds=socket)) as aclient:
-                try:
-                    async with aconnect_ws("http://socket/ws", aclient) as aws:
-                        await aws.send_json({"message": "CLIENT_MESSAGE"}, mode=mode)
-                except WebSocketDisconnect:  # pragma: no cover
-                    pass
+                async with aconnect_ws("http://socket/ws", aclient) as aws:
+                    await aws.send_json({"message": "CLIENT_MESSAGE"}, mode=mode)
 
         on_receive_message.assert_has_calls([call({"message": "CLIENT_MESSAGE"}), call({"message": "CLIENT_MESSAGE"})])
 
@@ -237,6 +215,45 @@ class TestReceive:
             with WebSocketSession(stream) as websocket_session:
                 websocket_session.receive()
 
+    def test_receive_closed_socket(self) -> None:
+        class MockNetworkStream(NetworkStream):
+            def __init__(self) -> None:
+                self.connection = wsproto.connection.Connection(wsproto.connection.ConnectionType.SERVER)
+
+            def read(self, max_bytes: int, timeout: float | None = None) -> bytes:
+                return b""
+
+            def write(self, buffer: bytes, timeout: float | None = None) -> None:
+                pass
+
+            def close(self) -> None:
+                pass
+
+        stream = MockNetworkStream()
+        with pytest.raises(WebSocketNetworkError):
+            with WebSocketSession(stream) as websocket_session:
+                websocket_session.receive()
+
+    def test_receive_timeout(self) -> None:
+        class MockNetworkStream(NetworkStream):
+            def __init__(self) -> None:
+                self.connection = wsproto.connection.Connection(wsproto.connection.ConnectionType.SERVER)
+
+            def read(self, max_bytes: int, timeout: float | None = None) -> bytes:
+                time.sleep(0.2)
+                return b""
+
+            def write(self, buffer: bytes, timeout: float | None = None) -> None:
+                pass
+
+            def close(self) -> None:
+                pass
+
+        stream = MockNetworkStream()
+        with pytest.raises(TimeoutError):
+            with WebSocketSession(stream) as websocket_session:
+                websocket_session.receive(timeout=0.1)
+
     async def test_async_receive_error(self) -> None:
         class AsyncMockNetworkStream(AsyncNetworkStream):
             def __init__(self) -> None:
@@ -252,7 +269,26 @@ class TestReceive:
                 pass
 
         stream = AsyncMockNetworkStream()
-        with pytest.raises(WebSocketNetworkError):
+        with pytest.RaisesGroup(WebSocketNetworkError):
+            async with AsyncWebSocketSession(stream) as websocket_session:
+                await websocket_session.receive()
+
+    async def test_async_receive_closed_socket(self) -> None:
+        class AsyncMockNetworkStream(AsyncNetworkStream):
+            def __init__(self) -> None:
+                self.connection = wsproto.connection.Connection(wsproto.connection.ConnectionType.SERVER)
+
+            async def read(self, max_bytes: int, timeout: float | None = None) -> bytes:
+                return b""
+
+            async def write(self, buffer: bytes, timeout: float | None = None) -> None:
+                pass
+
+            async def aclose(self) -> None:
+                pass
+
+        stream = AsyncMockNetworkStream()
+        with pytest.RaisesGroup(WebSocketNetworkError):
             async with AsyncWebSocketSession(stream) as websocket_session:
                 await websocket_session.receive()
 
@@ -266,22 +302,16 @@ class TestReceive:
 
         with server_factory(websocket_endpoint) as socket:
             with httpx.Client(transport=httpx.HTTPTransport(uds=socket)) as client:
-                try:
-                    with connect_ws("http://socket/ws", client) as ws:
-                        event = ws.receive()
-                        assert isinstance(event, wsproto.events.TextMessage)
-                        assert event.data == "SERVER_MESSAGE"
-                except WebSocketDisconnect:  # pragma: no cover
-                    pass
+                with connect_ws("http://socket/ws", client) as ws:
+                    event = ws.receive()
+                    assert isinstance(event, wsproto.events.TextMessage)
+                    assert event.data == "SERVER_MESSAGE"
 
             async with httpx.AsyncClient(transport=httpx.AsyncHTTPTransport(uds=socket)) as aclient:
-                try:
-                    async with aconnect_ws("http://socket/ws", aclient) as aws:
-                        event = await aws.receive()
-                        assert isinstance(event, wsproto.events.TextMessage)
-                        assert event.data == "SERVER_MESSAGE"
-                except WebSocketDisconnect:  # pragma: no cover
-                    pass
+                async with aconnect_ws("http://socket/ws", aclient) as aws:
+                    event = await aws.receive()
+                    assert isinstance(event, wsproto.events.TextMessage)
+                    assert event.data == "SERVER_MESSAGE"
 
     @pytest.mark.parametrize(
         "full_message,send_method",
@@ -306,26 +336,16 @@ class TestReceive:
 
         with server_factory(websocket_endpoint) as socket:
             with httpx.Client(transport=httpx.HTTPTransport(uds=socket)) as client:
-                try:
-                    with connect_ws("http://socket/ws", client, max_message_size_bytes=1024) as ws:
-                        event = ws.receive()
-                        assert isinstance(event, wsproto.events.Message)
-                        assert event.data == full_message
-                except WebSocketDisconnect:  # pragma: no cover
-                    pass
+                with connect_ws("http://socket/ws", client, max_message_size_bytes=1024) as ws:
+                    event = ws.receive()
+                    assert isinstance(event, wsproto.events.Message)
+                    assert event.data == full_message
 
             async with httpx.AsyncClient(transport=httpx.AsyncHTTPTransport(uds=socket)) as aclient:
-                try:
-                    async with aconnect_ws(
-                        "http://socket/ws",
-                        aclient,
-                        keepalive_ping_interval_seconds=None,
-                    ) as aws:
-                        event = await aws.receive()
-                        assert isinstance(event, wsproto.events.Message)
-                        assert event.data == full_message
-                except WebSocketDisconnect:  # pragma: no cover
-                    pass
+                async with aconnect_ws("http://socket/ws", aclient, max_message_size_bytes=1024) as aws:
+                    event = await aws.receive()
+                    assert isinstance(event, wsproto.events.Message)
+                    assert event.data == full_message
 
     async def test_receive_text(self, server_factory: ServerFactoryFixture) -> None:
         async def websocket_endpoint(websocket: WebSocket) -> None:
@@ -337,20 +357,14 @@ class TestReceive:
 
         with server_factory(websocket_endpoint) as socket:
             with httpx.Client(transport=httpx.HTTPTransport(uds=socket)) as client:
-                try:
-                    with connect_ws("http://socket/ws", client) as ws:
-                        data = ws.receive_text()
-                        assert data == "SERVER_MESSAGE"
-                except WebSocketDisconnect:  # pragma: no cover
-                    pass
+                with connect_ws("http://socket/ws", client) as ws:
+                    data = ws.receive_text()
+                    assert data == "SERVER_MESSAGE"
 
             async with httpx.AsyncClient(transport=httpx.AsyncHTTPTransport(uds=socket)) as aclient:
-                try:
-                    async with aconnect_ws("http://socket/ws", aclient) as aws:
-                        data = await aws.receive_text()
-                        assert data == "SERVER_MESSAGE"
-                except WebSocketDisconnect:  # pragma: no cover
-                    pass
+                async with aconnect_ws("http://socket/ws", aclient) as aws:
+                    data = await aws.receive_text()
+                    assert data == "SERVER_MESSAGE"
 
     async def test_receive_text_invalid_type(self, server_factory: ServerFactoryFixture) -> None:
         async def websocket_endpoint(websocket: WebSocket) -> None:
@@ -362,20 +376,14 @@ class TestReceive:
 
         with server_factory(websocket_endpoint) as socket:
             with httpx.Client(transport=httpx.HTTPTransport(uds=socket)) as client:
-                try:
-                    with connect_ws("http://socket/ws", client) as ws:
-                        with pytest.raises(WebSocketInvalidTypeReceived):
-                            ws.receive_text()
-                except WebSocketDisconnect:  # pragma: no cover
-                    pass
+                with connect_ws("http://socket/ws", client) as ws:
+                    with pytest.raises(WebSocketInvalidTypeReceived):
+                        ws.receive_text()
 
             async with httpx.AsyncClient(transport=httpx.AsyncHTTPTransport(uds=socket)) as aclient:
-                try:
-                    async with aconnect_ws("http://socket/ws", aclient) as aws:
-                        with pytest.raises(WebSocketInvalidTypeReceived):
-                            await aws.receive_text()
-                except WebSocketDisconnect:  # pragma: no cover
-                    pass
+                async with aconnect_ws("http://socket/ws", aclient) as aws:
+                    with pytest.raises(WebSocketInvalidTypeReceived):
+                        await aws.receive_text()
 
     async def test_receive_bytes(self, server_factory: ServerFactoryFixture) -> None:
         async def websocket_endpoint(websocket: WebSocket) -> None:
@@ -387,20 +395,14 @@ class TestReceive:
 
         with server_factory(websocket_endpoint) as socket:
             with httpx.Client(transport=httpx.HTTPTransport(uds=socket)) as client:
-                try:
-                    with connect_ws("http://socket/ws", client) as ws:
-                        data = ws.receive_bytes()
-                        assert data == b"SERVER_MESSAGE"
-                except WebSocketDisconnect:  # pragma: no cover
-                    pass
+                with connect_ws("http://socket/ws", client) as ws:
+                    data = ws.receive_bytes()
+                    assert data == b"SERVER_MESSAGE"
 
             async with httpx.AsyncClient(transport=httpx.AsyncHTTPTransport(uds=socket)) as aclient:
-                try:
-                    async with aconnect_ws("http://socket/ws", aclient) as aws:
-                        data = await aws.receive_bytes()
-                        assert data == b"SERVER_MESSAGE"
-                except WebSocketDisconnect:  # pragma: no cover
-                    pass
+                async with aconnect_ws("http://socket/ws", aclient) as aws:
+                    data = await aws.receive_bytes()
+                    assert data == b"SERVER_MESSAGE"
 
     async def test_receive_bytes_invalid_type(self, server_factory: ServerFactoryFixture) -> None:
         async def websocket_endpoint(websocket: WebSocket) -> None:
@@ -432,20 +434,14 @@ class TestReceive:
 
         with server_factory(websocket_endpoint) as socket:
             with httpx.Client(transport=httpx.HTTPTransport(uds=socket)) as client:
-                try:
-                    with connect_ws("http://socket/ws", client) as ws:
-                        data = ws.receive_json(mode=mode)
-                        assert data == {"message": "SERVER_MESSAGE"}
-                except WebSocketDisconnect:  # pragma: no cover
-                    pass
+                with connect_ws("http://socket/ws", client) as ws:
+                    data = ws.receive_json(mode=mode)
+                    assert data == {"message": "SERVER_MESSAGE"}
 
             async with httpx.AsyncClient(transport=httpx.AsyncHTTPTransport(uds=socket)) as aclient:
-                try:
-                    async with aconnect_ws("http://socket/ws", aclient) as aws:
-                        data = await aws.receive_json(mode=mode)
-                        assert data == {"message": "SERVER_MESSAGE"}
-                except WebSocketDisconnect:  # pragma: no cover
-                    pass
+                async with aconnect_ws("http://socket/ws", aclient) as aws:
+                    data = await aws.receive_json(mode=mode)
+                    assert data == {"message": "SERVER_MESSAGE"}
 
 
 @pytest.mark.anyio
@@ -583,7 +579,6 @@ class TestKeepalivePing:
             ) as websocket_session:
                 websocket_session.receive()
 
-    @pytest.mark.flaky(max_runs=5, min_passes=1)
     async def test_async_keepalive_ping(self) -> None:
         class MockAsyncNetworkStream(AsyncNetworkStream):
             def __init__(self) -> None:
@@ -629,7 +624,7 @@ class TestKeepalivePing:
         assert stream.ping_received >= 1
         assert stream.ping_answered >= 1
 
-    async def test_async_keepalive_ping_skips_when_closing(self) -> None:
+    async def test_async_keepalive_ping_exits_when_closing(self) -> None:
         writes = 0
 
         class MockAsyncNetworkStream(AsyncNetworkStream):
@@ -642,11 +637,10 @@ class TestKeepalivePing:
 
             async def aclose(self) -> None: ...  # pragma: no cover
 
-        session = AsyncWebSocketSession(MockAsyncNetworkStream(), keepalive_ping_interval_seconds=0.2)
-        async with anyio.create_task_group() as tg:
-            tg.start_soon(session._background_keepalive_ping, 0.2)
-            await anyio.sleep(0.05)  # Let the loop enter its sleep before closing.
-            session._should_close.set()
+        session = AsyncWebSocketSession(MockAsyncNetworkStream(), keepalive_ping_interval_seconds=0.1)
+        session.connection.send(wsproto.events.CloseConnection(1000))
+        with anyio.fail_after(1):
+            await session._background_keepalive_ping(0.01)
 
         assert writes == 0
 
@@ -668,7 +662,7 @@ class TestKeepalivePing:
                 self._should_close = True
 
         stream = MockAsyncNetworkStream()
-        with pytest.raises(WebSocketNetworkError):
+        with pytest.RaisesGroup(WebSocketNetworkError):
             async with AsyncWebSocketSession(
                 stream,
                 keepalive_ping_interval_seconds=0.1,
@@ -742,21 +736,19 @@ async def test_receive_close(server_factory: ServerFactoryFixture) -> None:
 
 @pytest.mark.anyio
 async def test_default_httpx_client() -> None:
-    mock_context = contextlib.ExitStack()
-    with patch.object(_api, "_connect_ws", return_value=mock_context) as mock_connect_ws:
+    with patch.object(_api, "WebSocketClient") as mock_client:
         with connect_ws("http://socket/ws"):
             pass
-    mock_connect_ws.assert_called_once()
-    httpx_client = mock_connect_ws.call_args[1]["client"]
+    mock_client.return_value.connect.assert_called_once()
+    httpx_client = mock_client.call_args[1]["client"]
     assert isinstance(httpx_client, httpx.Client)
     assert httpx_client.is_closed
 
-    mock_async_context = contextlib.AsyncExitStack()
-    with patch.object(_api, "_aconnect_ws", return_value=mock_async_context) as mock_aconnect_ws:
+    with patch.object(_api, "AsyncWebSocketClient") as mock_async_client:
         async with aconnect_ws("http://socket/ws"):
             pass
-    mock_aconnect_ws.assert_called_once()
-    httpx_client = mock_aconnect_ws.call_args[1]["client"]
+    mock_async_client.return_value.connect.assert_called_once()
+    httpx_client = mock_async_client.call_args[1]["client"]
     assert isinstance(httpx_client, httpx.AsyncClient)
     assert httpx_client.is_closed
 
@@ -838,3 +830,55 @@ async def test_threads_wont_hang(server_factory: ServerFactoryFixture) -> None:
                     ws.send_text("CLIENT_MESSAGE")
                 wait_for_session_threads(2)
             wait_for_session_threads(0)
+
+
+@pytest.mark.anyio
+async def test_concurrency_write(server_factory: ServerFactoryFixture) -> None:
+    """
+    Check that there is no error because of two tasks trying to write the stream at the
+    same time. Typically, this is when a background ping tries to send a ping while the
+    main task is sending a message.
+
+    See: https://github.com/frankie567/httpx-ws/issues/29
+    """
+
+    async def websocket_endpoint(websocket: WebSocket) -> None:
+        await websocket.accept()
+        while True:
+            message = await websocket.receive_text()
+            await websocket.send_text(message)
+
+    with server_factory(websocket_endpoint) as socket:
+        # Added for completeness, but were not able to reproduce the issue with the sync client
+        with httpx.Client(transport=httpx.HTTPTransport(uds=socket)) as client:
+            with connect_ws("http://socket/ws", client) as ws:
+                with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+                    for _ in range(10):
+                        executor.submit(ws.send_text, "CLIENT_MESSAGE")
+
+        async with httpx.AsyncClient(transport=httpx.AsyncHTTPTransport(uds=socket)) as aclient:
+            async with aconnect_ws("http://socket/ws", aclient) as aws:
+                async with anyio.create_task_group() as tg:
+                    for _ in range(10):
+                        tg.start_soon(aws.send_text, "CLIENT_MESSAGE")
+
+
+@pytest.mark.anyio
+async def test_client() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(101, extensions={"network_stream": MagicMock(spec=NetworkStream)})
+
+    def async_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(101, extensions={"network_stream": MagicMock(spec=AsyncNetworkStream)})
+
+    with httpx.Client(base_url="http://localhost:8000", transport=httpx.MockTransport(handler)) as client:
+        ws_client = WebSocketClient(client)
+        with ws_client.connect("http://socket/ws") as ws:
+            assert isinstance(ws.response, httpx.Response)
+
+    async with httpx.AsyncClient(
+        base_url="http://localhost:8000", transport=httpx.MockTransport(async_handler)
+    ) as aclient:
+        async_ws_client = AsyncWebSocketClient(aclient)
+        async with async_ws_client.connect("http://socket/ws") as aws:
+            assert isinstance(aws.response, httpx.Response)

--- a/tests/httpx2/websockets/test_high_level.py
+++ b/tests/httpx2/websockets/test_high_level.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import contextlib
 import subprocess
 import sys
 from unittest.mock import patch
@@ -22,12 +21,11 @@ def test_importing_httpx2_does_not_import_wsproto() -> None:
 
 
 def test_top_level_websocket_uses_a_dedicated_client() -> None:
-    mock_context = contextlib.ExitStack()
-    with patch.object(_api, "_connect_ws", return_value=mock_context) as mock_connect_ws:
+    with patch.object(_api, "WebSocketClient") as mock_client:
         with httpx.websocket("http://socket/ws"):
             pass
-    mock_connect_ws.assert_called_once()
-    client = mock_connect_ws.call_args[1]["client"]
+    mock_client.return_value.connect.assert_called_once()
+    client = mock_client.call_args[1]["client"]
     assert isinstance(client, httpx.Client)
     assert client.is_closed
 

--- a/tests/httpx2/websockets/test_transport.py
+++ b/tests/httpx2/websockets/test_transport.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 import base64
 import secrets
+import sys
 from typing import Any
 
+import anyio
 import pytest
 import wsproto
+from anyio import CancelScope, ClosedResourceError, create_task_group
 from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse
@@ -14,7 +17,7 @@ from starlette.websockets import WebSocket
 
 import httpx2 as httpx
 from httpx2.websockets._api import aconnect_ws
-from httpx2.websockets._exceptions import WebSocketDisconnect
+from httpx2.websockets._exceptions import WebSocketDisconnect, WebSocketUpgradeError
 from httpx2.websockets._transport import (
     ASGIWebSocketAsyncNetworkStream,
     ASGIWebSocketTransport,
@@ -24,6 +27,9 @@ from httpx2.websockets._transport import (
     UnhandledASGIMessageType,
     UnhandledWebSocketEvent,
 )
+
+if sys.version_info < (3, 11):
+    from exceptiongroup import ExceptionGroup  # pragma: no cover
 
 
 @pytest.fixture
@@ -62,12 +68,15 @@ class TestASGIWebSocketAsyncNetworkStream:
             await send({"type": "websocket.accept"})
             message = await receive()
             received_messages.append(message)
-            while message["type"] != "websocket.close":
+            while message["type"] != "websocket.disconnect":
                 message = await receive()
                 received_messages.append(message)
 
         connection = wsproto.connection.Connection(wsproto.connection.CLIENT)
-        async with ASGIWebSocketAsyncNetworkStream(app, scope) as (stream, _):
+        async with (
+            create_task_group() as tg,
+            ASGIWebSocketAsyncNetworkStream(app, scope, tg) as (stream, _),
+        ):
             text_event = wsproto.events.TextMessage("CLIENT_MESSAGE")
             await stream.write(connection.send(text_event))
 
@@ -77,11 +86,14 @@ class TestASGIWebSocketAsyncNetworkStream:
             close_event = wsproto.events.CloseConnection(1000)
             await stream.write(connection.send(close_event))
 
+            # Add a small delay to ensure the app has processed all messages
+            await anyio.sleep(0.1)
+
         assert received_messages == [
             {"type": "websocket.connect"},
             {"type": "websocket.receive", "text": "CLIENT_MESSAGE"},
             {"type": "websocket.receive", "bytes": b"CLIENT_MESSAGE"},
-            {"type": "websocket.close", "code": 1000, "reason": ""},
+            {"type": "websocket.disconnect", "code": 1000, "reason": ""},
         ]
 
     async def test_write_unhandled_event(self, scope: Scope) -> None:
@@ -90,7 +102,10 @@ class TestASGIWebSocketAsyncNetworkStream:
             await receive()
 
         connection = wsproto.connection.Connection(wsproto.connection.CLIENT)
-        async with ASGIWebSocketAsyncNetworkStream(app, scope) as (stream, _):
+        async with (
+            create_task_group() as tg,
+            ASGIWebSocketAsyncNetworkStream(app, scope, tg) as (stream, _),
+        ):
             with pytest.raises(UnhandledWebSocketEvent):
                 ping_event = wsproto.events.Ping(b"PING")
                 await stream.write(connection.send(ping_event))
@@ -104,7 +119,10 @@ class TestASGIWebSocketAsyncNetworkStream:
 
         connection = wsproto.connection.Connection(wsproto.connection.CLIENT)
         events = []
-        async with ASGIWebSocketAsyncNetworkStream(app, scope) as (stream, _):
+        async with (
+            create_task_group() as tg,
+            ASGIWebSocketAsyncNetworkStream(app, scope, tg) as (stream, _),
+        ):
             for _ in range(3):
                 data = await stream.read(4096)
                 connection.receive_data(data)
@@ -121,27 +139,96 @@ class TestASGIWebSocketAsyncNetworkStream:
             await send({"type": "websocket.accept"})
             await send({"type": "websocket.foo"})
 
-        async with ASGIWebSocketAsyncNetworkStream(app, scope) as (stream, _):
+        async with (
+            create_task_group() as tg,
+            ASGIWebSocketAsyncNetworkStream(app, scope, tg) as (stream, _),
+        ):
             with pytest.raises(UnhandledASGIMessageType):
                 await stream.read(4096)
+
+    async def test_enter_twice(self, scope: Scope) -> None:
+        async def app(scope: Scope, receive: Receive, send: Send) -> None:
+            await send({"type": "websocket.accept"})
+            await receive()
+
+        async with (
+            create_task_group() as tg,
+            ASGIWebSocketAsyncNetworkStream(app, scope, tg) as (stream, _),
+        ):
+            with pytest.raises(RuntimeError, match="context manager twice"):
+                async with stream:
+                    pass  # pragma: no cover
 
     async def test_close_immediately(self, scope: Scope) -> None:
         async def app(scope: Scope, receive: Receive, send: Send) -> None:
             await send({"type": "websocket.close", "code": 1000, "reason": ""})
 
-        with pytest.raises(WebSocketDisconnect):
-            async with ASGIWebSocketAsyncNetworkStream(app, scope):
+        with pytest.raises(ExceptionGroup) as excinfo:
+            async with (
+                create_task_group() as tg,
+                ASGIWebSocketAsyncNetworkStream(app, scope, tg),
+            ):
                 pass  # pragma: no cover
+        assert excinfo.group_contains(WebSocketDisconnect)
+
+    async def test_denial_response(self, scope: Scope) -> None:
+        async def app(scope: Scope, receive: Receive, send: Send) -> None:
+            await send({"type": "websocket.http.response.start", "status": 401, "headers": []})
+            await send({"type": "websocket.http.response.body", "body": b"Unauthorized"})
+
+        with pytest.raises(ExceptionGroup) as excinfo:
+            async with (
+                create_task_group() as tg,
+                ASGIWebSocketAsyncNetworkStream(app, scope, tg),
+            ):
+                pass  # pragma: no cover
+        assert excinfo.group_contains(WebSocketUpgradeError)
+        error = excinfo.value.exceptions[0]
+        assert isinstance(error, WebSocketUpgradeError)
+        assert error.response.status_code == 401
+        assert error.response.content == b"Unauthorized"
 
     async def test_exception(self, scope: Scope) -> None:
         async def app(scope: Scope, receive: Receive, send: Send) -> None:
             raise Exception("Error")
 
-        with pytest.raises(WebSocketDisconnect) as excinfo:
-            async with ASGIWebSocketAsyncNetworkStream(app, scope):
+        with pytest.raises(ExceptionGroup) as excinfo:
+            async with (
+                create_task_group() as tg,
+                ASGIWebSocketAsyncNetworkStream(app, scope, tg),
+            ):
                 pass  # pragma: no cover
-        assert excinfo.value.code == 1011
-        assert excinfo.value.reason == "Error"
+        assert excinfo.group_contains(WebSocketDisconnect)
+        error = excinfo.value.exceptions[0]
+        assert isinstance(error, WebSocketDisconnect)
+        assert error.code == 1011
+        assert error.reason == "Error"
+
+    async def test_never_accepts(self, scope: Scope) -> None:
+        async def app(scope: Scope, receive: Receive, send: Send) -> None:
+            return
+
+        with pytest.raises(ExceptionGroup) as excinfo:
+            async with (
+                create_task_group() as tg,
+                ASGIWebSocketAsyncNetworkStream(app, scope, tg),
+            ):
+                pass  # pragma: no cover
+
+        assert excinfo.group_contains(RuntimeError)
+
+    async def test_app_exception_with_closed_send_queue(self, scope: Scope) -> None:
+        async def app(scope: Scope, receive: Receive, send: Send) -> None:
+            await send({"type": "websocket.accept"})
+            await receive()
+            raise Exception("App error")
+
+        async with (
+            create_task_group() as tg,
+            ASGIWebSocketAsyncNetworkStream(app, scope, tg) as (stream, _),
+        ):
+            await stream._send_queue.aclose()
+            await stream.send({"type": "websocket.receive", "text": "trigger"})
 
 
 @pytest.fixture
@@ -192,6 +279,42 @@ class TestASGIWebSocketTransport:
 
             assert isinstance(response.extensions["network_stream"], ASGIWebSocketAsyncNetworkStream)
 
+    @pytest.mark.parametrize("stream_count", [1, 3])
+    async def test_transport_exit_closes_stream_queues(
+        self,
+        stream_count: int,
+        test_app: Starlette,
+        websocket_request_headers: dict[str, str],
+    ) -> None:
+        async with ASGIWebSocketTransport(app=test_app) as transport:
+            streams = []
+            for _ in range(stream_count):
+                request = httpx.Request(
+                    "GET",
+                    "ws://localhost:8000/ws",
+                    headers=websocket_request_headers,
+                )
+                response = await transport.handle_async_request(request)
+                streams.append(response.extensions["network_stream"])
+
+        for stream in streams:
+            with pytest.raises(ClosedResourceError):
+                await stream._receive_queue.send({})
+            with pytest.raises(ClosedResourceError):
+                await stream._send_queue.send({})
+
+    async def test_aclose_after_transport_exit_does_not_raise(
+        self,
+        test_app: Starlette,
+        websocket_request_headers: dict[str, str],
+    ) -> None:
+        async with ASGIWebSocketTransport(app=test_app) as transport:
+            request = httpx.Request("GET", "ws://localhost:8000/ws", headers=websocket_request_headers)
+            response = await transport.handle_async_request(request)
+            stream = response.extensions["network_stream"]
+
+        await stream.aclose()
+
 
 @pytest.mark.anyio
 async def test_subprotocol_support() -> None:
@@ -229,3 +352,45 @@ async def test_keepalive_ping_disabled() -> None:
     async with httpx.AsyncClient(transport=ASGIWebSocketTransport(app)) as client:
         async with aconnect_ws("ws://localhost:8000/ws", client) as ws:
             assert ws._keepalive_ping_interval_seconds is None
+
+
+@pytest.mark.anyio
+async def test_cancel_scope_integrity() -> None:
+    async def websocket_endpoint(websocket: WebSocket) -> None:
+        await websocket.accept()
+        await websocket.receive_text()
+        await websocket.close()  # pragma: no cover
+
+    app = Starlette(
+        routes=[
+            WebSocketRoute("/ws", endpoint=websocket_endpoint),
+        ]
+    )
+
+    async with httpx.AsyncClient(transport=ASGIWebSocketTransport(app)) as client:
+        with CancelScope():
+            async with aconnect_ws("ws://localhost:8000/ws", client):
+                pass
+
+
+@pytest.mark.anyio
+async def test_receive() -> None:
+    messages: list[str] = []
+
+    async def websocket_endpoint(websocket: WebSocket) -> None:
+        await websocket.accept()
+        messages.append(await websocket.receive_text())
+        await websocket.close()
+
+    app = Starlette(
+        routes=[
+            WebSocketRoute("/ws", endpoint=websocket_endpoint),
+        ]
+    )
+
+    async with httpx.AsyncClient(transport=ASGIWebSocketTransport(app)) as client:
+        async with aconnect_ws("ws://localhost:8000/ws", client) as ws:
+            await ws.send_text("RESULT")
+
+    assert len(messages) == 1
+    assert messages[0] == "RESULT"

--- a/uv.lock
+++ b/uv.lock
@@ -1393,7 +1393,7 @@ zstd = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anyio" },
+    { name = "anyio", specifier = ">=4.10" },
     { name = "brotli", marker = "platform_python_implementation == 'CPython' and extra == 'brotli'" },
     { name = "brotlicffi", marker = "platform_python_implementation != 'CPython' and extra == 'brotli'" },
     { name = "click", marker = "extra == 'cli'", specifier = ">=8.4" },


### PR DESCRIPTION
Closes the gap reported in [#1066](https://github.com/pydantic/httpx2/discussions/1066): the vendoring in [#1042](https://github.com/pydantic/httpx2/pull/1042) accidentally used [frankie567/httpx-ws@6bc568b](https://github.com/frankie567/httpx-ws/commit/6bc568b29f60ebfa28c228f39630c02074a369bf) (v0.6.2 era, October 2024). This ports every upstream change from there to the current tip, [frankie567/httpx-ws@0341891](https://github.com/frankie567/httpx-ws/commit/034189169aaa7ee16d4c41084925ae256f4eb860) (v0.9.0 + 6 commits) - 80 commits, of which 38 touch library or test code; the rest are upstream CI/docs/tooling.

## What comes in

- Write lock serializing stream writes ([httpx-ws#29](https://github.com/frankie567/httpx-ws/issues/29))
- Async session rebuilt on `anyio.AsyncContextManagerMixin`, fixing the asyncio hang on exit after cancellation and cancel scope corruption ([httpx-ws#108](https://github.com/frankie567/httpx-ws/issues/108)); `anyio>=4.10` is now required
- `ASGIWebSocketTransport` rewritten on a task group and anyio streams instead of a blocking portal and `queue.Queue`
- WebSocket Denial Response ASGI extension support
- Configurable `initial_receive_timeout` with a clear error when the server never calls `accept()`
- `TimeoutError` instead of `queue.Empty` on sync receive timeout (docs updated)
- Proper end-of-stream handling and keepalive ping exit when the connection is closing
- Class-based `WebSocketClient`/`AsyncWebSocketClient` with `session_class` support, exported from `httpx2.websockets`

## Deliberate deviations from upstream

- httpx2 adaptations preserved: relative imports, lazy `httpcore2` imports, explicit handshake parameters instead of `**kwargs`, `Client.websocket()` as the public entry point (`connect_ws`/`aconnect_ws` stay unexported)
- `session_class` lives only on the client classes, not on `connect_ws`/`aconnect_ws`: mypy cannot infer the PEP 696 TypeVar default through the `contextmanager` decorator
- Two fixes upstream does not have (worth PRing back): `aclose` is registered before the initial receive so a never-accepting app does not leak memory object streams, and the double-`__aenter__` guard is covered by a test

## Verification

- 164 websocket tests pass on asyncio and trio, 3 consecutive full runs; whole httpx2 suite: 1634 passed
- 100% coverage on all `websockets/` files; ruff format, ruff check, mypy strict, unasync all clean
- Independently reviewed by Codex against the full upstream commit range: all 38 code commits verified present, no porting bugs found

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

