### PR TITLE
Use `httpx2-jsfetch` on Emscripten

### DIFF
--- a/docs/advanced/emscripten.md
+++ b/docs/advanced/emscripten.md
@@ -44,9 +44,10 @@ addresses.
 
 <div id="pyodide_editor">
 import httpx2
+from js import document
 print("Sending response using httpx2 in the browser:")
 print("--------------------------------------------")
-r = httpx2.get("https://www.example.com")
+r = httpx2.get(document.location.origin)
 print("Status = ", r.status_code)
 print("Response = ", r.text[:50], "...")
 </div>

--- a/docs/advanced/emscripten.md
+++ b/docs/advanced/emscripten.md
@@ -1,0 +1,56 @@
+---
+template: pyodide.html
+---
+
+# Emscripten Support
+
+httpx2 has support for running on WebAssembly / Emscripten using
+[Pyodide](https://github.com/pyodide/pyodide/). It uses the
+[httpx2-jsfetch](https://github.com/hoodmane/httpx2-jsfetch) package to define
+the `JavascriptFetchTransport`.
+
+Asynchronous requests always use `fetch`. Synchronous requests use the following
+methods:
+1. If [Javascript Promise Integration](https://github.com/WebAssembly/js-promise-integration/blob/main/proposals/js-promise-integration/Overview.md)
+   (JSPI) is supported by the JavaScript runtime, the request will be made with
+   `fetch` and stack switching.
+2. Otherwise, if in a browser, the request will be made using a synchronous
+   `XMLHttpRequest`.
+3. Otherwise, if in Node, the request will fail. Synchronous requests in Node
+   require JSPI.
+
+In Emscripten, all network connections are handled by the enclosing Javascript
+runtime. As such, there is limited control over various features. In particular:
+
+- Proxy servers are handled by the runtime, so httpx2 cannot control them.
+- httpx2 has no control over connection pooling.
+- Certificate handling is done by the browser, so httpx2 cannot modify it.
+- Requests are constrained by cross-origin isolation settings in the same way as
+  any request that is originated by Javascript code.
+- Timeouts will not work in the main browser thread unless the browser supports
+  JSPI because main thread synchronous `XMLHttpRequest` does not support
+  timeouts.
+
+Setting any of the transport options that depend on these features (`verify`,
+`cert`, `http2`, `limits`, `proxy`, `uds`, `local_address`, `retries`, or
+`socket_options`) will emit a `UserWarning` and the option will be silently
+ignored.
+
+## Try it in your browser
+
+Use the following live example to test httpx2 in your web browser. You can
+change the code below and hit run again to test different features or web
+addresses.
+
+<div id="pyodide_editor">
+import httpx2
+print("Sending response using httpx2 in the browser:")
+print("--------------------------------------------")
+r = httpx2.get("https://www.example.com")
+print("Status = ", r.status_code)
+print("Response = ", r.text[:50], "...")
+</div>
+
+<div id="pyodide_output"></div>
+
+<div id="pyodide_buttons"></div>

--- a/docs/overrides/pyodide.html
+++ b/docs/overrides/pyodide.html
@@ -2,8 +2,11 @@
 {% block styles %}
   {{ super() }}
   <link
-    href="https://cdn.jsdelivr.net/npm/ace-builds@1.36.2/css/ace.min.css"
+    href="https://cdn.jsdelivr.net/npm/ace-builds@1.36.2/css/ace.css"
     rel="stylesheet"
+    integrity="sha384-ufydNiMif57Clv54md4N4sdAsM4gsJXYuGcZ+7v6fqHDlQ7JWICGt3eW00qaw2l5"
+    crossorigin="anonymous"
+    referrerpolicy="no-referrer"
   />
   <style>
   #pyodide_editor {
@@ -42,8 +45,18 @@
 
 {% block scripts %}
 {{ super() }}
-<script src="https://cdn.jsdelivr.net/npm/ace-builds@1.36.2/src-noconflict/ace.min.js"></script>
-<script src="https://cdn.jsdelivr.net/pyodide/v0.29.3/full/pyodide.js"></script>
+<script
+  src="https://cdn.jsdelivr.net/npm/ace-builds@1.36.2/src-noconflict/ace.js"
+  integrity="sha384-KXFed0LStIAv8N+BF2J6AQ1Jt83vq4cc/pWqaHh3JxE6nWxwkWZ2gSYqIBSy3tHq"
+  crossorigin="anonymous"
+  referrerpolicy="no-referrer"
+></script>
+<script
+  src="https://cdn.jsdelivr.net/pyodide/v0.29.3/full/pyodide.js"
+  integrity="sha384-Hcsv6LxK5rH9vVB+a/+cLJZR3kIIM2Y851r6waxy+9JInvSROiD1bTMk748pYdat"
+  crossorigin="anonymous"
+  referrerpolicy="no-referrer"
+></script>
 <script language="javascript">
   const editor = ace.edit("pyodide_editor");
   editor.setTheme("ace/theme/monokai");

--- a/docs/overrides/pyodide.html
+++ b/docs/overrides/pyodide.html
@@ -74,10 +74,12 @@
     pyodide.setStderr({ batched: stderrLine });
     if (
       document.location.origin.startsWith("http://127.0.0.1") ||
+      document.location.origin.startsWith("http://0.0.0.0") ||
       document.location.origin.startsWith("http://localhost")
     ) {
       // If we are on a development machine, use the wheel from the dist folder
-      await pyodide.loadPackage(["/test.whl", "ssl", "idna", "certifi"]);
+      await pyodide.loadPackage(["micropip",  "ssl", "idna", "certifi"]);
+      await pyodide.loadPackage(["/test.whl",]);
     } else {
       // Otherwise load it from PyPI
       // (once a Pyodide-supporting version is on there)

--- a/docs/overrides/pyodide.html
+++ b/docs/overrides/pyodide.html
@@ -1,0 +1,123 @@
+{% extends "main.html" %}
+{% block styles %}
+  {{ super() }}
+  <link
+    href="https://cdn.jsdelivr.net/npm/ace-builds@1.36.2/css/ace.min.css"
+    rel="stylesheet"
+  />
+  <style>
+  #pyodide_editor {
+    width: 100%;
+    height: 14em;
+    font-size: 0.8rem;
+    box-sizing: border-box;
+  }
+  #pyodide_editor .ace_gutter,
+  #pyodide_editor .ace_content,
+  #pyodide_editor .ace_text-layer {
+    font-size: 0.8rem;
+  }
+  #pyodide_output {
+    width: 100%;
+    height: 20em;
+    white-space: pre-wrap;
+    background-color: #1e1e1e;
+    color: #e6e6e6;
+    font-family: "Courier New", monospace;
+    font-size: 0.8rem;
+    overflow-y: scroll;
+    padding: 0.5em;
+    box-sizing: border-box;
+    border-radius: 4px;
+  }
+
+  #pyodide_output span {
+    display: block;
+  }
+  .pyodide_error {
+    color: #ff6b6b;
+  }
+  </style>
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<script src="https://cdn.jsdelivr.net/npm/ace-builds@1.36.2/src-noconflict/ace.min.js"></script>
+<script src="https://cdn.jsdelivr.net/pyodide/v0.29.3/full/pyodide.js"></script>
+<script language="javascript">
+  const editor = ace.edit("pyodide_editor");
+  editor.setTheme("ace/theme/monokai");
+  editor.session.setMode("ace/mode/python");
+  editor.setOptions({
+    fontSize: "0.8rem",
+    vScrollBarAlwaysVisible: true,
+  });
+  const outputDiv = document.getElementById("pyodide_output");
+  outputDiv.innerText = "Loading python in your browser";
+
+  function stdoutLine(line) {
+    const content = document.createElement("span");
+    content.textContent = line;
+    outputDiv.appendChild(content);
+  }
+
+  function stderrLine(line) {
+    const content = document.createElement("span");
+    content.className = "pyodide_error";
+    content.textContent = line;
+    outputDiv.appendChild(content);
+  }
+
+  async function initPyodide() {
+    const pyodide = await loadPyodide();
+    pyodide.setStdout({ batched: stdoutLine });
+    pyodide.setStderr({ batched: stderrLine });
+    if (
+      document.location.origin.startsWith("http://127.0.0.1") ||
+      document.location.origin.startsWith("http://localhost")
+    ) {
+      // If we are on a development machine, use the wheel from the dist folder
+      await pyodide.loadPackage(["/test.whl", "ssl", "idna", "certifi"]);
+    } else {
+      // Otherwise load it from PyPI
+      // (once a Pyodide-supporting version is on there)
+      await pyodide.loadPackage("micropip");
+      await pyodide.runPythonAsync("import micropip; await micropip.install('httpx2')");
+    }
+    outputDiv.innerText = "Python runtime ready...\n";
+    return pyodide;
+  }
+
+  const loadPromise = initPyodide();
+
+  async function runCode() {
+    const pyodide = await loadPromise;
+    const code = editor.getValue();
+    await pyodide.loadPackagesFromImports(code);
+    try {
+      await pyodide.runPythonAsync(code);
+    } catch (e) {
+      stderrLine(e.message);
+    }
+  }
+
+  function clearOutput() {
+    outputDiv.innerHTML = "";
+  }
+
+  const run_button = document.createElement("button");
+  run_button.className = "md-button";
+  run_button.onclick = runCode;
+  run_button.innerText = "Run";
+  const clear_button = document.createElement("button");
+  clear_button.className = "md-button";
+  clear_button.onclick = clearOutput;
+  clear_button.innerText = "Clear output";
+  clear_button.style = "float:right";
+  const buttonDiv = document.getElementById("pyodide_buttons");
+  buttonDiv.appendChild(run_button);
+  buttonDiv.appendChild(clear_button);
+
+  globalThis.runCode = runCode;
+</script>
+{% endblock %}

--- a/docs/overrides/pyodide.html
+++ b/docs/overrides/pyodide.html
@@ -79,7 +79,8 @@
     ) {
       // If we are on a development machine, use the wheel from the dist folder
       await pyodide.loadPackage(["micropip",  "ssl", "idna", "certifi"]);
-      await pyodide.loadPackage(["/test.whl",]);
+      await pyodide.runPythonAsync("import micropip; await micropip.install('httpx2-jsfetch')");
+      await pyodide.loadPackage(["/test.whl"]);
     } else {
       // Otherwise load it from PyPI
       // (once a Pyodide-supporting version is on there)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,7 @@ nav:
         - Transports: 'advanced/transports.md'
         - Text Encodings: 'advanced/text-encodings.md'
         - Extensions: 'advanced/extensions.md'
+        - Emscripten: 'advanced/emscripten.md'
     - Guides:
         - Async Support: 'async.md'
         - HTTP/2 Support: 'http2.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ site_description: A next-generation HTTP client for Python.
 
 theme:
     name: 'material'
+    custom_dir: 'docs/overrides'
     palette:
       - scheme: 'default'
         media: '(prefers-color-scheme: light)'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ package = false
 default-groups = ["dev", "docs", "bench"]
 required-version = ">=0.8.6"
 exclude-newer = "7 days"
-exclude-newer-package = { idna = "2026-06-03T00:00:00Z" }
+exclude-newer-package = { idna = "2026-06-03T00:00:00Z", httpx2-jsfetch = "2026-08-08T00:00:00Z" }
 
 [tool.uv.workspace]
 members = ["src/httpx2", "src/httpcore2"]

--- a/src/httpx2/CHANGELOG.md
+++ b/src/httpx2/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Added
+
+* Support for running on WebAssembly / Emscripten via Pyodide, using a
+  JavaScript `fetch`-based transport defined in `httpx2-jsfetch`.
+  ([1119](https://github.com/pydantic/httpx2/pull/1119))
+
 ## 2.9.1 (July 24th, 2026)
 
 ### Fixed

--- a/src/httpx2/CHANGELOG.md
+++ b/src/httpx2/CHANGELOG.md
@@ -8,8 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-* Support for running on WebAssembly / Emscripten via Pyodide, using a
-  JavaScript `fetch`-based transport defined in `httpx2-jsfetch`.
+* Add support for running on WebAssembly / Emscripten via Pyodide, using a JavaScript
+  `fetch`-based transport defined in `httpx2-jsfetch`.
   ([1119](https://github.com/pydantic/httpx2/pull/1119))
 
 ## 2.9.1 (July 24th, 2026)

--- a/src/httpx2/httpx2/_transports/__init__.py
+++ b/src/httpx2/httpx2/_transports/__init__.py
@@ -7,9 +7,7 @@ from .wsgi import WSGITransport
 
 if sys.platform == "emscripten":  # pragma: nocover
     if sys.version_info < (3, 12):
-        raise RuntimeError(
-            "Python 3.12 or later is required on emscripten platforms."
-        )
+        raise RuntimeError("Python 3.12 or later is required on emscripten platforms.")
 
     # in emscripten we use javascript fetch
     from httpx2_jsfetch import (

--- a/src/httpx2/httpx2/_transports/__init__.py
+++ b/src/httpx2/httpx2/_transports/__init__.py
@@ -11,8 +11,8 @@ if sys.platform == "emscripten":  # pragma: nocover
 
     # in emscripten we use javascript fetch
     from httpx2_jsfetch import (
-        JavascriptFetchTransport as HTTPTransport,
         AsyncJavascriptFetchTransport as AsyncHTTPTransport,
+        JavascriptFetchTransport as HTTPTransport,
     )
 else:
     # everywhere else we use default

--- a/src/httpx2/httpx2/_transports/__init__.py
+++ b/src/httpx2/httpx2/_transports/__init__.py
@@ -13,8 +13,8 @@ if sys.platform == "emscripten":  # pragma: nocover
 
     # in emscripten we use javascript fetch
     from httpx2_jsfetch import (
-        AsyncJavascriptFetchTransport as HTTPTransport,
-        JavascriptFetchTransport as AsyncHTTPTransport,
+        JavascriptFetchTransport as HTTPTransport,
+        AsyncJavascriptFetchTransport as AsyncHTTPTransport,
     )
 else:
     # everywhere else we use default

--- a/src/httpx2/httpx2/_transports/__init__.py
+++ b/src/httpx2/httpx2/_transports/__init__.py
@@ -6,6 +6,11 @@ from .mock import MockTransport
 from .wsgi import WSGITransport
 
 if sys.platform == "emscripten":  # pragma: nocover
+    if sys.version_info < (3, 12):
+        raise RuntimeError(
+            "Python 3.12 or later is required on emscripten platforms."
+        )
+
     # in emscripten we use javascript fetch
     from httpx2_jsfetch import (
         AsyncJavascriptFetchTransport as HTTPTransport,

--- a/src/httpx2/httpx2/_transports/__init__.py
+++ b/src/httpx2/httpx2/_transports/__init__.py
@@ -9,13 +9,11 @@ if sys.platform == "emscripten":  # pragma: nocover
     if sys.version_info < (3, 12):
         raise RuntimeError("Python 3.12 or later is required on emscripten platforms.")
 
-    # in emscripten we use javascript fetch
     from httpx2_jsfetch import (
         AsyncJavascriptFetchTransport as AsyncHTTPTransport,
         JavascriptFetchTransport as HTTPTransport,
     )
 else:
-    # everywhere else we use default
     from .default import AsyncHTTPTransport, HTTPTransport
 
 __all__ = [

--- a/src/httpx2/httpx2/_transports/__init__.py
+++ b/src/httpx2/httpx2/_transports/__init__.py
@@ -7,7 +7,9 @@ from .wsgi import WSGITransport
 
 if sys.platform == "emscripten":  # pragma: nocover
     if sys.version_info < (3, 12):
-        raise RuntimeError("Python 3.12 or later is required on emscripten platforms.")
+        raise RuntimeError(
+            "httpx2 requires Python 3.12+ on Emscripten. If you are using Pyodide, upgrade to Pyodide 0.26 or later."
+        )
 
     from httpx2_jsfetch import (
         AsyncJavascriptFetchTransport as AsyncHTTPTransport,

--- a/src/httpx2/httpx2/_transports/__init__.py
+++ b/src/httpx2/httpx2/_transports/__init__.py
@@ -1,8 +1,23 @@
+import sys
+
 from .asgi import ASGITransport
 from .base import AsyncBaseTransport, BaseTransport
-from .default import AsyncHTTPTransport, HTTPTransport
 from .mock import MockTransport
 from .wsgi import WSGITransport
+
+if sys.platform == "emscripten":  # pragma: nocover
+    # in emscripten we use javascript fetch
+    from httpx2_jsfetch import (
+        AsyncJavascriptFetchTransport,
+        JavascriptFetchTransport,
+    )
+
+    # override default transport names
+    HTTPTransport = JavascriptFetchTransport
+    AsyncHTTPTransport = AsyncJavascriptFetchTransport
+else:
+    # everywhere else we use default
+    from .default import AsyncHTTPTransport, HTTPTransport
 
 __all__ = [
     "ASGITransport",

--- a/src/httpx2/httpx2/_transports/__init__.py
+++ b/src/httpx2/httpx2/_transports/__init__.py
@@ -8,13 +8,9 @@ from .wsgi import WSGITransport
 if sys.platform == "emscripten":  # pragma: nocover
     # in emscripten we use javascript fetch
     from httpx2_jsfetch import (
-        AsyncJavascriptFetchTransport,
-        JavascriptFetchTransport,
+        AsyncJavascriptFetchTransport as HTTPTransport,
+        JavascriptFetchTransport as AsyncHTTPTransport,
     )
-
-    # override default transport names
-    HTTPTransport = JavascriptFetchTransport
-    AsyncHTTPTransport = AsyncJavascriptFetchTransport
 else:
     # everywhere else we use default
     from .default import AsyncHTTPTransport, HTTPTransport

--- a/src/httpx2/httpx2/_transports/__init__.py
+++ b/src/httpx2/httpx2/_transports/__init__.py
@@ -7,9 +7,7 @@ from .wsgi import WSGITransport
 
 if sys.platform == "emscripten":  # pragma: nocover
     if sys.version_info < (3, 12):
-        raise RuntimeError(
-            "httpx2 requires Python 3.12+ on Emscripten. If you are using Pyodide, upgrade to Pyodide 0.26 or later."
-        )
+        raise RuntimeError("httpx2 requires Python 3.12+ on Emscripten.")
 
     from httpx2_jsfetch import (
         AsyncJavascriptFetchTransport as AsyncHTTPTransport,

--- a/src/httpx2/pyproject.toml
+++ b/src/httpx2/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "truststore>=0.10; sys_platform != 'emscripten'",
     "httpcore2=={{ version }}; sys_platform != 'emscripten'",
     "anyio>=4.10; sys_platform != 'emscripten'",
-    "httpx2-jsfetch; sys_platform == 'emscripten'",
+    "httpx2-jsfetch; sys_platform == 'emscripten' and python_version >= '3.12'",
     "idna>=3.18",
     "typing_extensions>=4.5.0; python_version < '3.13'",
 ]

--- a/src/httpx2/pyproject.toml
+++ b/src/httpx2/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
     "truststore>=0.10; sys_platform != 'emscripten'",
     "httpcore2=={{ version }}; sys_platform != 'emscripten'",
     "anyio>=4.10; sys_platform != 'emscripten'",
+    "httpx2-jsfetch; sys_platform == 'emscripten'",
     "idna>=3.18",
     "typing_extensions>=4.5.0; python_version < '3.13'",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -14,6 +14,7 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
+httpx2-jsfetch = "2026-08-08T00:00:00Z"
 idna = "2026-06-03T00:00:00Z"
 
 [manifest]
@@ -1482,6 +1483,7 @@ source = { editable = "src/httpx2" }
 dependencies = [
     { name = "anyio", marker = "sys_platform != 'emscripten'" },
     { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "python_full_version >= '3.12' and sys_platform == 'emscripten'" },
     { name = "idna" },
     { name = "truststore", marker = "sys_platform != 'emscripten'" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
@@ -1518,6 +1520,7 @@ requires-dist = [
     { name = "click", marker = "extra == 'cli'", specifier = ">=8.4.2" },
     { name = "h2", marker = "extra == 'http2'", specifier = ">=3,<5" },
     { name = "httpcore2", marker = "sys_platform != 'emscripten'", editable = "src/httpcore2" },
+    { name = "httpx2-jsfetch", marker = "python_full_version >= '3.12' and sys_platform == 'emscripten'" },
     { name = "idna", specifier = ">=3.18" },
     { name = "pygments", marker = "extra == 'cli'", specifier = "==2.*" },
     { name = "rich", marker = "extra == 'cli'", specifier = ">=10,<16" },
@@ -1528,6 +1531,15 @@ requires-dist = [
     { name = "zstandard", marker = "python_full_version < '3.14' and extra == 'zstd'", specifier = ">=0.18.0" },
 ]
 provides-extras = ["brotli", "cli", "http2", "socks", "ws", "zstd"]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
+]
 
 [[package]]
 name = "hyperframe"


### PR DESCRIPTION
Use httpx2-jsfetch to provide JavascriptFetchTransport in Emscripten Python.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.

Tested in httpx2-jsfetch as requested.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

