### PR TITLE
fix: HTTP 2.0 Throws KeyError rather than the internal exception thrown in th...

### DIFF
--- a/src/httpcore2/httpcore2/_async/http2.py
+++ b/src/httpcore2/httpcore2/_async/http2.py
@@ -373,9 +373,10 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
                     self._max_streams -= 1
 
     async def _response_closed(self, stream_id: int) -> None:
-        await self._max_streams_semaphore.release()
         async with self._state_lock:
-            del self._events[stream_id]
+            if stream_id in self._events:
+                await self._max_streams_semaphore.release()
+                del self._events[stream_id]
             if self._connection_terminated and not self._events:
                 await self.aclose()
 

--- a/src/httpcore2/httpcore2/_sync/http2.py
+++ b/src/httpcore2/httpcore2/_sync/http2.py
@@ -373,9 +373,10 @@ class HTTP2Connection(ConnectionInterface):
                     self._max_streams -= 1
 
     def _response_closed(self, stream_id: int) -> None:
-        self._max_streams_semaphore.release()
         with self._state_lock:
-            del self._events[stream_id]
+            if stream_id in self._events:
+                self._max_streams_semaphore.release()
+                del self._events[stream_id]
             if self._connection_terminated and not self._events:
                 self.close()
 

--- a/tests/httpcore2/_async/test_http2.py
+++ b/tests/httpcore2/_async/test_http2.py
@@ -69,6 +69,37 @@ async def test_http2_connection_closed() -> None:
 
 
 @pytest.mark.anyio
+async def test_http2_response_closed_twice() -> None:
+    """
+    Closing a response for a stream that has already been removed should be
+    a no-op, rather than raising a `KeyError` that masks the exception which
+    triggered the cleanup. See https://github.com/encode/httpx/issues/3072
+    """
+    origin = httpcore2.Origin(b"https", b"example.com", 443)
+    stream = httpcore2.AsyncMockStream(
+        [
+            hyperframe.frame.SettingsFrame().serialize(),
+            hyperframe.frame.HeadersFrame(
+                stream_id=1,
+                data=hpack.Encoder().encode(
+                    [
+                        (b":status", b"200"),
+                        (b"content-type", b"plain/text"),
+                    ]
+                ),
+                flags=["END_HEADERS"],
+            ).serialize(),
+            hyperframe.frame.DataFrame(stream_id=1, data=b"Hello, world!", flags=["END_STREAM"]).serialize(),
+        ]
+    )
+    async with httpcore2.AsyncHTTP2Connection(origin=origin, stream=stream, keepalive_expiry=5.0) as conn:
+        await conn.request("GET", "https://example.com/")
+
+        # The stream was closed when the response completed.
+        await conn._response_closed(stream_id=1)
+
+
+@pytest.mark.anyio
 async def test_http2_connection_post_request() -> None:
     origin = httpcore2.Origin(b"https", b"example.com", 443)
     stream = httpcore2.AsyncMockStream(

--- a/tests/httpcore2/_sync/test_http2.py
+++ b/tests/httpcore2/_sync/test_http2.py
@@ -69,6 +69,37 @@ def test_http2_connection_closed() -> None:
 
 
 
+def test_http2_response_closed_twice() -> None:
+    """
+    Closing a response for a stream that has already been removed should be
+    a no-op, rather than raising a `KeyError` that masks the exception which
+    triggered the cleanup. See https://github.com/encode/httpx/issues/3072
+    """
+    origin = httpcore2.Origin(b"https", b"example.com", 443)
+    stream = httpcore2.MockStream(
+        [
+            hyperframe.frame.SettingsFrame().serialize(),
+            hyperframe.frame.HeadersFrame(
+                stream_id=1,
+                data=hpack.Encoder().encode(
+                    [
+                        (b":status", b"200"),
+                        (b"content-type", b"plain/text"),
+                    ]
+                ),
+                flags=["END_HEADERS"],
+            ).serialize(),
+            hyperframe.frame.DataFrame(stream_id=1, data=b"Hello, world!", flags=["END_STREAM"]).serialize(),
+        ]
+    )
+    with httpcore2.HTTP2Connection(origin=origin, stream=stream, keepalive_expiry=5.0) as conn:
+        conn.request("GET", "https://example.com/")
+
+        # The stream was closed when the response completed.
+        conn._response_closed(stream_id=1)
+
+
+
 def test_http2_connection_post_request() -> None:
     origin = httpcore2.Origin(b"https", b"example.com", 443)
     stream = httpcore2.MockStream(


### PR DESCRIPTION
Fixes #808.

## Summary

HTTP 2.0 Throws KeyError rather than the internal exception thrown in the thread

## Validation

- Mechanical gate: +68/-4, tests passed
- Adversarial review: approved

---
🤖 AI-authored PR, operated by @yhay81. <!-- tsumugi-ai-disclosure -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

