### PR TITLE
Ensure mounted transports are closed even if main transport raises

### DIFF
--- a/src/httpx2/httpx2/_client.py
+++ b/src/httpx2/httpx2/_client.py
@@ -1369,10 +1369,12 @@ class Client(BaseClient):
         if self._state != ClientState.CLOSED:
             self._state = ClientState.CLOSED
 
-            self._transport.close()
-            for transport in self._mounts.values():
-                if transport is not None:
-                    transport.close()
+            try:
+                self._transport.close()
+            finally:
+                for transport in self._mounts.values():
+                    if transport is not None:
+                        transport.close()
 
     def __enter__(self: T) -> T:
         if self._state != ClientState.UNOPENED:
@@ -1398,10 +1400,12 @@ class Client(BaseClient):
     ) -> None:
         self._state = ClientState.CLOSED
 
-        self._transport.__exit__(exc_type, exc_value, traceback)
-        for transport in self._mounts.values():
-            if transport is not None:
-                transport.__exit__(exc_type, exc_value, traceback)
+        try:
+            self._transport.__exit__(exc_type, exc_value, traceback)
+        finally:
+            for transport in self._mounts.values():
+                if transport is not None:
+                    transport.__exit__(exc_type, exc_value, traceback)
 
 
 class AsyncClient(BaseClient):
@@ -2206,10 +2210,12 @@ class AsyncClient(BaseClient):
         if self._state != ClientState.CLOSED:
             self._state = ClientState.CLOSED
 
-            await self._transport.aclose()
-            for proxy in self._mounts.values():
-                if proxy is not None:
-                    await proxy.aclose()
+            try:
+                await self._transport.aclose()
+            finally:
+                for proxy in self._mounts.values():
+                    if proxy is not None:
+                        await proxy.aclose()
 
     async def __aenter__(self: U) -> U:
         if self._state != ClientState.UNOPENED:
@@ -2235,7 +2241,9 @@ class AsyncClient(BaseClient):
     ) -> None:
         self._state = ClientState.CLOSED
 
-        await self._transport.__aexit__(exc_type, exc_value, traceback)
-        for proxy in self._mounts.values():
-            if proxy is not None:
-                await proxy.__aexit__(exc_type, exc_value, traceback)
+        try:
+            await self._transport.__aexit__(exc_type, exc_value, traceback)
+        finally:
+            for proxy in self._mounts.values():
+                if proxy is not None:
+                    await proxy.__aexit__(exc_type, exc_value, traceback)

--- a/tests/httpx2/client/test_async_client.py
+++ b/tests/httpx2/client/test_async_client.py
@@ -258,6 +258,50 @@ async def test_context_managed_transport_and_mount() -> None:
     ]
 
 
+@pytest.mark.anyio
+async def test_aclose_still_closes_mount_when_transport_raises() -> None:
+    class RaisingTransport(httpx2.AsyncBaseTransport):
+        async def aclose(self) -> None:
+            raise RuntimeError("boom")
+
+    class Transport(httpx2.AsyncBaseTransport):
+        def __init__(self) -> None:
+            self.closed = False
+
+        async def aclose(self) -> None:
+            self.closed = True
+
+    mounted = Transport()
+    client = httpx2.AsyncClient(transport=RaisingTransport(), mounts={"http://www.example.org": mounted})
+
+    with pytest.raises(RuntimeError):
+        await client.aclose()
+
+    assert mounted.closed
+
+
+@pytest.mark.anyio
+async def test_aexit_still_closes_mount_when_transport_raises() -> None:
+    class RaisingTransport(httpx2.AsyncBaseTransport):
+        async def aclose(self) -> None:
+            raise RuntimeError("boom")
+
+    class Transport(httpx2.AsyncBaseTransport):
+        def __init__(self) -> None:
+            self.closed = False
+
+        async def aclose(self) -> None:
+            self.closed = True
+
+    mounted = Transport()
+
+    with pytest.raises(RuntimeError):
+        async with httpx2.AsyncClient(transport=RaisingTransport(), mounts={"http://www.example.org": mounted}):
+            pass
+
+    assert mounted.closed
+
+
 def hello_world(request: httpx2.Request) -> httpx2.Response:
     return httpx2.Response(200, text="Hello, world!")
 

--- a/tests/httpx2/client/test_client.py
+++ b/tests/httpx2/client/test_client.py
@@ -308,6 +308,48 @@ def test_context_managed_transport_and_mount() -> None:
     ]
 
 
+def test_close_still_closes_mount_when_transport_raises() -> None:
+    class RaisingTransport(httpx2.BaseTransport):
+        def close(self) -> None:
+            raise RuntimeError("boom")
+
+    class Transport(httpx2.BaseTransport):
+        def __init__(self) -> None:
+            self.closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    mounted = Transport()
+    client = httpx2.Client(transport=RaisingTransport(), mounts={"http://www.example.org": mounted})
+
+    with pytest.raises(RuntimeError):
+        client.close()
+
+    assert mounted.closed
+
+
+def test_exit_still_closes_mount_when_transport_raises() -> None:
+    class RaisingTransport(httpx2.BaseTransport):
+        def close(self) -> None:
+            raise RuntimeError("boom")
+
+    class Transport(httpx2.BaseTransport):
+        def __init__(self) -> None:
+            self.closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    mounted = Transport()
+
+    with pytest.raises(RuntimeError):
+        with httpx2.Client(transport=RaisingTransport(), mounts={"http://www.example.org": mounted}):
+            pass
+
+    assert mounted.closed
+
+
 def hello_world(request: httpx2.Request) -> httpx2.Response:
     return httpx2.Response(200, text="Hello, world!")
 


### PR DESCRIPTION
If a client with proxy mounts fails to close the main transport (its close()/__exit__/aclose()/__aexit__ raises), the mounted transports were never reached, leaking their connections. Wrap the main transport cleanup in try/finally so mounts are always closed regardless.

Ported from encode/httpx#3769.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

