### PR TITLE
Ignore unsolicited and duplicate Pong frames

### DIFF
--- a/src/httpx2/httpx2/websockets/_ping.py
+++ b/src/httpx2/httpx2/websockets/_ping.py
@@ -22,8 +22,9 @@ class PingManager(PingManagerBase):
         return ping_id, event
 
     def ack(self, ping_id: bytes | bytearray) -> None:
-        event = self._pings.pop(bytes(ping_id))
-        event.set()
+        event = self._pings.pop(bytes(ping_id), None)
+        if event is not None:
+            event.set()
 
 
 class AsyncPingManager(PingManagerBase):
@@ -37,5 +38,6 @@ class AsyncPingManager(PingManagerBase):
         return ping_id, event
 
     def ack(self, ping_id: bytes | bytearray) -> None:
-        event = self._pings.pop(bytes(ping_id))
-        event.set()
+        event = self._pings.pop(bytes(ping_id), None)
+        if event is not None:
+            event.set()

--- a/tests/httpx2/websockets/test_api.py
+++ b/tests/httpx2/websockets/test_api.py
@@ -581,6 +581,60 @@ class TestReceivePing:
             wsproto.events.CloseConnection(1000, ""),
         ]
 
+    async def test_receive_unsolicited_pong(self) -> None:
+        class MockNetworkStream(NetworkStream):
+            def __init__(self) -> None:
+                self.connection = wsproto.connection.Connection(wsproto.connection.ConnectionType.SERVER)
+                self.events_to_send = [
+                    wsproto.events.Pong(b"UNSOLICITED"),
+                    wsproto.events.TextMessage("SERVER_MESSAGE"),
+                    wsproto.events.CloseConnection(1000),
+                ]
+
+            def read(self, max_bytes: int, timeout: float | None = None) -> bytes:
+                try:
+                    event = self.events_to_send.pop(0)
+                    return self.connection.send(event)
+                except IndexError:  # pragma: no cover
+                    raise httpcore.ReadError()
+
+            def write(self, buffer: bytes, timeout: float | None = None) -> None:
+                self.connection.receive_data(buffer)
+
+            def close(self) -> None:
+                pass
+
+        stream = MockNetworkStream()
+        with WebSocketSession(stream) as session:
+            assert session.receive_text(timeout=1) == "SERVER_MESSAGE"
+
+    async def test_async_receive_unsolicited_pong(self) -> None:
+        class MockAsyncNetworkStream(AsyncNetworkStream):
+            def __init__(self) -> None:
+                self.connection = wsproto.connection.Connection(wsproto.connection.ConnectionType.SERVER)
+                self.events_to_send = [
+                    wsproto.events.Pong(b"UNSOLICITED"),
+                    wsproto.events.TextMessage("SERVER_MESSAGE"),
+                    wsproto.events.CloseConnection(1000),
+                ]
+
+            async def read(self, max_bytes: int, timeout: float | None = None) -> bytes:
+                try:
+                    event = self.events_to_send.pop(0)
+                    return self.connection.send(event)
+                except IndexError:  # pragma: no cover
+                    raise httpcore.ReadError()
+
+            async def write(self, buffer: bytes, timeout: float | None = None) -> None:
+                self.connection.receive_data(buffer)
+
+            async def aclose(self) -> None:
+                pass
+
+        stream = MockAsyncNetworkStream()
+        async with AsyncWebSocketSession(stream) as session:
+            assert await session.receive_text(timeout=1) == "SERVER_MESSAGE"
+
 
 @pytest.mark.anyio
 class TestKeepalivePing:


### PR DESCRIPTION
The WebSocket protocol permits a peer to send an unsolicited `Pong`, and a peer may also duplicate a `Pong` for an outstanding `Ping`. In both cases the payload has no matching entry in the ping manager, so `ack()` raised a `KeyError` that escaped the receive loop and stopped the background receive worker (the sync thread died silently; the async task tore down the session's task group).

`PingManager.ack()` and `AsyncPingManager.ack()` now pop the ping event with a default and only set it when present, so stray `Pong` frames are ignored. Added regression tests to `TestReceivePing` covering both the sync and async loops.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

