### PR TITLE
Add interlock-cb to third party packages

### DIFF
--- a/docs/third_party_packages.md
+++ b/docs/third_party_packages.md
@@ -67,6 +67,12 @@ WebSocket support for HTTPX.
 Provides a [pytest](https://docs.pytest.org/en/latest/) fixture to mock HTTPX within test cases.
 This package is fork of the [pytest-httpx](https://github.com/Colin-b/pytest_httpx) package that compatible with httpx2
 
+### interlock-cb
+
+[GitHub](https://github.com/bagowix/interlock) - [Documentation](https://bagowix.github.io/interlock/integrations/httpx2/)
+
+A circuit breaker transport: keeps one breaker per host, so calls to a failing host fail fast instead of waiting out every timeout. Trips on failure rate over a sliding window and on slow responses.
+
 ### pytest-HTTPX
 
 [GitHub](https://github.com/Colin-b/pytest_httpx) - [Documentation](https://colin-b.github.io/pytest_httpx/)


### PR DESCRIPTION
Adds `interlock-cb` to the Plugins section of the third party packages page.

It mounts as an httpx2 transport and keeps one circuit breaker per host, so once a host starts failing, calls to it are rejected immediately instead of waiting out every timeout. It trips on the failure rate over a sliding window and on slow responses, so a host that degrades without erroring is caught too.

- GitHub: https://github.com/bagowix/interlock
- httpx2 integration docs: https://bagowix.github.io/interlock/integrations/httpx2/

The entry is placed alphabetically, between `httpx2-pytest` and `pytest-HTTPX`.

Disclosure: I'm the author of the package.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

