### PR TITLE
Add httpx-pki to third party packages

### DIFF
--- a/docs/third_party_packages.md
+++ b/docs/third_party_packages.md
@@ -24,6 +24,12 @@ Provides authentication classes to be used with HTTPX's [authentication paramete
 
 This package adds caching functionality to HTTPX
 
+### httpx-pki
+
+[GitHub](https://github.com/ccbest/httpx-pki)
+
+PKCS#12 / PEM client-certificate (mTLS) sessions, with OS cert-store loading, identity selection, and certificate rotation.
+
 ### httpx-secure
 
 [GitHub](https://github.com/Zaczero/httpx-secure)


### PR DESCRIPTION
# Summary

Adds httpx-pki (https://github.com/ccbest/httpx-pki) to the Plugins section of the third-party packages page, as invited in Discussion #1095.

httpx-pki provides PKCS#12 / PEM client-certificate (mTLS) sessions — Client/AsyncClient subclasses with the certificate already mounted, plus a build_ssl_context() helper — covering format auto-detection, multi-identity bundles, the Windows cert store / macOS keychain, and certificate rotation.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1096?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

