### PR TITLE
Interrupt blocked queue puts during sync WebSocket teardown

### DIFF
--- a/src/httpx2/httpx2/websockets/_api.py
+++ b/src/httpx2/httpx2/websockets/_api.py
@@ -487,6 +487,15 @@ class WebSocketSession:
                 pass
         self.stream.close()
 
+    def _put_event(self, event: wsproto.events.Event | HTTPXWSException) -> None:
+        while True:
+            try:
+                self._events.put(event, timeout=0.1)
+                return
+            except queue.Full:
+                if self._should_close.is_set():
+                    raise ShouldClose() from None
+
     def _background_receive(self, max_bytes: int) -> None:
         """
         Background thread listening for data from the server.
@@ -524,7 +533,7 @@ class WebSocketSession:
                         partial_message_size += len(event.data.encode() if isinstance(event.data, str) else event.data)
                         if partial_message_size > max_bytes:
                             self.close(CloseReason.MESSAGE_TOO_BIG, "Message too big")
-                            self._events.put(WebSocketDisconnect(CloseReason.MESSAGE_TOO_BIG, "Message too big"))
+                            self._put_event(WebSocketDisconnect(CloseReason.MESSAGE_TOO_BIG, "Message too big"))
                             break
                         # Unfinished message: bufferize
                         if not event.message_finished:
@@ -535,19 +544,20 @@ class WebSocketSession:
                         # Finished message but no buffer: just emit the event
                         elif partial_message_buffer is None:
                             partial_message_size = 0
-                            self._events.put(event)
+                            self._put_event(event)
                         # Finished message with buffer: emit the full event
                         else:
                             event_type = type(event)
                             full_message_event = event_type(partial_message_buffer + event.data)
                             partial_message_buffer = None
                             partial_message_size = 0
-                            self._events.put(full_message_event)
+                            self._put_event(full_message_event)
                         continue
-                    self._events.put(event)
+                    self._put_event(event)
         except (httpcore2.ReadError, httpcore2.WriteError, EndOfStream):
             self.close(CloseReason.INTERNAL_ERROR, "Stream error")
-            self._events.put(WebSocketNetworkError())
+            with contextlib.suppress(ShouldClose):
+                self._put_event(WebSocketNetworkError())
         except ShouldClose:
             pass
 
@@ -562,7 +572,7 @@ class WebSocketSession:
                     acknowledged = self._wait_until_closed(pong_callback.wait, timeout_seconds)
                     if not acknowledged:
                         self.close(CloseReason.INTERNAL_ERROR, "Keepalive ping timeout")
-                        self._events.put(WebSocketNetworkError())
+                        self._put_event(WebSocketNetworkError())
         except ShouldClose:
             pass
 

--- a/src/httpx2/httpx2/websockets/_api.py
+++ b/src/httpx2/httpx2/websockets/_api.py
@@ -149,9 +149,16 @@ class WebSocketSession:
         tb: TracebackType | None,
     ) -> None:
         self.close()
-        self._background_receive_task.join()
+        self._join_discarding_events(self._background_receive_task)
         if self._background_keepalive_ping_task is not None:
-            self._background_keepalive_ping_task.join()
+            self._join_discarding_events(self._background_keepalive_ping_task)
+
+    def _join_discarding_events(self, task: threading.Thread) -> None:
+        # A task blocked on a full events queue can only exit once room is made.
+        while task.is_alive():
+            with contextlib.suppress(queue.Empty):
+                self._events.get_nowait()
+            task.join(timeout=0.01)
 
     def ping(self, payload: bytes = b"") -> threading.Event:
         """
@@ -487,15 +494,6 @@ class WebSocketSession:
                 pass
         self.stream.close()
 
-    def _put_event(self, event: wsproto.events.Event | HTTPXWSException) -> None:
-        while True:
-            try:
-                self._events.put(event, timeout=0.1)
-                return
-            except queue.Full:
-                if self._should_close.is_set():
-                    raise ShouldClose() from None
-
     def _background_receive(self, max_bytes: int) -> None:
         """
         Background thread listening for data from the server.
@@ -533,7 +531,7 @@ class WebSocketSession:
                         partial_message_size += len(event.data.encode() if isinstance(event.data, str) else event.data)
                         if partial_message_size > max_bytes:
                             self.close(CloseReason.MESSAGE_TOO_BIG, "Message too big")
-                            self._put_event(WebSocketDisconnect(CloseReason.MESSAGE_TOO_BIG, "Message too big"))
+                            self._events.put(WebSocketDisconnect(CloseReason.MESSAGE_TOO_BIG, "Message too big"))
                             break
                         # Unfinished message: bufferize
                         if not event.message_finished:
@@ -544,20 +542,19 @@ class WebSocketSession:
                         # Finished message but no buffer: just emit the event
                         elif partial_message_buffer is None:
                             partial_message_size = 0
-                            self._put_event(event)
+                            self._events.put(event)
                         # Finished message with buffer: emit the full event
                         else:
                             event_type = type(event)
                             full_message_event = event_type(partial_message_buffer + event.data)
                             partial_message_buffer = None
                             partial_message_size = 0
-                            self._put_event(full_message_event)
+                            self._events.put(full_message_event)
                         continue
-                    self._put_event(event)
+                    self._events.put(event)
         except (httpcore2.ReadError, httpcore2.WriteError, EndOfStream):
             self.close(CloseReason.INTERNAL_ERROR, "Stream error")
-            with contextlib.suppress(ShouldClose):
-                self._put_event(WebSocketNetworkError())
+            self._events.put(WebSocketNetworkError())
         except ShouldClose:
             pass
 
@@ -572,7 +569,7 @@ class WebSocketSession:
                     acknowledged = self._wait_until_closed(pong_callback.wait, timeout_seconds)
                     if not acknowledged:
                         self.close(CloseReason.INTERNAL_ERROR, "Keepalive ping timeout")
-                        self._put_event(WebSocketNetworkError())
+                        self._events.put(WebSocketNetworkError())
         except ShouldClose:
             pass
 

--- a/tests/httpx2/websockets/test_api.py
+++ b/tests/httpx2/websockets/test_api.py
@@ -927,7 +927,28 @@ async def test_exit_with_full_queue(server_factory: ServerFactoryFixture) -> Non
                         break
                     time.sleep(0.05)
                 assert ws._events.full()
-                time.sleep(0.3)
+
+
+@pytest.mark.anyio
+async def test_close_delivered_after_draining_full_queue(server_factory: ServerFactoryFixture) -> None:
+    """
+    Check that the close event is still delivered once the consumer drains
+    messages that had filled the events queue.
+    """
+
+    async def websocket_endpoint(websocket: WebSocket) -> None:
+        await websocket.accept()
+        for i in range(5):
+            await websocket.send_text(f"MESSAGE_{i}")
+        await websocket.close()
+
+    with server_factory(websocket_endpoint) as socket:
+        with httpx.Client(transport=httpx.HTTPTransport(uds=socket)) as client:
+            with connect_ws("http://socket/ws", client, queue_size=1, keepalive_ping_interval_seconds=None) as ws:
+                for i in range(5):
+                    assert ws.receive_text(timeout=5) == f"MESSAGE_{i}"
+                with pytest.raises(WebSocketDisconnect):
+                    ws.receive(timeout=5)
 
 
 @pytest.mark.anyio

--- a/tests/httpx2/websockets/test_api.py
+++ b/tests/httpx2/websockets/test_api.py
@@ -904,6 +904,33 @@ async def test_threads_wont_hang(server_factory: ServerFactoryFixture) -> None:
 
 
 @pytest.mark.anyio
+async def test_exit_with_full_queue(server_factory: ServerFactoryFixture) -> None:
+    """
+    Check that exiting the session doesn't deadlock when the background receive
+    thread is blocked on a full events queue.
+    """
+
+    async def websocket_endpoint(websocket: WebSocket) -> None:
+        await websocket.accept()
+        for _ in range(10):
+            await websocket.send_text("SERVER_MESSAGE")
+        try:
+            await websocket.receive_text()
+        except StarletteWebSocketDisconnect:
+            pass
+
+    with server_factory(websocket_endpoint) as socket:
+        with httpx.Client(transport=httpx.HTTPTransport(uds=socket)) as client:
+            with connect_ws("http://socket/ws", client, queue_size=1, keepalive_ping_interval_seconds=None) as ws:
+                for _ in range(100):
+                    if ws._events.full():
+                        break
+                    time.sleep(0.05)
+                assert ws._events.full()
+                time.sleep(0.3)
+
+
+@pytest.mark.anyio
 async def test_concurrency_write(server_factory: ServerFactoryFixture) -> None:
     """
     Check that there is no error because of two tasks trying to write the stream at the


### PR DESCRIPTION
When the sync session's bounded events queue is full, the background receive thread blocks indefinitely on `queue.Queue.put()`. Since `close()` never drains the queue, the `.join()` in `__exit__` then hangs forever, so exiting the `with` block deadlocks whenever more than `queue_size` unread messages are pending.

The fix is confined to teardown: `__exit__` now drains the queue while joining the background threads, which unblocks any pending `put()` and lets them exit. Everything else - backpressure, event ordering, `receive()` semantics - is unchanged, and close/error events are still delivered in order behind buffered messages. The async session is unaffected since its cancel scope already cancels pending sends.

`test_exit_with_full_queue` reproduces the hang on `main`, and `test_close_delivered_after_draining_full_queue` checks the close event is still delivered after draining a queue that had filled up.

Once `requires-python` reaches 3.13, the drain helper can be replaced by `Queue.shutdown(immediate=True)`.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.