### PR TITLE
Enforce WebSocket max message size across fragments

### DIFF
--- a/docs/websockets.md
+++ b/docs/websockets.md
@@ -97,7 +97,7 @@ You can also send a Ping manually. `ping()` returns an event that is set when th
 
 | Argument | Default | Description |
 | -------- | ------- | ----------- |
-| `max_message_size_bytes` | 65536 | The number of bytes read from the network at a time. Larger messages are received in multiple chunks and reassembled. |
+| `max_message_size_bytes` | 65536 | The maximum incoming message size in bytes. Messages larger than this limit, including fragmented messages whose cumulative size exceeds the limit, close the connection with `MESSAGE_TOO_BIG`. |
 | `queue_size` | 512 | The size of the queue holding received messages until they are consumed. When full, the session stops reading from the server until room is available. |
 | `keepalive_ping_interval_seconds` | 20.0 | The interval between automatic keepalive pings. Use `None` to disable them. |
 | `keepalive_ping_timeout_seconds` | 20.0 | How long to wait for the server to answer a keepalive ping before considering the connection lost. |

--- a/src/httpx2/httpx2/websockets/_api.py
+++ b/src/httpx2/httpx2/websockets/_api.py
@@ -1169,7 +1169,10 @@ class WebSocketClient(typing.Generic[SyncSession]):
         client:
             HTTPX client to use.
         max_message_size_bytes:
-            Message size in bytes to receive from the server.
+            Maximum incoming message size in bytes.
+            Larger messages, including fragmented messages whose
+            cumulative size exceeds the limit, close the connection
+            with `MESSAGE_TOO_BIG`.
             Defaults to 65 KiB.
         queue_size:
             Size of the queue where the received messages will be held
@@ -1318,7 +1321,10 @@ def connect_ws(
             HTTPX client to use.
             If not provided, a default one will be initialized.
         max_message_size_bytes:
-            Message size in bytes to receive from the server.
+            Maximum incoming message size in bytes.
+            Larger messages, including fragmented messages whose
+            cumulative size exceeds the limit, close the connection
+            with `MESSAGE_TOO_BIG`.
             Defaults to 65 KiB.
         queue_size:
             Size of the queue where the received messages will be held
@@ -1412,7 +1418,10 @@ class AsyncWebSocketClient(typing.Generic[AsyncSession]):
         client:
             HTTPX client to use.
         max_message_size_bytes:
-            Message size in bytes to receive from the server.
+            Maximum incoming message size in bytes.
+            Larger messages, including fragmented messages whose
+            cumulative size exceeds the limit, close the connection
+            with `MESSAGE_TOO_BIG`.
             Defaults to 65 KiB.
         queue_size:
             Size of the queue where the received messages will be held
@@ -1561,7 +1570,10 @@ async def aconnect_ws(
             HTTPX client to use.
             If not provided, a default one will be initialized.
         max_message_size_bytes:
-            Message size in bytes to receive from the server.
+            Maximum incoming message size in bytes.
+            Larger messages, including fragmented messages whose
+            cumulative size exceeds the limit, close the connection
+            with `MESSAGE_TOO_BIG`.
             Defaults to 65 KiB.
         queue_size:
             Size of the queue where the received messages will be held

--- a/src/httpx2/httpx2/websockets/_api.py
+++ b/src/httpx2/httpx2/websockets/_api.py
@@ -55,6 +55,7 @@ if typing.TYPE_CHECKING:
     )
 
 JSONMode = typing.Literal["text", "binary"]
+
 TaskFunction = typing.TypeVar("TaskFunction")
 TaskResult = typing.TypeVar("TaskResult")
 SyncSession = TypeVar("SyncSession", bound="WebSocketSession", default="WebSocketSession")
@@ -504,6 +505,7 @@ class WebSocketSession:
         import httpcore2
 
         partial_message_buffer: str | bytes | None = None
+        partial_message_size = 0
         try:
             while not self._should_close.is_set():
                 data = self._wait_until_closed(self._read_stream, max_bytes)
@@ -520,6 +522,11 @@ class WebSocketSession:
                     if isinstance(event, wsproto.events.CloseConnection):
                         self._should_close.set()
                     if isinstance(event, wsproto.events.Message):
+                        partial_message_size += len(event.data.encode() if isinstance(event.data, str) else event.data)
+                        if partial_message_size > max_bytes:
+                            self.close(CloseReason.MESSAGE_TOO_BIG, "Message too big")
+                            self._events.put(WebSocketDisconnect(CloseReason.MESSAGE_TOO_BIG, "Message too big"))
+                            break
                         # Unfinished message: bufferize
                         if not event.message_finished:
                             if partial_message_buffer is None:
@@ -528,12 +535,14 @@ class WebSocketSession:
                                 partial_message_buffer += event.data
                         # Finished message but no buffer: just emit the event
                         elif partial_message_buffer is None:
+                            partial_message_size = 0
                             self._events.put(event)
                         # Finished message with buffer: emit the full event
                         else:
                             event_type = type(event)
                             full_message_event = event_type(partial_message_buffer + event.data)
                             partial_message_buffer = None
+                            partial_message_size = 0
                             self._events.put(full_message_event)
                         continue
                     self._events.put(event)
@@ -1065,6 +1074,7 @@ class AsyncWebSocketSession(anyio.AsyncContextManagerMixin):
         import httpcore2
 
         partial_message_buffer: str | bytes | None = None
+        partial_message_size = 0
         try:
             while not self._should_close.is_set():
                 data = await self._read_stream(max_bytes)
@@ -1081,6 +1091,13 @@ class AsyncWebSocketSession(anyio.AsyncContextManagerMixin):
                     if isinstance(event, wsproto.events.CloseConnection):
                         self._should_close.set()
                     if isinstance(event, wsproto.events.Message):
+                        partial_message_size += len(event.data.encode() if isinstance(event.data, str) else event.data)
+                        if partial_message_size > max_bytes:
+                            await self.close(CloseReason.MESSAGE_TOO_BIG, "Message too big")
+                            await self._send_event.send(
+                                WebSocketDisconnect(CloseReason.MESSAGE_TOO_BIG, "Message too big")
+                            )
+                            break
                         # Unfinished message: bufferize
                         if not event.message_finished:
                             if partial_message_buffer is None:
@@ -1089,12 +1106,14 @@ class AsyncWebSocketSession(anyio.AsyncContextManagerMixin):
                                 partial_message_buffer += event.data
                         # Finished message but no buffer: just emit the event
                         elif partial_message_buffer is None:
+                            partial_message_size = 0
                             await self._send_event.send(event)
                         # Finished message with buffer: emit the full event
                         else:
                             event_type = type(event)
                             full_message_event = event_type(partial_message_buffer + event.data)
                             partial_message_buffer = None
+                            partial_message_size = 0
                             await self._send_event.send(full_message_event)
                         continue
                     await self._send_event.send(event)

--- a/src/httpx2/httpx2/websockets/_api.py
+++ b/src/httpx2/httpx2/websockets/_api.py
@@ -55,7 +55,6 @@ if typing.TYPE_CHECKING:
     )
 
 JSONMode = typing.Literal["text", "binary"]
-
 TaskFunction = typing.TypeVar("TaskFunction")
 TaskResult = typing.TypeVar("TaskResult")
 SyncSession = TypeVar("SyncSession", bound="WebSocketSession", default="WebSocketSession")

--- a/tests/httpx2/websockets/test_api.py
+++ b/tests/httpx2/websockets/test_api.py
@@ -4,6 +4,7 @@ import concurrent.futures
 import queue
 import threading
 import time
+import typing
 from unittest.mock import MagicMock, call, patch
 
 import anyio
@@ -348,19 +349,18 @@ class TestReceive:
                     assert aexcinfo.value.code == wsproto.frame_protocol.CloseReason.MESSAGE_TOO_BIG
 
     @pytest.mark.parametrize(
-        "event_type,fragment_data",
+        "fragment_event",
         [
-            pytest.param(wsproto.events.BytesMessage, b"A" * 8, id="binary"),
-            pytest.param(wsproto.events.TextMessage, "é" * 4, id="multibyte-text"),
+            pytest.param(wsproto.events.BytesMessage(data=b"A" * 8, message_finished=False), id="binary"),
+            pytest.param(wsproto.events.TextMessage(data="é" * 4, message_finished=False), id="multibyte-text"),
         ],
     )
     async def test_receive_oversized_fragmented_message(
         self,
-        event_type: type[wsproto.events.BytesMessage] | type[wsproto.events.TextMessage],
-        fragment_data: str | bytes,
+        fragment_event: wsproto.events.Message[typing.Any],
     ) -> None:
         server_connection = wsproto.connection.Connection(wsproto.connection.ConnectionType.SERVER)
-        fragments = [server_connection.send(event_type(data=fragment_data, message_finished=False)) for _ in range(3)]
+        fragments = [server_connection.send(fragment_event) for _ in range(3)]
 
         class MockNetworkStream(NetworkStream):
             def __init__(self) -> None:
@@ -384,19 +384,18 @@ class TestReceive:
             assert excinfo.value.code == wsproto.frame_protocol.CloseReason.MESSAGE_TOO_BIG
 
     @pytest.mark.parametrize(
-        "event_type,fragment_data",
+        "fragment_event",
         [
-            pytest.param(wsproto.events.BytesMessage, b"A" * 8, id="binary"),
-            pytest.param(wsproto.events.TextMessage, "é" * 4, id="multibyte-text"),
+            pytest.param(wsproto.events.BytesMessage(data=b"A" * 8, message_finished=False), id="binary"),
+            pytest.param(wsproto.events.TextMessage(data="é" * 4, message_finished=False), id="multibyte-text"),
         ],
     )
     async def test_async_receive_oversized_fragmented_message(
         self,
-        event_type: type[wsproto.events.BytesMessage] | type[wsproto.events.TextMessage],
-        fragment_data: str | bytes,
+        fragment_event: wsproto.events.Message[typing.Any],
     ) -> None:
         server_connection = wsproto.connection.Connection(wsproto.connection.ConnectionType.SERVER)
-        fragments = [server_connection.send(event_type(data=fragment_data, message_finished=False)) for _ in range(3)]
+        fragments = [server_connection.send(fragment_event) for _ in range(3)]
 
         class AsyncMockNetworkStream(AsyncNetworkStream):
             def __init__(self) -> None:

--- a/tests/httpx2/websockets/test_api.py
+++ b/tests/httpx2/websockets/test_api.py
@@ -337,15 +337,69 @@ class TestReceive:
         with server_factory(websocket_endpoint) as socket:
             with httpx.Client(transport=httpx.HTTPTransport(uds=socket)) as client:
                 with connect_ws("http://socket/ws", client, max_message_size_bytes=1024) as ws:
-                    event = ws.receive()
-                    assert isinstance(event, wsproto.events.Message)
-                    assert event.data == full_message
+                    with pytest.raises(WebSocketDisconnect) as excinfo:
+                        ws.receive()
+                    assert excinfo.value.code == wsproto.frame_protocol.CloseReason.MESSAGE_TOO_BIG
 
             async with httpx.AsyncClient(transport=httpx.AsyncHTTPTransport(uds=socket)) as aclient:
                 async with aconnect_ws("http://socket/ws", aclient, max_message_size_bytes=1024) as aws:
-                    event = await aws.receive()
-                    assert isinstance(event, wsproto.events.Message)
-                    assert event.data == full_message
+                    with pytest.raises(WebSocketDisconnect) as aexcinfo:
+                        await aws.receive()
+                    assert aexcinfo.value.code == wsproto.frame_protocol.CloseReason.MESSAGE_TOO_BIG
+
+    async def test_receive_oversized_fragmented_message(self) -> None:
+        server_connection = wsproto.connection.Connection(wsproto.connection.ConnectionType.SERVER)
+        fragments = [
+            server_connection.send(wsproto.events.TextMessage(data="A" * 8, message_finished=False)) for _ in range(4)
+        ]
+
+        class MockNetworkStream(NetworkStream):
+            def __init__(self) -> None:
+                self._fragments = list(fragments)
+
+            def read(self, max_bytes: int, timeout: float | None = None) -> bytes:
+                if self._fragments:
+                    return self._fragments.pop(0)
+                time.sleep(0.1)
+                return b""
+
+            def write(self, buffer: bytes, timeout: float | None = None) -> None:
+                pass
+
+            def close(self) -> None:
+                pass
+
+        with WebSocketSession(MockNetworkStream(), max_message_size_bytes=16) as websocket_session:
+            with pytest.raises(WebSocketDisconnect) as excinfo:
+                websocket_session.receive()
+            assert excinfo.value.code == wsproto.frame_protocol.CloseReason.MESSAGE_TOO_BIG
+
+    async def test_async_receive_oversized_fragmented_message(self) -> None:
+        server_connection = wsproto.connection.Connection(wsproto.connection.ConnectionType.SERVER)
+        fragments = [
+            server_connection.send(wsproto.events.TextMessage(data="A" * 8, message_finished=False)) for _ in range(4)
+        ]
+
+        class AsyncMockNetworkStream(AsyncNetworkStream):
+            def __init__(self) -> None:
+                self._fragments = list(fragments)
+
+            async def read(self, max_bytes: int, timeout: float | None = None) -> bytes:
+                if self._fragments:
+                    return self._fragments.pop(0)
+                await anyio.sleep(0.1)
+                return b""
+
+            async def write(self, buffer: bytes, timeout: float | None = None) -> None:
+                pass
+
+            async def aclose(self) -> None:
+                pass
+
+        async with AsyncWebSocketSession(AsyncMockNetworkStream(), max_message_size_bytes=16) as websocket_session:
+            with pytest.raises(WebSocketDisconnect) as excinfo:
+                await websocket_session.receive()
+            assert excinfo.value.code == wsproto.frame_protocol.CloseReason.MESSAGE_TOO_BIG
 
     async def test_receive_text(self, server_factory: ServerFactoryFixture) -> None:
         async def websocket_endpoint(websocket: WebSocket) -> None:

--- a/tests/httpx2/websockets/test_api.py
+++ b/tests/httpx2/websockets/test_api.py
@@ -369,8 +369,8 @@ class TestReceive:
             def read(self, max_bytes: int, timeout: float | None = None) -> bytes:
                 if self._fragments:
                     return self._fragments.pop(0)
-                time.sleep(0.1)
-                return b""
+                time.sleep(0.1)  # pragma: no cover
+                return b""  # pragma: no cover
 
             def write(self, buffer: bytes, timeout: float | None = None) -> None:
                 pass
@@ -404,8 +404,8 @@ class TestReceive:
             async def read(self, max_bytes: int, timeout: float | None = None) -> bytes:
                 if self._fragments:
                     return self._fragments.pop(0)
-                await anyio.sleep(0.1)
-                return b""
+                await anyio.sleep(0.1)  # pragma: no cover
+                return b""  # pragma: no cover
 
             async def write(self, buffer: bytes, timeout: float | None = None) -> None:
                 pass

--- a/tests/httpx2/websockets/test_api.py
+++ b/tests/httpx2/websockets/test_api.py
@@ -347,11 +347,20 @@ class TestReceive:
                         await aws.receive()
                     assert aexcinfo.value.code == wsproto.frame_protocol.CloseReason.MESSAGE_TOO_BIG
 
-    async def test_receive_oversized_fragmented_message(self) -> None:
+    @pytest.mark.parametrize(
+        "event_type,fragment_data",
+        [
+            pytest.param(wsproto.events.BytesMessage, b"A" * 8, id="binary"),
+            pytest.param(wsproto.events.TextMessage, "é" * 4, id="multibyte-text"),
+        ],
+    )
+    async def test_receive_oversized_fragmented_message(
+        self,
+        event_type: type[wsproto.events.BytesMessage] | type[wsproto.events.TextMessage],
+        fragment_data: str | bytes,
+    ) -> None:
         server_connection = wsproto.connection.Connection(wsproto.connection.ConnectionType.SERVER)
-        fragments = [
-            server_connection.send(wsproto.events.TextMessage(data="A" * 8, message_finished=False)) for _ in range(4)
-        ]
+        fragments = [server_connection.send(event_type(data=fragment_data, message_finished=False)) for _ in range(3)]
 
         class MockNetworkStream(NetworkStream):
             def __init__(self) -> None:
@@ -374,11 +383,20 @@ class TestReceive:
                 websocket_session.receive()
             assert excinfo.value.code == wsproto.frame_protocol.CloseReason.MESSAGE_TOO_BIG
 
-    async def test_async_receive_oversized_fragmented_message(self) -> None:
+    @pytest.mark.parametrize(
+        "event_type,fragment_data",
+        [
+            pytest.param(wsproto.events.BytesMessage, b"A" * 8, id="binary"),
+            pytest.param(wsproto.events.TextMessage, "é" * 4, id="multibyte-text"),
+        ],
+    )
+    async def test_async_receive_oversized_fragmented_message(
+        self,
+        event_type: type[wsproto.events.BytesMessage] | type[wsproto.events.TextMessage],
+        fragment_data: str | bytes,
+    ) -> None:
         server_connection = wsproto.connection.Connection(wsproto.connection.ConnectionType.SERVER)
-        fragments = [
-            server_connection.send(wsproto.events.TextMessage(data="A" * 8, message_finished=False)) for _ in range(4)
-        ]
+        fragments = [server_connection.send(event_type(data=fragment_data, message_finished=False)) for _ in range(3)]
 
         class AsyncMockNetworkStream(AsyncNetworkStream):
             def __init__(self) -> None:

--- a/tests/httpx2/websockets/test_high_level.py
+++ b/tests/httpx2/websockets/test_high_level.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import subprocess
 import sys
-import time
+import threading
 from unittest.mock import patch
 
 import anyio
@@ -74,17 +74,19 @@ def test_receive_reassembles_fragmented_message() -> None:
     class MockNetworkStream(NetworkStream):
         def __init__(self) -> None:
             self._sent = False
+            self._closed = threading.Event()
 
         def read(self, max_bytes: int, timeout: float | None = None) -> bytes:
             if self._sent:
-                time.sleep(0.1)  # pragma: no cover
-                return b""  # pragma: no cover
+                self._closed.wait()
+                return b""
             self._sent = True
             return fragments
 
         def write(self, buffer: bytes, timeout: float | None = None) -> None: ...
 
-        def close(self) -> None: ...
+        def close(self) -> None:
+            self._closed.set()
 
     with WebSocketSession(MockNetworkStream()) as ws:
         assert ws.receive_text() == "FRAGMENTED"

--- a/tests/httpx2/websockets/test_high_level.py
+++ b/tests/httpx2/websockets/test_high_level.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import subprocess
 import sys
+import time
 from unittest.mock import patch
 
 import anyio
@@ -10,8 +11,8 @@ import wsproto
 from starlette.websockets import WebSocket
 
 import httpx2 as httpx
-from httpcore2 import AsyncNetworkStream
-from httpx2.websockets import AsyncWebSocketSession, _api
+from httpcore2 import AsyncNetworkStream, NetworkStream
+from httpx2.websockets import AsyncWebSocketSession, WebSocketSession, _api
 from tests.httpx2.websockets.conftest import ServerFactoryFixture
 
 
@@ -62,6 +63,31 @@ async def test_client_websocket_forwards_request_params(server_factory: ServerFa
         async with httpx.AsyncClient(transport=httpx.AsyncHTTPTransport(uds=socket)) as aclient:
             async with aclient.websocket("http://socket/ws", headers={"x-token": "secret"}) as aws:
                 assert await aws.receive_text() == "secret"
+
+
+def test_receive_reassembles_fragmented_message() -> None:
+    server = wsproto.connection.Connection(wsproto.connection.ConnectionType.SERVER)
+    fragments = server.send(wsproto.events.TextMessage("FRAG", message_finished=False))
+    fragments += server.send(wsproto.events.TextMessage("MEN", message_finished=False))
+    fragments += server.send(wsproto.events.TextMessage("TED", message_finished=True))
+
+    class MockNetworkStream(NetworkStream):
+        def __init__(self) -> None:
+            self._sent = False
+
+        def read(self, max_bytes: int, timeout: float | None = None) -> bytes:
+            if self._sent:
+                time.sleep(0.1)  # pragma: no cover
+                return b""  # pragma: no cover
+            self._sent = True
+            return fragments
+
+        def write(self, buffer: bytes, timeout: float | None = None) -> None: ...
+
+        def close(self) -> None: ...
+
+    with WebSocketSession(MockNetworkStream()) as ws:
+        assert ws.receive_text() == "FRAGMENTED"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- enforce `max_message_size_bytes` against cumulative incoming WebSocket message size
- close with `MESSAGE_TOO_BIG` and raise `WebSocketDisconnect` when the limit is exceeded
- add sync/async tests for oversized complete and fragmented messages

## Tests
- `uv run ruff check src/httpx2/httpx2/websockets/_api.py tests/httpx2/websockets/test_api.py`
- `uv run ruff format --check src/httpx2/httpx2/websockets/_api.py tests/httpx2/websockets/test_api.py`
- `uv run pytest tests/httpx2/websockets/ -q`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1085?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

