### PR TITLE
Enable preview URLs for docs Worker versions

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,5 +1,6 @@
 name = "httpx2-docs"
 compatibility_date = "2026-05-22"
+preview_urls = true
 
 [[routes]]
 pattern = "httpx2.pydantic.dev"


### PR DESCRIPTION
## Summary

The `Docs preview:` sticky comment on PRs has been empty (e.g. #1077, #1078): the workflow interpolates `steps.deploy.outputs.deployment-url`, but `wrangler versions upload` only prints the `Version Preview URL` line that populates the output when preview URLs are enabled for the Worker. This adds `preview_urls = true` to `wrangler.toml`.

Note: preview URLs are served on `workers.dev`, so the account's `workers.dev` subdomain must be registered (one-time dashboard setting) for wrangler to print the URL.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

