### PR TITLE
Detail the WebSocket API surface in the 2.6.0 and 2.7.0 changelogs

### DIFF
--- a/src/httpx2/CHANGELOG.md
+++ b/src/httpx2/CHANGELOG.md
@@ -16,16 +16,20 @@ No changes since `2.7.0`. Version bumped to stay in lockstep with `httpcore2`.
 
 ## 2.7.0 (July 14th, 2026)
 
+### Added
+
+* Add `WebSocketClient` and `AsyncWebSocketClient` to `httpx2.websockets`, wrapping a client with reusable WebSocket connection settings. ([#1067](https://github.com/pydantic/httpx2/pull/1067))
+
 ### Changed
 
-* Update the vendored `httpx-ws` to upstream v0.9.0. ([#1067](https://github.com/pydantic/httpx2/pull/1067))
+* Update the vendored `httpx-ws` to upstream v0.9.0, which was previously pinned to an outdated snapshot. ([#1067](https://github.com/pydantic/httpx2/pull/1067))
 
 ## 2.6.0 (July 14th, 2026)
 
 ### Added
 
-* Add native WebSocket support by vendoring `httpx-ws`, installable with `httpx2[ws]`. ([#1042](https://github.com/pydantic/httpx2/pull/1042))
-* Add support for the `QUERY` HTTP method via `httpx2.query()` and `client.query()`. ([#1055](https://github.com/pydantic/httpx2/pull/1055))
+* Add native WebSocket support by vendoring `httpx-ws`, installable with `httpx2[ws]`: `client.websocket()`, `httpx2.websocket()`, and the `httpx2.websockets` module with sync/async sessions, exceptions, and `ASGIWebSocketTransport`. ([#1042](https://github.com/pydantic/httpx2/pull/1042))
+* Add support for the `QUERY` HTTP method via `httpx2.query()`, `client.query()`, and the CLI. ([#1055](https://github.com/pydantic/httpx2/pull/1055))
 
 ### Changed
 


### PR DESCRIPTION
## Summary

Follow-up to #1080, cross-checked against the GitHub release notes and the public API diffs between tags:

- `2.7.0` was under-reported: the httpx-ws v0.9.0 sync (#1067) also added `WebSocketClient` and `AsyncWebSocketClient` to `httpx2.websockets` - new public API, now listed under `Added`. The `Changed` entry also mentions the previous vendored snapshot was outdated, matching the release notes.
- `2.6.0`: the WebSocket entry now names the actual surface (`client.websocket()`, `httpx2.websocket()`, the `httpx2.websockets` module), and the `QUERY` entry mentions the CLI support.

For the record, #983 and #1045 from the v2.6.0 release notes are intentionally in the `httpcore2` changelog, following the per-package split.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

