### PR TITLE
Add SSE chunking benchmark

### DIFF
--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -99,6 +99,23 @@ def test_bench_line_decoder(benchmark: BenchmarkFixture) -> None:
     benchmark(split)
 
 
+def test_bench_sse_many_chunks_without_line_separator(benchmark: BenchmarkFixture) -> None:
+    chunks = [b"data: ", *([b"A" * 16] * 10_000), b"\n\n"]
+    request = httpx2.Request("GET", "https://example.org/sse")
+
+    def decode() -> int:
+        response = httpx2.Response(
+            200,
+            content=iter(chunks),
+            headers={"content-type": "text/event-stream"},
+            request=request,
+        )
+        (event,) = list(httpx2.EventSource(response, max_event_size=None))
+        return len(event.data)
+
+    assert benchmark(decode) == 10_000 * 16
+
+
 def test_bench_extract_cookies(benchmark: BenchmarkFixture) -> None:
     request = httpx2.Request("GET", "https://example.org/")
 


### PR DESCRIPTION
## Summary

- Add a benchmark for SSE events split across many chunks before a line separator.
- Exercise the public `EventSource` API so the benchmark reflects user-facing behavior.

## Motivation

Track SSE parsing performance for highly fragmented event streams.

## Validation

- `uv run pytest tests/test_benchmark.py::test_bench_sse_many_chunks_without_line_separator -q`
- Ruff formatting and lint checks
- mypy

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

