### PR TITLE
Start TLS for wss scheme in SOCKS5 proxy connections

### DIFF
--- a/src/httpcore2/httpcore2/_async/socks_proxy.py
+++ b/src/httpcore2/httpcore2/_async/socks_proxy.py
@@ -240,7 +240,7 @@ class AsyncSocks5Connection(AsyncConnectionInterface):
                         trace.return_value = stream
 
                     # Upgrade the stream to SSL
-                    if self._remote_origin.scheme == b"https":
+                    if self._remote_origin.scheme in (b"https", b"wss"):
                         ssl_context = default_ssl_context() if self._ssl_context is None else self._ssl_context
                         alpn_protocols = ["http/1.1", "h2"] if self._http2 else ["http/1.1"]
                         ssl_context.set_alpn_protocols(alpn_protocols)

--- a/src/httpcore2/httpcore2/_sync/socks_proxy.py
+++ b/src/httpcore2/httpcore2/_sync/socks_proxy.py
@@ -240,7 +240,7 @@ class Socks5Connection(ConnectionInterface):
                         trace.return_value = stream
 
                     # Upgrade the stream to SSL
-                    if self._remote_origin.scheme == b"https":
+                    if self._remote_origin.scheme in (b"https", b"wss"):
                         ssl_context = default_ssl_context() if self._ssl_context is None else self._ssl_context
                         alpn_protocols = ["http/1.1", "h2"] if self._http2 else ["http/1.1"]
                         ssl_context.set_alpn_protocols(alpn_protocols)


### PR DESCRIPTION
The SOCKS5 proxy connection path only started TLS when the remote origin scheme was `https`. The direct connection path already handles both `https` and `wss` (see #869), but the SOCKS5 path (sync and async) was not updated to match.

This change aligns the SOCKS5 path with the direct connection path so that `wss://` requests routed through a SOCKS5 proxy also upgrade the stream to TLS.

- `src/httpcore2/httpcore2/_async/socks_proxy.py`
- `src/httpcore2/httpcore2/_sync/socks_proxy.py`

Replaces #1101, which accidentally included unrelated commits.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

