### PR TITLE
Skip cookie extraction without Set-Cookie

### DIFF
--- a/src/httpx2/httpx2/_models.py
+++ b/src/httpx2/httpx2/_models.py
@@ -1079,6 +1079,9 @@ class Cookies(typing.MutableMapping[str, str]):
         """
         Loads any cookies based on the response `Set-Cookie` headers.
         """
+        if "set-cookie" not in response.headers:
+            return
+
         urllib_response = self._CookieCompatResponse(response)
         urllib_request = self._CookieCompatRequest(response.request)
 

--- a/src/httpx2/httpx2/_models.py
+++ b/src/httpx2/httpx2/_models.py
@@ -1079,7 +1079,7 @@ class Cookies(typing.MutableMapping[str, str]):
         """
         Loads any cookies based on the response `Set-Cookie` headers.
         """
-        if "set-cookie" not in response.headers:
+        if "set-cookie" not in response.headers and "set-cookie2" not in response.headers:
             return
 
         urllib_response = self._CookieCompatResponse(response)

--- a/tests/httpx2/models/test_cookies.py
+++ b/tests/httpx2/models/test_cookies.py
@@ -1,4 +1,5 @@
 import http.cookiejar
+from unittest.mock import Mock
 
 import pytest
 
@@ -52,15 +53,16 @@ def test_cookies_with_domain_and_path() -> None:
     assert len(cookies) == 0
 
 
-def test_extract_cookies_skips_cookie_jar_without_set_cookie() -> None:
-    class FailingCookieJar(http.cookiejar.CookieJar):
-        def extract_cookies(self, response: object, request: object) -> None:
-            raise AssertionError("CookieJar should not be called without a Set-Cookie header")
-
+def test_extract_cookies_skips_cookie_jar_without_set_cookie(monkeypatch: pytest.MonkeyPatch) -> None:
+    jar = http.cookiejar.CookieJar()
+    extract_cookies = Mock()
+    monkeypatch.setattr(jar, "extract_cookies", extract_cookies)
     request = httpx2.Request("GET", "https://www.example.org")
     response = httpx2.Response(200, request=request)
 
-    httpx2.Cookies(FailingCookieJar()).extract_cookies(response)
+    httpx2.Cookies(jar).extract_cookies(response)
+
+    extract_cookies.assert_not_called()
 
 
 def test_set_cookie2() -> None:

--- a/tests/httpx2/models/test_cookies.py
+++ b/tests/httpx2/models/test_cookies.py
@@ -63,6 +63,19 @@ def test_extract_cookies_skips_cookie_jar_without_set_cookie() -> None:
     httpx2.Cookies(FailingCookieJar()).extract_cookies(response)
 
 
+def test_set_cookie2() -> None:
+    policy = http.cookiejar.DefaultCookiePolicy(rfc2965=True)
+    jar = http.cookiejar.CookieJar(policy=policy)
+    headers = [(b"Set-Cookie2", b'customer="WILE_E_COYOTE"; Version="1"; Path="/"')]
+    request = httpx2.Request("GET", "https://www.example.org")
+    response = httpx2.Response(200, request=request, headers=headers)
+
+    cookies = httpx2.Cookies(jar)
+    cookies.extract_cookies(response)
+
+    assert cookies["customer"] == "WILE_E_COYOTE"
+
+
 def test_multiple_set_cookie() -> None:
     jar = http.cookiejar.CookieJar()
     headers = [

--- a/tests/httpx2/models/test_cookies.py
+++ b/tests/httpx2/models/test_cookies.py
@@ -52,6 +52,17 @@ def test_cookies_with_domain_and_path() -> None:
     assert len(cookies) == 0
 
 
+def test_extract_cookies_skips_cookie_jar_without_set_cookie() -> None:
+    class FailingCookieJar(http.cookiejar.CookieJar):
+        def extract_cookies(self, response: object, request: object) -> None:
+            raise AssertionError("CookieJar should not be called without a Set-Cookie header")
+
+    request = httpx2.Request("GET", "https://www.example.org")
+    response = httpx2.Response(200, request=request)
+
+    httpx2.Cookies(FailingCookieJar()).extract_cookies(response)
+
+
 def test_multiple_set_cookie() -> None:
     jar = http.cookiejar.CookieJar()
     headers = [

--- a/tests/httpx2/models/test_cookies.py
+++ b/tests/httpx2/models/test_cookies.py
@@ -1,5 +1,6 @@
 import http.cookiejar
-from unittest.mock import Mock
+from http.client import HTTPResponse
+from urllib.request import Request as UrllibRequest
 
 import pytest
 
@@ -53,16 +54,24 @@ def test_cookies_with_domain_and_path() -> None:
     assert len(cookies) == 0
 
 
-def test_extract_cookies_skips_cookie_jar_without_set_cookie(monkeypatch: pytest.MonkeyPatch) -> None:
-    jar = http.cookiejar.CookieJar()
-    extract_cookies = Mock()
-    monkeypatch.setattr(jar, "extract_cookies", extract_cookies)
+def test_extract_cookies_skips_cookie_jar_without_set_cookie() -> None:
+    class TrackingCookieJar(http.cookiejar.CookieJar):
+        def __init__(self) -> None:
+            super().__init__()
+            self.extract_count = 0
+
+        def extract_cookies(self, response: HTTPResponse, request: UrllibRequest) -> None:
+            self.extract_count += 1
+
+    jar = TrackingCookieJar()
     request = httpx2.Request("GET", "https://www.example.org")
-    response = httpx2.Response(200, request=request)
+    cookies = httpx2.Cookies(jar)
 
-    httpx2.Cookies(jar).extract_cookies(response)
+    cookies.extract_cookies(httpx2.Response(200, request=request))
+    assert jar.extract_count == 0
 
-    extract_cookies.assert_not_called()
+    cookies.extract_cookies(httpx2.Response(200, request=request, headers={"Set-Cookie": "name=value"}))
+    assert jar.extract_count == 1
 
 
 def test_set_cookie2() -> None:


### PR DESCRIPTION
## Summary

Skip `CookieJar.extract_cookies()` when a response has no `Set-Cookie` header.

The current path constructs urllib request/response compatibility wrappers and an email message for every response, even though most responses cannot update the cookie jar. Checking the already-parsed response headers first avoids that work while preserving cookie handling when `Set-Cookie` is present.

Related to #827.

## Benchmark

The #827 localhost benchmark uses 100 requests at concurrency 20 after a 100-request warmup. Median across three 10-round runs:

| | `main` | This PR |
|---|---:|---:|
| Total time | 42.14 ms | 38.75 ms |

This is an approximately 8% improvement for HTTPX2 in this workload.

## Validation

- Added a regression test proving that the cookie jar is not invoked without `Set-Cookie`.
- Existing multiple-`Set-Cookie` coverage continues to pass.
- Full suite: 1,909 passed, 1 skipped.
- Mypy, Ruff, formatting, and `git diff --check` pass.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

