### PR TITLE
Return `str | None` instead of `Any` from `Headers.get`

### DIFF
--- a/src/httpx2/httpx2/_models.py
+++ b/src/httpx2/httpx2/_models.py
@@ -51,7 +51,7 @@ __all__ = ["Cookies", "Headers", "Request", "Response"]
 
 SENSITIVE_HEADERS = {"authorization", "proxy-authorization"}
 
-T = typing.TypeVar("T")
+_T = typing.TypeVar("_T")
 
 
 def _is_known_encoding(encoding: str) -> bool:
@@ -241,12 +241,9 @@ class Headers(typing.MutableMapping[str, str]):
     def get(self, key: str, /) -> str | None: ...
 
     @typing.overload
-    def get(self, key: str, default: str, /) -> str: ...
+    def get(self, key: str, default: _T) -> str | _T: ...
 
-    @typing.overload
-    def get(self, key: str, default: T) -> str | T: ...
-
-    def get(self, key: str, default: T | None = None) -> str | T | None:
+    def get(self, key: str, default: _T | None = None) -> str | _T | None:
         """
         Return a header value. If multiple occurrences of the header occur
         then concatenate them together with commas.
@@ -1131,13 +1128,21 @@ class Cookies(typing.MutableMapping[str, str]):
         cookie = Cookie(**kwargs)  # type: ignore
         self.jar.set_cookie(cookie)
 
-    def get(  # type: ignore
+    @typing.overload
+    def get(
+        self, name: str, default: None = None, domain: str | None = None, path: str | None = None
+    ) -> str | None: ...
+
+    @typing.overload
+    def get(self, name: str, default: _T, domain: str | None = None, path: str | None = None) -> str | _T: ...
+
+    def get(
         self,
         name: str,
-        default: str | None = None,
+        default: _T | None = None,
         domain: str | None = None,
         path: str | None = None,
-    ) -> str | None:
+    ) -> str | _T | None:
         """
         Get a cookie by name. May optionally include domain and path
         in order to specify exactly which cookie to retrieve.

--- a/src/httpx2/httpx2/_models.py
+++ b/src/httpx2/httpx2/_models.py
@@ -1128,21 +1128,13 @@ class Cookies(typing.MutableMapping[str, str]):
         cookie = Cookie(**kwargs)  # type: ignore
         self.jar.set_cookie(cookie)
 
-    @typing.overload
-    def get(
-        self, name: str, default: None = None, domain: str | None = None, path: str | None = None
-    ) -> str | None: ...
-
-    @typing.overload
-    def get(self, name: str, default: _T, domain: str | None = None, path: str | None = None) -> str | _T: ...
-
-    def get(
+    def get(  # type: ignore
         self,
         name: str,
-        default: _T | None = None,
+        default: str | None = None,
         domain: str | None = None,
         path: str | None = None,
-    ) -> str | _T | None:
+    ) -> str | None:
         """
         Get a cookie by name. May optionally include domain and path
         in order to specify exactly which cookie to retrieve.

--- a/src/httpx2/httpx2/_models.py
+++ b/src/httpx2/httpx2/_models.py
@@ -51,6 +51,8 @@ __all__ = ["Cookies", "Headers", "Request", "Response"]
 
 SENSITIVE_HEADERS = {"authorization", "proxy-authorization"}
 
+T = typing.TypeVar("T")
+
 
 def _is_known_encoding(encoding: str) -> bool:
     """
@@ -235,7 +237,16 @@ class Headers(typing.MutableMapping[str, str]):
         """
         return [(key.decode(self.encoding), value.decode(self.encoding)) for _, key, value in self._list]
 
-    def get(self, key: str, default: typing.Any = None) -> typing.Any:
+    @typing.overload
+    def get(self, key: str, /) -> str | None: ...
+
+    @typing.overload
+    def get(self, key: str, default: str, /) -> str: ...
+
+    @typing.overload
+    def get(self, key: str, default: T) -> str | T: ...
+
+    def get(self, key: str, default: T | None = None) -> str | T | None:
         """
         Return a header value. If multiple occurrences of the header occur
         then concatenate them together with commas.

--- a/src/httpx2/httpx2/_urls.py
+++ b/src/httpx2/httpx2/_urls.py
@@ -18,6 +18,8 @@ from ._utils import primitive_value_to_str
 
 __all__ = ["URL", "QueryParams"]
 
+_T = typing.TypeVar("_T")
+
 
 class URL:
     """
@@ -504,7 +506,13 @@ class QueryParams(typing.Mapping[str, str]):
             multi_items.extend([(k, i) for i in v])
         return multi_items
 
-    def get(self, key: typing.Any, default: typing.Any = None) -> typing.Any:
+    @typing.overload
+    def get(self, key: typing.Any, /) -> str | None: ...
+
+    @typing.overload
+    def get(self, key: typing.Any, default: _T) -> str | _T: ...
+
+    def get(self, key: typing.Any, default: _T | None = None) -> str | _T | None:
         """
         Get a value from the query param for a given key. If the key occurs
         more than once, then only the first value is returned.

--- a/src/httpx2/httpx2/_urls.py
+++ b/src/httpx2/httpx2/_urls.py
@@ -18,8 +18,6 @@ from ._utils import primitive_value_to_str
 
 __all__ = ["URL", "QueryParams"]
 
-_T = typing.TypeVar("_T")
-
 
 class URL:
     """
@@ -506,13 +504,7 @@ class QueryParams(typing.Mapping[str, str]):
             multi_items.extend([(k, i) for i in v])
         return multi_items
 
-    @typing.overload
-    def get(self, key: typing.Any, /) -> str | None: ...
-
-    @typing.overload
-    def get(self, key: typing.Any, default: _T) -> str | _T: ...
-
-    def get(self, key: typing.Any, default: _T | None = None) -> str | _T | None:
+    def get(self, key: typing.Any, default: typing.Any = None) -> typing.Any:
         """
         Get a value from the query param for a given key. If the key occurs
         more than once, then only the first value is returned.


### PR DESCRIPTION
# Summary

This fixes the loose type signature that relied on `typing.Any` in `Headers.get` with a type-safe signature that directly matches  the parent `MutableMapping[str, str]` definition and leads to a concrete return type.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
  - Ref: https://github.com/pydantic/httpx2/discussions/1120
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
  - The tests don't seem to apply to this change, as it's just a typing signature change
- [x] I've updated the documentation accordingly.
  - Does not seem to apply for this change


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

