### PR TITLE
Add `alias_httpx()` to alias `httpx` imports to `httpx2`

### DIFF
--- a/src/httpx2/CHANGELOG.md
+++ b/src/httpx2/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Added
+
+* Add `alias_httpx()`, letting applications make `import httpx` resolve to `httpx2` process-wide.
+
 ## 2.5.0 (June 25th, 2026)
 
 ### Added

--- a/src/httpx2/httpx2/__init__.py
+++ b/src/httpx2/httpx2/__init__.py
@@ -1,4 +1,5 @@
 from .__version__ import __description__, __title__, __version__
+from ._alias import *
 from ._api import *
 from ._auth import *
 from ._client import *
@@ -16,6 +17,7 @@ __all__ = [
     "__description__",
     "__title__",
     "__version__",
+    "alias_httpx",
     "ASGITransport",
     "AsyncBaseTransport",
     "AsyncByteStream",

--- a/src/httpx2/httpx2/_alias.py
+++ b/src/httpx2/httpx2/_alias.py
@@ -12,11 +12,15 @@ __all__ = ["alias_httpx"]
 
 
 class _AliasLoader(importlib.abc.Loader):
+    _original_spec: importlib.machinery.ModuleSpec | None
+
     def create_module(self, spec: importlib.machinery.ModuleSpec) -> ModuleType:
-        return importlib.import_module("httpx2" + spec.name.removeprefix("httpx"))
+        module = importlib.import_module("httpx2" + spec.name.removeprefix("httpx"))
+        self._original_spec = module.__spec__
+        return module
 
     def exec_module(self, module: ModuleType) -> None:
-        pass
+        module.__spec__ = self._original_spec
 
 
 class _AliasFinder(importlib.abc.MetaPathFinder):
@@ -49,6 +53,6 @@ def alias_httpx() -> None:
     if existing is not None and existing is not httpx2:
         raise RuntimeError("httpx was already imported; call `alias_httpx()` before any `import httpx`.")
 
-    sys.modules["httpx"] = httpx2
     if not any(isinstance(finder, _AliasFinder) for finder in sys.meta_path):
         sys.meta_path.insert(0, _AliasFinder())
+    sys.modules["httpx"] = httpx2

--- a/src/httpx2/httpx2/_alias.py
+++ b/src/httpx2/httpx2/_alias.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib
 import importlib.abc
 import importlib.machinery
+import importlib.util
 import sys
 from collections.abc import Sequence
 from types import ModuleType
@@ -25,9 +26,12 @@ class _AliasFinder(importlib.abc.MetaPathFinder):
         path: Sequence[str] | None = None,
         target: ModuleType | None = None,
     ) -> importlib.machinery.ModuleSpec | None:
-        if fullname == "httpx" or fullname.startswith("httpx."):
-            return importlib.machinery.ModuleSpec(fullname, _AliasLoader())
-        return None
+        if fullname != "httpx" and not fullname.startswith("httpx."):
+            return None
+        real_name = "httpx2" + fullname.removeprefix("httpx")
+        if real_name not in sys.modules and importlib.util.find_spec(real_name) is None:
+            return None
+        return importlib.machinery.ModuleSpec(fullname, _AliasLoader())
 
 
 def alias_httpx() -> None:

--- a/src/httpx2/httpx2/_alias.py
+++ b/src/httpx2/httpx2/_alias.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import importlib
+import importlib.abc
+import importlib.machinery
+import sys
+from collections.abc import Sequence
+from types import ModuleType
+
+__all__ = ["alias_httpx"]
+
+
+class _AliasLoader(importlib.abc.Loader):
+    def create_module(self, spec: importlib.machinery.ModuleSpec) -> ModuleType:
+        return importlib.import_module("httpx2" + spec.name.removeprefix("httpx"))
+
+    def exec_module(self, module: ModuleType) -> None:
+        pass
+
+
+class _AliasFinder(importlib.abc.MetaPathFinder):
+    def find_spec(
+        self,
+        fullname: str,
+        path: Sequence[str] | None = None,
+        target: ModuleType | None = None,
+    ) -> importlib.machinery.ModuleSpec | None:
+        if fullname == "httpx" or fullname.startswith("httpx."):
+            return importlib.machinery.ModuleSpec(fullname, _AliasLoader())
+        return None
+
+
+def alias_httpx() -> None:
+    """
+    Make `import httpx` resolve to `httpx2`, process-wide.
+
+    Intended for applications migrating from `httpx`, so that dependencies still
+    importing `httpx` share the `httpx2` classes. Libraries should never call this.
+
+    Must be called before anything imports `httpx`. Calling it again is a no-op.
+    """
+    import httpx2
+
+    existing = sys.modules.get("httpx")
+    if existing is not None and existing is not httpx2:
+        raise RuntimeError("httpx was already imported; call `alias_httpx()` before any `import httpx`.")
+
+    sys.modules["httpx"] = httpx2
+    if not any(isinstance(finder, _AliasFinder) for finder in sys.meta_path):
+        sys.meta_path.insert(0, _AliasFinder())

--- a/tests/httpx2/test_alias.py
+++ b/tests/httpx2/test_alias.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import sys
+import types
+from collections.abc import Iterator
+
+import pytest
+
+import httpx2
+from httpx2._alias import _AliasFinder
+
+
+@pytest.fixture(autouse=True)
+def restore_import_state() -> Iterator[None]:
+    yield
+    sys.meta_path[:] = [finder for finder in sys.meta_path if not isinstance(finder, _AliasFinder)]
+    for name in [name for name in sys.modules if name == "httpx" or name.startswith("httpx.")]:
+        del sys.modules[name]
+
+
+def test_alias_top_level_import() -> None:
+    httpx2.alias_httpx()
+
+    import httpx
+
+    assert httpx is httpx2
+    assert httpx.Client is httpx2.Client
+
+
+def test_alias_submodules_share_modules() -> None:
+    httpx2.alias_httpx()
+
+    from httpx._exceptions import HTTPError
+
+    assert HTTPError is httpx2.HTTPError
+    assert sys.modules["httpx._exceptions"] is sys.modules["httpx2._exceptions"]
+
+    with pytest.raises(HTTPError):
+        raise httpx2.ConnectError("boom")
+
+
+def test_alias_finder_handles_top_level_import() -> None:
+    httpx2.alias_httpx()
+    del sys.modules["httpx"]
+
+    import httpx
+
+    assert httpx is httpx2
+
+
+def test_alias_is_idempotent() -> None:
+    httpx2.alias_httpx()
+    httpx2.alias_httpx()
+
+    assert sum(isinstance(finder, _AliasFinder) for finder in sys.meta_path) == 1
+
+
+def test_alias_raises_if_httpx_already_imported() -> None:
+    sys.modules["httpx"] = types.ModuleType("httpx")
+
+    with pytest.raises(RuntimeError, match="httpx was already imported"):
+        httpx2.alias_httpx()
+
+
+def test_finder_ignores_other_modules() -> None:
+    assert _AliasFinder().find_spec("json") is None

--- a/tests/httpx2/test_alias.py
+++ b/tests/httpx2/test_alias.py
@@ -14,10 +14,15 @@ from httpx2._alias import _AliasFinder
 
 @pytest.fixture(autouse=True)
 def restore_import_state() -> Iterator[None]:
+    saved_meta_path = list(sys.meta_path)
+    saved_modules = {
+        name: module for name, module in sys.modules.items() if name == "httpx" or name.startswith("httpx.")
+    }
     yield
-    sys.meta_path[:] = [finder for finder in sys.meta_path if not isinstance(finder, _AliasFinder)]
+    sys.meta_path[:] = saved_meta_path
     for name in [name for name in sys.modules if name == "httpx" or name.startswith("httpx.")]:
         del sys.modules[name]
+    sys.modules.update(saved_modules)
 
 
 def test_alias_top_level_import() -> None:
@@ -48,6 +53,16 @@ def test_alias_finder_handles_top_level_import() -> None:
     import httpx
 
     assert httpx is httpx2
+
+
+def test_alias_preserves_canonical_spec() -> None:
+    httpx2.alias_httpx()
+
+    importlib.import_module("httpx._exceptions")
+
+    spec = sys.modules["httpx2._exceptions"].__spec__
+    assert spec is not None
+    assert spec.name == "httpx2._exceptions"
 
 
 def test_alias_is_idempotent() -> None:

--- a/tests/httpx2/test_alias.py
+++ b/tests/httpx2/test_alias.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import importlib
+import importlib.util
 import sys
 import types
 from collections.abc import Iterator
@@ -64,3 +66,19 @@ def test_alias_raises_if_httpx_already_imported() -> None:
 
 def test_finder_ignores_other_modules() -> None:
     assert _AliasFinder().find_spec("json") is None
+
+
+def test_finder_returns_none_for_missing_submodules() -> None:
+    httpx2.alias_httpx()
+
+    assert importlib.util.find_spec("httpx._does_not_exist") is None
+
+    with pytest.raises(ModuleNotFoundError):
+        importlib.import_module("httpx._does_not_exist")
+
+
+def test_finder_locates_unloaded_submodules(monkeypatch: pytest.MonkeyPatch) -> None:
+    httpx2.alias_httpx()
+    monkeypatch.delitem(sys.modules, "httpx2._main", raising=False)
+
+    assert importlib.util.find_spec("httpx._main") is not None


### PR DESCRIPTION
## Summary

Adds `httpx2.alias_httpx()`: an explicit, application-level function that makes `import httpx` resolve to `httpx2` process-wide, so dependencies still importing `httpx` share the `httpx2` classes - `isinstance()` checks and `except` clauses interoperate.

Closes #963.

## Why not just `sys.modules['httpx'] = httpx2`?

The one-liner only covers top-level imports. Any `from httpx._x import y` makes the import system load `httpx2/_x.py` a second time under the `httpx._x` name, recreating the split class hierarchy - and libraries do import httpx internals. So `alias_httpx()` also installs a `MetaPathFinder` whose loader returns the already-loaded `httpx2.*` module for any `httpx.*` import (no re-execution, `__name__` stays truthful).

## Behavior

- Raises `RuntimeError` if real `httpx` was already imported (the alias can't rewrite existing references, so it fails loudly instead of half-working).
- Idempotent; repairs a prior bare `sys.modules` assignment by installing the finder.
- For applications only, never libraries - per the docstring and the discussion in #963.

Known limits (unfixable by any aliasing): `importlib.metadata.version("httpx")` mismatches, `logging.getLogger("httpx")` silence, and spawn-based subprocess workers re-importing without the alias. These will be covered in the migration guide.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

