### PR TITLE
Improve SSE chunk buffering performance

### DIFF
--- a/src/httpx2/httpx2/_sse.py
+++ b/src/httpx2/httpx2/_sse.py
@@ -112,12 +112,12 @@ class _SSEDecoder:
 
         return None
 
-    def check_pending(self, pending: str) -> None:
+    def check_pending(self, pending_size: int) -> None:
         """
         Bound the total bytes buffered for the in-progress event, including
         a trailing line that has not been terminated by a newline yet.
         """
-        self._check_size(len(pending.encode("utf-8")))
+        self._check_size(pending_size)
 
     def _check_size(self, pending_size: int = 0) -> None:
         if self._max_event_size is not None and self._event_size + pending_size > self._max_event_size:
@@ -126,12 +126,13 @@ class _SSEDecoder:
 
 class _SSELineDecoder:
     def __init__(self) -> None:
-        self._buffer = ""
+        self._parts: list[str] = []
+        self._pending_size = 0
         self._trailing_cr = False
 
     @property
-    def pending(self) -> str:
-        return self._buffer
+    def pending_size(self) -> int:
+        return self._pending_size
 
     def decode(self, text: str) -> list[str]:
         if self._trailing_cr:
@@ -141,20 +142,34 @@ class _SSELineDecoder:
             self._trailing_cr = True
             text = text[:-1]
 
-        text = self._buffer + text.replace("\r\n", "\n").replace("\r", "\n")
+        text = text.replace("\r\n", "\n").replace("\r", "\n")
+        if "\n" not in text:
+            self._append(text)
+            return []
+
         lines = text.split("\n")
-        self._buffer = lines.pop()
+        self._append(lines[0])
+        lines[0] = "".join(self._parts)
+        self._parts = []
+        self._pending_size = 0
+        self._append(lines.pop())
         return lines
 
     def flush(self) -> list[str]:
         if self._trailing_cr:
-            self._buffer += "\n"
+            self._append("\n")
             self._trailing_cr = False
-        if not self._buffer:
+        buffer = "".join(self._parts)
+        self._parts = []
+        self._pending_size = 0
+        if not buffer:
             return []
-        lines = self._buffer.split("\n")
-        self._buffer = ""
-        return lines
+        return buffer.split("\n")
+
+    def _append(self, text: str) -> None:
+        if text:
+            self._parts.append(text)
+            self._pending_size += len(text.encode("utf-8"))
 
 
 class EventSource:
@@ -181,7 +196,7 @@ class EventSource:
                     sse = decoder.decode(line)
                     if sse is not None:
                         yield sse
-                decoder.check_pending(lines.pending)
+                decoder.check_pending(lines.pending_size)
             for line in lines.flush():
                 sse = decoder.decode(line)
                 if sse is not None:
@@ -197,7 +212,7 @@ class EventSource:
                     sse = decoder.decode(line)
                     if sse is not None:
                         yield sse
-                decoder.check_pending(lines.pending)
+                decoder.check_pending(lines.pending_size)
             for line in lines.flush():
                 sse = decoder.decode(line)
                 if sse is not None:

--- a/tests/httpx2/test_sse.py
+++ b/tests/httpx2/test_sse.py
@@ -497,3 +497,20 @@ async def test_event_dispatched_at_eof_on_trailing_cr_async() -> None:
             events = [event async for event in source]
 
     assert [event.data for event in events] == ["hi"]
+
+
+def test_many_chunks_without_line_separator() -> None:
+    def chunks() -> Iterator[bytes]:
+        yield b"data: "
+        for _ in range(1_000):
+            yield b"A" * 16
+        yield b"\n\n"
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(200, content=chunks(), headers={"Content-Type": "text/event-stream"})
+
+    with httpx2.Client(transport=httpx2.MockTransport(handler)) as client:
+        with client.sse("http://testserver/sse") as source:
+            (event,) = list(source)
+
+    assert len(event.data) == 1_000 * 16


### PR DESCRIPTION
## Summary

- Accumulate incomplete SSE lines as string fragments and join them when a line separator arrives.
- Track the pending UTF-8 byte count incrementally while preserving `max_event_size` behavior.
- Add coverage for events split across many chunks.

## Motivation

Reduce repeated copying and rescanning when SSE event lines are delivered in highly fragmented streams. This keeps parsing performance predictable without changing the public API or event semantics.

## Validation

- `pytest tests/httpx2/test_sse.py -q`
- `pytest tests/test_benchmark.py::test_bench_sse_many_chunks_without_line_separator -q`
- Ruff formatting and lint checks
- mypy

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

