### PR TITLE
docs: fix stale httpcore and httpx references across the docs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -174,9 +174,9 @@ If something goes wrong with the PyPI job the release can be re-published using 
 ## Development proxy setup
 
 To test and debug requests via a proxy it's best to run a proxy server locally.
-Any server should do but HTTPCore's test suite uses
-[`mitmproxy`](https://mitmproxy.org/) which is written in Python, it's fully
-featured and has excellent UI and tools for introspection of requests.
+Any server should do but [`mitmproxy`](https://mitmproxy.org/) is a good
+choice - it's written in Python, fully featured and has excellent UI and
+tools for introspection of requests.
 
 You can install `mitmproxy` using `pip install mitmproxy` or [several
 other ways](https://docs.mitmproxy.org/stable/overview-installation/).
@@ -198,17 +198,16 @@ UI options.
 
 At this point the server is ready to start serving requests, you'll need to
 configure HTTPX2 as described in the
-[proxy section](https://httpx2.pydantic.dev/advanced/#http-proxying) and
-the [SSL certificates section](https://httpx2.pydantic.dev/advanced/#ssl-certificates),
+[proxy section](https://httpx2.pydantic.dev/advanced/proxies/#http-proxies) and
+the [SSL certificates section](https://httpx2.pydantic.dev/advanced/ssl/),
 this is where our previously generated `client.pem` comes in:
 
-```
-import httpx
+```python
+import ssl
+import httpx2
 
-ssl_context = httpx.SSLContext()
-ssl_context.load_verify_locations("/path/to/client.pem")
-
-with httpx.Client(proxy="http://127.0.0.1:8080/", ssl_context=ssl_context) as client:
+ctx = ssl.create_default_context(cafile="/path/to/client.pem")
+with httpx2.Client(proxy="http://127.0.0.1:8080/", verify=ctx) as client:
     response = client.get("https://example.org")
     print(response.status_code)  # should print 200
 ```

--- a/docs/advanced/extensions.md
+++ b/docs/advanced/extensions.md
@@ -2,7 +2,7 @@
 
 Request and response extensions provide a untyped space where additional information may be added.
 
-Extensions should be used for features that may not be available on all transports, and that do not fit neatly into [the simplified request/response model](https://www.encode.io/httpcore/extensions/) that the underlying `httpcore` package uses as its API.
+Extensions should be used for features that may not be available on all transports, and that do not fit neatly into [the simplified request/response model](https://www.encode.io/httpcore/extensions/) that the underlying `httpcore2` package inherits from upstream `httpcore` and uses as its API.
 
 Several extensions are supported on the request:
 
@@ -34,7 +34,7 @@ print(response.extensions["http_version"])  # b"HTTP/1.1"
 ### `"trace"`
 
 The trace extension allows a callback handler to be installed to monitor the internal
-flow of events within the underlying `httpcore` transport.
+flow of events within the underlying `httpcore2` transport.
 
 The simplest way to explain this is with an example:
 
@@ -46,10 +46,10 @@ def log(event_name, info):
 
 client = httpx2.Client()
 response = client.get("https://www.example.com/", extensions={"trace": log})
-# connection.connect_tcp.started {'host': 'www.example.com', 'port': 443, 'local_address': None, 'timeout': None}
-# connection.connect_tcp.complete {'return_value': <httpcore.backends.sync.SyncStream object at 0x1093f94d0>}
-# connection.start_tls.started {'ssl_context': <ssl.SSLContext object at 0x1093ee750>, 'server_hostname': b'www.example.com', 'timeout': None}
-# connection.start_tls.complete {'return_value': <httpcore.backends.sync.SyncStream object at 0x1093f9450>}
+# connection.connect_tcp.started {'host': 'www.example.com', 'port': 443, 'local_address': None, 'timeout': 5.0, 'socket_options': None}
+# connection.connect_tcp.complete {'return_value': <httpcore2._backends.sync.SyncStream object at 0x1093f94d0>}
+# connection.start_tls.started {'ssl_context': <truststore._api.SSLContext object at 0x1093ee750>, 'server_hostname': 'www.example.com', 'timeout': 5.0}
+# connection.start_tls.complete {'return_value': <httpcore2._backends.sync.SyncStream object at 0x1093f9450>}
 # http11.send_request_headers.started {'request': <Request [b'GET']>}
 # http11.send_request_headers.complete {'return_value': None}
 # http11.send_request_body.started {'request': <Request [b'GET']>}
@@ -95,7 +95,7 @@ The following event types are currently exposed...
 * `"http2.receive_response_body"`
 * `"http2.response_closed"`
 
-The exact set of trace events may be subject to change across different versions of `httpcore`. If you need to rely on a particular set of events it is recommended that you pin installation of the package to a fixed version.
+The exact set of trace events may be subject to change across different versions of `httpcore2`. If you need to rely on a particular set of events it is recommended that you pin installation of the package to a fixed version.
 
 ### `"sni_hostname"`
 

--- a/docs/advanced/proxies.md
+++ b/docs/advanced/proxies.md
@@ -67,7 +67,7 @@ If you encounter issues when setting up proxies, please refer to our [Troublesho
 
 ## SOCKS
 
-In addition to HTTP proxies, `httpcore` also supports proxies using the SOCKS protocol.
+In addition to HTTP proxies, `httpcore2` also supports proxies using the SOCKS protocol.
 This is an optional feature that requires an additional third-party library be installed before use.
 
 You can install SOCKS support using `pip`:

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -211,7 +211,7 @@ If you use `cachecontrol` or `requests-cache` to add HTTP Caching support to the
 
 `requests` defers most of its HTTP networking code to the excellent [`urllib3` library](https://urllib3.readthedocs.io/en/latest/).
 
-On the other hand, HTTPX uses [HTTPCore](https://github.com/encode/httpcore) as its core HTTP networking layer, which is a different project than `urllib3`.
+On the other hand, HTTPX2 uses [`httpcore2`](https://github.com/pydantic/httpx2/tree/main/src/httpcore2) as its core HTTP networking layer, which is a different project than `urllib3`.
 
 ## Query Parameters
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -178,9 +178,9 @@ If something goes wrong with the PyPI job the release can be published using the
 ## Development proxy setup
 
 To test and debug requests via a proxy it's best to run a proxy server locally.
-Any server should do but HTTPCore's test suite uses
-[`mitmproxy`](https://mitmproxy.org/) which is written in Python, it's fully
-featured and has excellent UI and tools for introspection of requests.
+Any server should do but [`mitmproxy`](https://mitmproxy.org/) is a good
+choice - it's written in Python, fully featured and has excellent UI and
+tools for introspection of requests.
 
 You can install `mitmproxy` using `pip install mitmproxy` or [several
 other ways](https://docs.mitmproxy.org/stable/overview-installation/).
@@ -201,14 +201,19 @@ certificate so we need to concatenate them:
 UI options.
 
 At this point the server is ready to start serving requests, you'll need to
-configure HTTPX as described in the
+configure HTTPX2 as described in the
 [proxy section](https://httpx2.pydantic.dev/advanced/proxies/#http-proxies) and
 the [SSL certificates section](https://httpx2.pydantic.dev/advanced/ssl/),
 this is where our previously generated `client.pem` comes in:
 
 ```python
+import ssl
+import httpx2
+
 ctx = ssl.create_default_context(cafile="/path/to/client.pem")
-client = httpx2.Client(proxy="http://127.0.0.1:8080/", verify=ctx)
+with httpx2.Client(proxy="http://127.0.0.1:8080/", verify=ctx) as client:
+    response = client.get("https://example.org")
+    print(response.status_code)  # should print 200
 ```
 
 Note, however, that HTTPS requests will only succeed to the host specified

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -20,26 +20,28 @@ httpx2.get("https://www.example.com")
 Will send debug level output to the console, or wherever `stdout` is directed too...
 
 ```
-DEBUG [2024-09-28 17:27:40] httpcore.connection - connect_tcp.started host='www.example.com' port=443 local_address=None timeout=5.0 socket_options=None
-DEBUG [2024-09-28 17:27:41] httpcore.connection - connect_tcp.complete return_value=<httpcore._backends.sync.SyncStream object at 0x101f1e8e0>
-DEBUG [2024-09-28 17:27:41] httpcore.connection - start_tls.started ssl_context=SSLContext(verify=True) server_hostname='www.example.com' timeout=5.0
-DEBUG [2024-09-28 17:27:41] httpcore.connection - start_tls.complete return_value=<httpcore._backends.sync.SyncStream object at 0x1020f49a0>
-DEBUG [2024-09-28 17:27:41] httpcore.http11 - send_request_headers.started request=<Request [b'GET']>
-DEBUG [2024-09-28 17:27:41] httpcore.http11 - send_request_headers.complete
-DEBUG [2024-09-28 17:27:41] httpcore.http11 - send_request_body.started request=<Request [b'GET']>
-DEBUG [2024-09-28 17:27:41] httpcore.http11 - send_request_body.complete
-DEBUG [2024-09-28 17:27:41] httpcore.http11 - receive_response_headers.started request=<Request [b'GET']>
-DEBUG [2024-09-28 17:27:41] httpcore.http11 - receive_response_headers.complete return_value=(b'HTTP/1.1', 200, b'OK', [(b'Content-Encoding', b'gzip'), (b'Accept-Ranges', b'bytes'), (b'Age', b'407727'), (b'Cache-Control', b'max-age=604800'), (b'Content-Type', b'text/html; charset=UTF-8'), (b'Date', b'Sat, 28 Sep 2024 13:27:42 GMT'), (b'Etag', b'"3147526947+gzip"'), (b'Expires', b'Sat, 05 Oct 2024 13:27:42 GMT'), (b'Last-Modified', b'Thu, 17 Oct 2019 07:18:26 GMT'), (b'Server', b'ECAcc (dcd/7D43)'), (b'Vary', b'Accept-Encoding'), (b'X-Cache', b'HIT'), (b'Content-Length', b'648')])
+DEBUG [2024-09-28 17:27:40] httpcore2.connection - connect_tcp.started host='www.example.com' port=443 local_address=None timeout=5.0 socket_options=None
+DEBUG [2024-09-28 17:27:41] httpcore2.connection - connect_tcp.complete return_value=<httpcore2._backends.sync.SyncStream object at 0x101f1e8e0>
+DEBUG [2024-09-28 17:27:41] httpcore2.connection - start_tls.started ssl_context=<truststore._api.SSLContext object at 0x101f1e9a0> server_hostname='www.example.com' timeout=5.0
+DEBUG [2024-09-28 17:27:41] httpcore2.connection - start_tls.complete return_value=<httpcore2._backends.sync.SyncStream object at 0x1020f49a0>
+DEBUG [2024-09-28 17:27:41] httpcore2.http11 - send_request_headers.started request=<Request [b'GET']>
+DEBUG [2024-09-28 17:27:41] httpcore2.http11 - send_request_headers.complete
+DEBUG [2024-09-28 17:27:41] httpcore2.http11 - send_request_body.started request=<Request [b'GET']>
+DEBUG [2024-09-28 17:27:41] httpcore2.http11 - send_request_body.complete
+DEBUG [2024-09-28 17:27:41] httpcore2.http11 - receive_response_headers.started request=<Request [b'GET']>
+DEBUG [2024-09-28 17:27:41] httpcore2.http11 - receive_response_headers.complete return_value=(b'HTTP/1.1', 200, b'OK', [(b'Content-Encoding', b'gzip'), (b'Accept-Ranges', b'bytes'), (b'Age', b'407727'), (b'Cache-Control', b'max-age=604800'), (b'Content-Type', b'text/html; charset=UTF-8'), (b'Date', b'Sat, 28 Sep 2024 13:27:42 GMT'), (b'Etag', b'"3147526947+gzip"'), (b'Expires', b'Sat, 05 Oct 2024 13:27:42 GMT'), (b'Last-Modified', b'Thu, 17 Oct 2019 07:18:26 GMT'), (b'Server', b'ECAcc (dcd/7D43)'), (b'Vary', b'Accept-Encoding'), (b'X-Cache', b'HIT'), (b'Content-Length', b'648')])
 INFO [2024-09-28 17:27:41] httpx2 - HTTP Request: GET https://www.example.com "HTTP/1.1 200 OK"
-DEBUG [2024-09-28 17:27:41] httpcore.http11 - receive_response_body.started request=<Request [b'GET']>
-DEBUG [2024-09-28 17:27:41] httpcore.http11 - receive_response_body.complete
-DEBUG [2024-09-28 17:27:41] httpcore.http11 - response_closed.started
-DEBUG [2024-09-28 17:27:41] httpcore.http11 - response_closed.complete
-DEBUG [2024-09-28 17:27:41] httpcore.connection - close.started
-DEBUG [2024-09-28 17:27:41] httpcore.connection - close.complete
+DEBUG [2024-09-28 17:27:41] httpcore2.http11 - receive_response_body.started request=<Request [b'GET']>
+DEBUG [2024-09-28 17:27:41] httpcore2.http11 - receive_response_body.complete
+DEBUG [2024-09-28 17:27:41] httpcore2.http11 - response_closed.started
+DEBUG [2024-09-28 17:27:41] httpcore2.http11 - response_closed.complete
+DEBUG [2024-09-28 17:27:41] httpcore2.connection - close.started
+DEBUG [2024-09-28 17:27:41] httpcore2.connection - close.complete
 ```
 
-Logging output includes information from both the high-level `httpx2` logger, and the network-level `httpcore` logger, which can be configured separately.
+Logging output includes information from both the high-level `httpx2` logger, and the network-level `httpcore2` loggers, which can be configured separately.
+
+The network-level loggers are named under the `httpcore2` namespace, such as `httpcore2.connection`, `httpcore2.http11`, and `httpcore2.http2`. Configuring the parent `httpcore2` logger captures the output of all of them.
 
 For handling more complex logging configurations you might want to use the dictionary configuration style...
 
@@ -67,7 +69,7 @@ LOGGING_CONFIG = {
             'handlers': ['default'],
             'level': 'DEBUG',
         },
-        'httpcore': {
+        'httpcore2': {
             'handlers': ['default'],
             'level': 'DEBUG',
         },
@@ -78,4 +80,4 @@ logging.config.dictConfig(LOGGING_CONFIG)
 httpx2.get('https://www.example.com')
 ```
 
-The exact formatting of the debug logging may be subject to change across different versions of `httpx2` and `httpcore`. If you need to rely on a particular format it is recommended that you pin installation of these packages to fixed versions.
+The exact formatting of the debug logging may be subject to change across different versions of `httpx2` and `httpcore2`. If you need to rely on a particular format it is recommended that you pin installation of these packages to fixed versions.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -287,9 +287,10 @@ We can raise an exception for any responses which are not a 2xx success code:
 404
 >>> not_found.raise_for_status()
 Traceback (most recent call last):
-  File "/Users/tomchristie/GitHub/encode/httpcore/httpx2/models.py", line 837, in raise_for_status
-    raise HTTPStatusError(message, response=self)
-httpx2._exceptions.HTTPStatusError: 404 Client Error: Not Found for url: https://httpbin.org/status/404
+  File "<stdin>", line 1, in <module>
+  File "/path/to/site-packages/httpx2/_models.py", line 815, in raise_for_status
+    raise HTTPStatusError(message, request=request, response=self)
+httpx2.HTTPStatusError: Client error '404 Not Found' for url 'https://httpbin.org/status/404'
 For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
 ```
 


### PR DESCRIPTION
# Summary

Closes https://github.com/pydantic/httpx2/discussions/1072 (already contains a description of the issue)


# Checklist

- [X] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- ~~[ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.~~
- [X] I've updated the documentation accordingly.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

