### PR TITLE
Bracket IPv6 address literals when rendering URLs and authorities

### DIFF
--- a/src/httpcore2/httpcore2/_async/http_proxy.py
+++ b/src/httpcore2/httpcore2/_async/http_proxy.py
@@ -15,6 +15,7 @@ from .._models import (
     enforce_bytes,
     enforce_headers,
     enforce_url,
+    format_host,
 )
 from .._ssl import default_ssl_context
 from .._synchronization import AsyncLock
@@ -261,7 +262,7 @@ class AsyncTunnelHTTPConnection(AsyncConnectionInterface):
 
         async with self._connect_lock:
             if not self._connected:
-                target = b"%b:%d" % (self._remote_origin.host, self._remote_origin.port)
+                target = b"%b:%d" % (format_host(self._remote_origin.host), self._remote_origin.port)
 
                 connect_url = URL(
                     scheme=self._proxy_origin.scheme,

--- a/src/httpcore2/httpcore2/_models.py
+++ b/src/httpcore2/httpcore2/_models.py
@@ -107,6 +107,22 @@ DEFAULT_PORTS = {
 }
 
 
+def format_host(host: bytes) -> bytes:
+    """
+    Wrap an IPv6 address literal in square brackets.
+
+    `URL.host` and `Origin.host` hold the host in the form required to establish
+    a connection, which for an IPv6 address is the bare address. Wherever the
+    host is instead rendered as part of a URL or of an authority, an IPv6
+    address literal must be bracketed, as an `IP-literal`.
+
+    * https://tools.ietf.org/html/rfc3986#section-3.2.2
+    """
+    # A colon cannot occur in a registered name or in an IPv4 address, so its
+    # presence is enough to tell an IPv6 address apart.
+    return b"[%b]" % host if b":" in host else host
+
+
 def include_request_headers(
     headers: list[tuple[bytes, bytes]],
     *,
@@ -118,9 +134,9 @@ def include_request_headers(
     if b"host" not in headers_set:
         default_port = DEFAULT_PORTS.get(url.scheme)
         if url.port is None or url.port == default_port:
-            header_value = url.host
+            header_value = format_host(url.host)
         else:
-            header_value = b"%b:%d" % (url.host, url.port)
+            header_value = b"%b:%d" % (format_host(url.host), url.port)
         headers = [(b"Host", header_value)] + headers
 
     if content is not None and b"content-length" not in headers_set and b"transfer-encoding" not in headers_set:
@@ -171,7 +187,7 @@ class Origin:
 
     def __str__(self) -> str:
         scheme = self.scheme.decode("ascii")
-        host = self.host.decode("ascii")
+        host = format_host(self.host).decode("ascii")
         port = str(self.port)
         return f"{scheme}://{host}:{port}"
 
@@ -296,8 +312,8 @@ class URL:
 
     def __bytes__(self) -> bytes:
         if self.port is None:
-            return b"%b://%b%b" % (self.scheme, self.host, self.target)
-        return b"%b://%b:%d%b" % (self.scheme, self.host, self.port, self.target)
+            return b"%b://%b%b" % (self.scheme, format_host(self.host), self.target)
+        return b"%b://%b:%d%b" % (self.scheme, format_host(self.host), self.port, self.target)
 
     def __repr__(self) -> str:
         return (

--- a/src/httpcore2/httpcore2/_sync/http_proxy.py
+++ b/src/httpcore2/httpcore2/_sync/http_proxy.py
@@ -15,6 +15,7 @@ from .._models import (
     enforce_bytes,
     enforce_headers,
     enforce_url,
+    format_host,
 )
 from .._ssl import default_ssl_context
 from .._synchronization import Lock
@@ -261,7 +262,7 @@ class TunnelHTTPConnection(ConnectionInterface):
 
         with self._connect_lock:
             if not self._connected:
-                target = b"%b:%d" % (self._remote_origin.host, self._remote_origin.port)
+                target = b"%b:%d" % (format_host(self._remote_origin.host), self._remote_origin.port)
 
                 connect_url = URL(
                     scheme=self._proxy_origin.scheme,

--- a/tests/httpcore2/_async/test_http_proxy.py
+++ b/tests/httpcore2/_async/test_http_proxy.py
@@ -105,6 +105,90 @@ async def test_proxy_tunneling() -> None:
         assert not proxy.connections[0].can_handle_request(Origin(b"https", b"other.com", 443))
 
 
+class RecordingStream(AsyncMockStream):
+    """A mock stream that keeps everything written to it."""
+
+    def __init__(self, buffer: list[bytes], http2: bool = False) -> None:
+        super().__init__(buffer, http2)
+        self.written = b""
+
+    async def write(self, buffer: bytes, timeout: float | None = None) -> None:
+        self.written += buffer
+
+
+class RecordingBackend(AsyncMockBackend):
+    def __init__(self, buffer: list[bytes], http2: bool = False) -> None:
+        super().__init__(buffer, http2)
+        self.stream = RecordingStream(list(buffer), http2=http2)
+
+    async def connect_tcp(
+        self,
+        host: str,
+        port: int,
+        timeout: float | None = None,
+        local_address: str | None = None,
+        socket_options: typing.Iterable[SOCKET_OPTION] | None = None,
+    ) -> AsyncMockStream:
+        return self.stream
+
+
+@pytest.mark.anyio
+async def test_proxy_forwarding_to_ipv6_host() -> None:
+    """
+    Send an HTTP request for an IPv6 address literal via a proxy.
+
+    The absolute-form request target is a URI, so the address is bracketed.
+    """
+    network_backend = RecordingBackend(
+        [
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Length: 0\r\n",
+            b"\r\n",
+        ]
+    )
+
+    async with AsyncConnectionPool(
+        proxy=Proxy("http://localhost:8080/"),
+        network_backend=network_backend,
+    ) as proxy:
+        response = await proxy.request("GET", "http://[::1]:1234/")
+        assert response.status == 200
+
+    request_line = network_backend.stream.written.split(b"\r\n")[0]
+    assert request_line == b"GET http://[::1]:1234/ HTTP/1.1"
+    assert b"\r\nHost: [::1]:1234\r\n" in network_backend.stream.written
+
+
+@pytest.mark.anyio
+async def test_proxy_tunneling_to_ipv6_host() -> None:
+    """
+    Send an HTTPS request for an IPv6 address literal via a proxy.
+
+    The CONNECT target is in authority-form, so the address is bracketed.
+    """
+    network_backend = RecordingBackend(
+        [
+            # The initial response to the proxy CONNECT
+            b"HTTP/1.1 200 OK\r\n\r\n",
+            # The actual response from the remote server
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Length: 0\r\n",
+            b"\r\n",
+        ]
+    )
+
+    async with AsyncConnectionPool(
+        proxy=Proxy("http://localhost:8080/"),
+        network_backend=network_backend,
+    ) as proxy:
+        response = await proxy.request("GET", "https://[::1]:8443/")
+        assert response.status == 200
+
+    request_line = network_backend.stream.written.split(b"\r\n")[0]
+    assert request_line == b"CONNECT [::1]:8443 HTTP/1.1"
+    assert b"\r\nHost: [::1]:8443\r\n" in network_backend.stream.written
+
+
 # We need to adapt the mock backend here slightly in order to deal
 # with the proxy case. We do not want the initial connection to the proxy
 # to indicate an HTTP/2 connection, but we do want it to indicate HTTP/2

--- a/tests/httpcore2/_sync/test_http_proxy.py
+++ b/tests/httpcore2/_sync/test_http_proxy.py
@@ -105,6 +105,90 @@ def test_proxy_tunneling() -> None:
         assert not proxy.connections[0].can_handle_request(Origin(b"https", b"other.com", 443))
 
 
+class RecordingStream(MockStream):
+    """A mock stream that keeps everything written to it."""
+
+    def __init__(self, buffer: list[bytes], http2: bool = False) -> None:
+        super().__init__(buffer, http2)
+        self.written = b""
+
+    def write(self, buffer: bytes, timeout: float | None = None) -> None:
+        self.written += buffer
+
+
+class RecordingBackend(MockBackend):
+    def __init__(self, buffer: list[bytes], http2: bool = False) -> None:
+        super().__init__(buffer, http2)
+        self.stream = RecordingStream(list(buffer), http2=http2)
+
+    def connect_tcp(
+        self,
+        host: str,
+        port: int,
+        timeout: float | None = None,
+        local_address: str | None = None,
+        socket_options: typing.Iterable[SOCKET_OPTION] | None = None,
+    ) -> MockStream:
+        return self.stream
+
+
+
+def test_proxy_forwarding_to_ipv6_host() -> None:
+    """
+    Send an HTTP request for an IPv6 address literal via a proxy.
+
+    The absolute-form request target is a URI, so the address is bracketed.
+    """
+    network_backend = RecordingBackend(
+        [
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Length: 0\r\n",
+            b"\r\n",
+        ]
+    )
+
+    with ConnectionPool(
+        proxy=Proxy("http://localhost:8080/"),
+        network_backend=network_backend,
+    ) as proxy:
+        response = proxy.request("GET", "http://[::1]:1234/")
+        assert response.status == 200
+
+    request_line = network_backend.stream.written.split(b"\r\n")[0]
+    assert request_line == b"GET http://[::1]:1234/ HTTP/1.1"
+    assert b"\r\nHost: [::1]:1234\r\n" in network_backend.stream.written
+
+
+
+def test_proxy_tunneling_to_ipv6_host() -> None:
+    """
+    Send an HTTPS request for an IPv6 address literal via a proxy.
+
+    The CONNECT target is in authority-form, so the address is bracketed.
+    """
+    network_backend = RecordingBackend(
+        [
+            # The initial response to the proxy CONNECT
+            b"HTTP/1.1 200 OK\r\n\r\n",
+            # The actual response from the remote server
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Length: 0\r\n",
+            b"\r\n",
+        ]
+    )
+
+    with ConnectionPool(
+        proxy=Proxy("http://localhost:8080/"),
+        network_backend=network_backend,
+    ) as proxy:
+        response = proxy.request("GET", "https://[::1]:8443/")
+        assert response.status == 200
+
+    request_line = network_backend.stream.written.split(b"\r\n")[0]
+    assert request_line == b"CONNECT [::1]:8443 HTTP/1.1"
+    assert b"\r\nHost: [::1]:8443\r\n" in network_backend.stream.written
+
+
 # We need to adapt the mock backend here slightly in order to deal
 # with the proxy case. We do not want the initial connection to the proxy
 # to indicate an HTTP/2 connection, but we do want it to indicate HTTP/2

--- a/tests/httpcore2/test_models.py
+++ b/tests/httpcore2/test_models.py
@@ -19,6 +19,29 @@ def test_url_with_port() -> None:
     assert bytes(url) == b"https://www.example.com:443/"
 
 
+def test_url_with_ipv6_host() -> None:
+    """
+    `URL.host` holds the bare address, as needed to establish a connection, but
+    rendering the URL brackets it.
+    """
+    url = httpcore2.URL("https://[::1]/")
+    assert url == httpcore2.URL(scheme="https", host="::1", port=None, target="/")
+    assert url.host == b"::1"
+    assert bytes(url) == b"https://[::1]/"
+
+    url = httpcore2.URL("https://[::1]:8443/")
+    assert url.host == b"::1"
+    assert bytes(url) == b"https://[::1]:8443/"
+
+
+def test_url_origin_ipv6() -> None:
+    url = httpcore2.URL("https://[::1]:8443/")
+    origin = url.origin
+    assert origin == httpcore2.Origin(scheme=b"https", host=b"::1", port=8443)
+    assert origin.host == b"::1"
+    assert str(origin) == "https://[::1]:8443"
+
+
 def test_url_with_invalid_argument() -> None:
     with pytest.raises(TypeError) as exc_info:
         httpcore2.URL(123)  # type: ignore


### PR DESCRIPTION
# Summary

Working on https://github.com/scrapy/scrapy/pull/7090, it seemed like httpx2 would support IPv6 in general but not through a proxy. Apparently the brackets get lost when proxying, thus the issue.

<details>
<summary>What Opus wanted me to use a PR description</summary>

`URL.host` and `Origin.host` hold a host in the form needed to open a connection,
which for IPv6 is the bare address. Four places rendered that bare host into a URL
or an authority without adding the square brackets that an `IP-literal` requires,
putting malformed values on the wire: `::1:8443` cannot be split back into a host
and a port, and `http://::1:8443/` is not a valid URI.

The most visible consequence is that no request to an IPv6 address literal works
through a proxy, in either forwarding or tunnelling mode.

| | Before | After |
| --- | --- | --- |
| CONNECT target (`https://[::1]:8443/` via proxy) | `CONNECT ::1:8443` | `CONNECT [::1]:8443` |
| Request target (`http://[::1]:1234/` via proxy) | `GET http://::1:1234/` | `GET http://[::1]:1234/` |
| Default `Host` header, no proxy | `Host: ::1:1234` | `Host: [::1]:1234` |
| `bytes(URL("http://[::1]:8080/x"))` | `http://::1:8080/x` | `http://[::1]:8080/x` |
| `str(Origin(b"http", b"::1", 8080))` | `http://::1:8080` | `http://[::1]:8080` |

The `Host` header row applies to `httpcore2` used on its own; through `httpx2` it is
masked, because `httpx2` sets `Host` itself from the bracketed `URL.netloc`.

## The change

A single helper in `_models.py`, used at each of those sites:

    def format_host(host: bytes) -> bytes:
        return b"[%b]" % host if b":" in host else host

The `":" in host` test is the same one `httpx2` already uses in
`ParseResult.authority` and `ParseResult.netloc` (`src/httpx2/httpx2/_urlparse.py`),
so both packages now build an authority the same way. A colon cannot occur in a
registered name or in an IPv4 address, so its presence is enough to identify an
IPv6 address. `URL.host` is bare by construction, since `URL.__init__` goes through
`urlparse().hostname`, which strips brackets.

`Origin.host` deliberately keeps the bare address: it feeds the socket connect, the
TLS `server_hostname`, and the SOCKS address, none of which want brackets. Only the
rendering sites changed.

`_sync/http_proxy.py` is regenerated by `scripts/unasync.py`, not hand-edited.

## Context

This is the bug from [encode/httpx#392](https://github.com/encode/httpx/issues/392),
carried over as #145. It was closed in 2019 as not reproducible, correctly at the
time: `httpx.URL("https://[::1]:8080").origin.host` was then `'[::1]'`, brackets
included. Delegating transport to `httpcore`, whose `Origin.host` is bare,
reintroduced it. The same lines are present in `encode/httpcore` today, and
`tests/_async/test_http_proxy.py` there has no IPv6 case.

Out of scope, to keep this atomic:

- #676, the IPv6 zone identifier leaking into the `Host` header. Different layer
  (`httpx2` header rendering rather than `httpcore2` authority rendering), and the
  zone still arrives percent-encoded as `%25`. Both need fixing for link-local
  addresses to work through a proxy.
- The SOCKS path, where the host is passed to `socksio` as a protocol address
  field rather than as part of a URL, so the bare form is correct.

</details>

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion.
  I’ll risk it :slightly_smiling_face:
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
  No doc changes I assume, this is a bug fix.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1091?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

