### PR TITLE
docs: quote pip install extras for zsh compatibility

### DIFF
--- a/src/httpcore2/README.md
+++ b/src/httpcore2/README.md
@@ -34,7 +34,7 @@ pip install httpcore2
 There are also a number of optional extras available...
 
 ```shell
-pip install httpcore2['asyncio,trio,http2,socks']
+pip install 'httpcore2[asyncio,trio,http2,socks]'
 ```
 
 ## Sending requests
@@ -89,10 +89,10 @@ The `httpcore2` package has the following dependencies...
 
 And the following optional extras...
 
-* `anyio` - Required by `pip install httpcore2['asyncio']`.
-* `trio` - Required by `pip install httpcore2['trio']`.
-* `h2` - Required by `pip install httpcore2['http2']`.
-* `socksio` - Required by `pip install httpcore2['socks']`.
+* `anyio` - Required by `pip install 'httpcore2[asyncio]'`.
+* `trio` - Required by `pip install 'httpcore2[trio]'`.
+* `h2` - Required by `pip install 'httpcore2[http2]'`.
+* `socksio` - Required by `pip install 'httpcore2[socks]'`.
 
 ## Versioning
 

--- a/src/httpcore2/docs/index.md
+++ b/src/httpcore2/docs/index.md
@@ -34,13 +34,13 @@ pip install httpcore2
 For HTTP/1.1 and HTTP/2 support, install with:
 
 ```shell
-pip install httpcore2[http2]
+pip install 'httpcore2[http2]'
 ```
 
 For SOCKS proxy support, install with:
 
 ```shell
-pip install httpcore2[socks]
+pip install 'httpcore2[socks]'
 ```
 
 ## Example


### PR DESCRIPTION
Follow-up to #1110, addressing cubic's post-merge comment: the optional-extras install commands placed quotes inside the bracket expression (`httpcore2['asyncio,...']`) or left brackets unquoted, which fails on zsh with 'no matches found'. All `pip install` extras in the httpcore2 README and `docs/index.md` now quote the whole requirement, e.g. `pip install 'httpcore2[asyncio,trio,http2,socks]'`, matching the style already used in `async.md`, `http2.md` and `proxies.md`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

