### PR TITLE
Backfill changelogs for 2.6.0-2.8.0 and cut 2.9.0

### DIFF
--- a/src/httpcore2/CHANGELOG.md
+++ b/src/httpcore2/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2.9.0 (July 23rd, 2026)
+
+No changes since `2.8.0`. Version bumped to stay in lockstep with `httpx2`.
+
+## 2.8.0 (July 23rd, 2026)
+
+### Changed
+
+* Assign each released connection to a single queued request, eliminating multi-assignment churn in the connection pool. ([#1075](https://github.com/pydantic/httpx2/pull/1075))
+
+## 2.7.0 (July 14th, 2026)
+
+No changes since `2.6.0`. Version bumped to stay in lockstep with `httpx2`.
+
+## 2.6.0 (July 14th, 2026)
+
+### Fixed
+
+* Clean up garbage connections on cancellation in `AsyncConnectionPool`. ([#983](https://github.com/pydantic/httpx2/pull/983))
+* Read `_expire_at` only once in `has_expired()`. ([#1045](https://github.com/pydantic/httpx2/pull/1045))
+
 ## 2.5.0 (June 25th, 2026)
 
 ### Fixed

--- a/src/httpx2/CHANGELOG.md
+++ b/src/httpx2/CHANGELOG.md
@@ -4,11 +4,32 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
+## 2.9.0 (July 23rd, 2026)
 
 ### Added
 
-* Add `alias_httpx()`, letting applications make `import httpx` resolve to `httpx2` process-wide.
+* Add `alias_httpx()`, letting applications make `import httpx` resolve to `httpx2` process-wide. ([#1077](https://github.com/pydantic/httpx2/pull/1077))
+
+## 2.8.0 (July 23rd, 2026)
+
+No changes since `2.7.0`. Version bumped to stay in lockstep with `httpcore2`.
+
+## 2.7.0 (July 14th, 2026)
+
+### Changed
+
+* Update the vendored `httpx-ws` to upstream v0.9.0. ([#1067](https://github.com/pydantic/httpx2/pull/1067))
+
+## 2.6.0 (July 14th, 2026)
+
+### Added
+
+* Add native WebSocket support by vendoring `httpx-ws`, installable with `httpx2[ws]`. ([#1042](https://github.com/pydantic/httpx2/pull/1042))
+* Add support for the `QUERY` HTTP method via `httpx2.query()` and `client.query()`. ([#1055](https://github.com/pydantic/httpx2/pull/1055))
+
+### Changed
+
+* Allow `click` 8.4+ in the `cli` extra, dropping the upper bound. ([#1040](https://github.com/pydantic/httpx2/pull/1040))
 
 ## 2.5.0 (June 25th, 2026)
 


### PR DESCRIPTION
## Summary

Releases `v2.6.0`, `v2.7.0`, and `v2.8.0` were tagged without changelog entries. This backfills both package changelogs from the commit history between tags, and renames `Unreleased` to `2.9.0`.

- `httpx2`: `2.6.0` (WebSocket support via #1042, `QUERY` method via #1055, click bounds via #1040), `2.7.0` (httpx-ws v0.9.0 via #1067), `2.8.0` (lockstep bump, no changes), `2.9.0` (`alias_httpx()` via #1077, with the PR link added).
- `httpcore2`: `2.6.0` (#983, #1045), `2.7.0` (lockstep bump), `2.8.0` (connection pool churn via #1075), `2.9.0` (lockstep bump).

Docs-only and test-only commits (#1041, #1054, #1058, #1061, #1062, #1063, #1065) are omitted, matching existing changelog conventions. Lockstep entries reuse the phrasing from `httpcore2` `2.2.0`. Dates come from the tag dates; `2.9.0` is dated today.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

