### PR TITLE
Attach the request to SSE errors via `request_context`

### DIFF
--- a/src/httpx2/httpx2/_sse.py
+++ b/src/httpx2/httpx2/_sse.py
@@ -10,7 +10,7 @@ import json as jsonlib
 from collections.abc import AsyncIterator, Iterator
 from dataclasses import dataclass
 
-from ._exceptions import TransportError
+from ._exceptions import TransportError, request_context
 from ._models import Response
 
 __all__ = ["EventSource", "SSEError", "ServerSentEvent"]
@@ -124,35 +124,34 @@ class EventSource:
     def _check_content_type(self) -> None:
         content_type, _, _ = self._response.headers.get("content-type", "").partition(";")
         if content_type.strip().lower() != "text/event-stream":
-            raise SSEError(
-                f"Expected response with content type 'text/event-stream', got {content_type.strip()!r}.",
-                request=self._response.request,
-            )
+            raise SSEError(f"Expected response with content type 'text/event-stream', got {content_type.strip()!r}.")
 
     def __iter__(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = _SSEDecoder()
-        lines = _SSELineDecoder()
-        for chunk in self._response.iter_text():
-            for line in lines.decode(chunk):
+        with request_context(request=self._response.request):
+            self._check_content_type()
+            decoder = _SSEDecoder()
+            lines = _SSELineDecoder()
+            for chunk in self._response.iter_text():
+                for line in lines.decode(chunk):
+                    sse = decoder.decode(line)
+                    if sse is not None:
+                        yield sse
+            for line in lines.flush():
                 sse = decoder.decode(line)
                 if sse is not None:
                     yield sse
-        for line in lines.flush():
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
 
     async def __aiter__(self) -> AsyncIterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = _SSEDecoder()
-        lines = _SSELineDecoder()
-        async for chunk in self._response.aiter_text():
-            for line in lines.decode(chunk):
+        with request_context(request=self._response.request):
+            self._check_content_type()
+            decoder = _SSEDecoder()
+            lines = _SSELineDecoder()
+            async for chunk in self._response.aiter_text():
+                for line in lines.decode(chunk):
+                    sse = decoder.decode(line)
+                    if sse is not None:
+                        yield sse
+            for line in lines.flush():
                 sse = decoder.decode(line)
                 if sse is not None:
                     yield sse
-        for line in lines.flush():
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse

--- a/src/httpx2/httpx2/_sse.py
+++ b/src/httpx2/httpx2/_sse.py
@@ -127,7 +127,7 @@ class EventSource:
             raise SSEError(f"Expected response with content type 'text/event-stream', got {content_type.strip()!r}.")
 
     def __iter__(self) -> Iterator[ServerSentEvent]:
-        with request_context(request=self._response.request):
+        with request_context(request=self._response._request):
             self._check_content_type()
             decoder = _SSEDecoder()
             lines = _SSELineDecoder()
@@ -142,7 +142,7 @@ class EventSource:
                     yield sse
 
     async def __aiter__(self) -> AsyncIterator[ServerSentEvent]:
-        with request_context(request=self._response.request):
+        with request_context(request=self._response._request):
             self._check_content_type()
             decoder = _SSEDecoder()
             lines = _SSELineDecoder()

--- a/tests/httpx2/test_sse.py
+++ b/tests/httpx2/test_sse.py
@@ -153,8 +153,10 @@ def test_content_type_mismatch_raises() -> None:
 
     with httpx2.Client(transport=httpx2.MockTransport(handler)) as client:
         with client.sse("http://testserver/sse") as source:
-            with pytest.raises(httpx2.SSEError, match="text/event-stream"):
+            with pytest.raises(httpx2.SSEError, match="text/event-stream") as exc_info:
                 list(source)
+
+    assert exc_info.value.request.url == "http://testserver/sse"
 
 
 @pytest.mark.anyio

--- a/tests/httpx2/test_sse.py
+++ b/tests/httpx2/test_sse.py
@@ -173,9 +173,7 @@ async def test_content_type_mismatch_raises_async() -> None:
 
 
 def test_event_source_without_request() -> None:
-    response = httpx2.Response(
-        200, content=b"data: hi\n\n", headers={"Content-Type": "text/event-stream"}
-    )
+    response = httpx2.Response(200, content=b"data: hi\n\n", headers={"Content-Type": "text/event-stream"})
 
     (event,) = list(httpx2.EventSource(response))
 

--- a/tests/httpx2/test_sse.py
+++ b/tests/httpx2/test_sse.py
@@ -166,8 +166,20 @@ async def test_content_type_mismatch_raises_async() -> None:
 
     async with httpx2.AsyncClient(transport=httpx2.MockTransport(handler)) as client:
         async with client.sse("http://testserver/sse") as source:
-            with pytest.raises(httpx2.SSEError, match="text/event-stream"):
+            with pytest.raises(httpx2.SSEError, match="text/event-stream") as exc_info:
                 [event async for event in source]
+
+    assert exc_info.value.request.url == "http://testserver/sse"
+
+
+def test_event_source_without_request() -> None:
+    response = httpx2.Response(
+        200, content=b"data: hi\n\n", headers={"Content-Type": "text/event-stream"}
+    )
+
+    (event,) = list(httpx2.EventSource(response))
+
+    assert event.data == "hi"
 
 
 def test_sets_sse_headers() -> None:


### PR DESCRIPTION
Wrap the SSE iteration in `request_context` so any `SSEError` raised while consuming the stream carries the originating request, the same way the client attaches request context to errors elsewhere (e.g. `Response.aiter_raw`).

Behaviour-neutral today: the only `SSEError` currently raised is the content-type check, which already passed `request=` explicitly and continues to carry it - now via the wrapper rather than the explicit argument. This is groundwork for [#1071](https://github.com/pydantic/httpx2/pull/1071), which adds size-limit errors during iteration that should carry the request too.

Extended `test_content_type_mismatch_raises` to assert `exc.request` is set.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1073?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

