### PR TITLE
Enable preview URLs for the docs worker

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,5 +1,6 @@
 name = "httpx2-docs"
 compatibility_date = "2026-05-22"
+preview_urls = true
 
 [[routes]]
 pattern = "httpx2.pydantic.dev"


### PR DESCRIPTION
`preview_urls` defaults to `workers_dev`, which is disabled because the worker uses a custom domain route - so every `wrangler deploy` in CI reverted the dashboard toggle. Setting it explicitly keeps preview URLs enabled across deploys.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1084?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

