### PR TITLE
Version 2.9.1

### DIFF
--- a/src/httpcore2/CHANGELOG.md
+++ b/src/httpcore2/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2.9.1 (July 24th, 2026)
+
+No changes since `2.9.0`. Version bumped to stay in lockstep with `httpx2`.
+
 ## 2.9.0 (July 23rd, 2026)
 
 No changes since `2.8.0`. Version bumped to stay in lockstep with `httpx2`.

--- a/src/httpx2/CHANGELOG.md
+++ b/src/httpx2/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2.9.1 (July 24th, 2026)
+
+### Fixed
+
+* Alias `httpcore` imports to `httpcore2` in `alias_httpx()`. ([#1082](https://github.com/pydantic/httpx2/pull/1082))
+
 ## 2.9.0 (July 23rd, 2026)
 
 ### Added


### PR DESCRIPTION
Changelog entries for `2.9.1`: `httpx2` gets the `alias_httpx()` httpcore aliasing from [#1082](https://github.com/pydantic/httpx2/pull/1082), `httpcore2` is a lockstep bump.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1083?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

