### PR TITLE
Enable force-single-line isort rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ ignore = ["B904", "B028", "C401", "PERF203"]
 
 [tool.ruff.lint.isort]
 combine-as-imports = true
+force-single-line = true
 known-first-party = ["httpx2", "httpcore2"]
 
 [tool.ruff.lint.per-file-ignores]

--- a/src/httpcore2/httpcore2/__init__.py
+++ b/src/httpcore2/httpcore2/__init__.py
@@ -1,52 +1,52 @@
 from importlib.metadata import version
 
-from ._api import request, stream
-from ._async import (
-    AsyncConnectionInterface,
-    AsyncConnectionPool,
-    AsyncHTTP2Connection,
-    AsyncHTTP11Connection,
-    AsyncHTTPConnection,
-    AsyncHTTPProxy,
-    AsyncSOCKSProxy,
-)
-from ._backends.base import (
-    SOCKET_OPTION,
-    AsyncNetworkBackend,
-    AsyncNetworkStream,
-    NetworkBackend,
-    NetworkStream,
-)
-from ._backends.mock import AsyncMockBackend, AsyncMockStream, MockBackend, MockStream
+from ._api import request
+from ._api import stream
+from ._async import AsyncConnectionInterface
+from ._async import AsyncConnectionPool
+from ._async import AsyncHTTP2Connection
+from ._async import AsyncHTTP11Connection
+from ._async import AsyncHTTPConnection
+from ._async import AsyncHTTPProxy
+from ._async import AsyncSOCKSProxy
+from ._backends.base import SOCKET_OPTION
+from ._backends.base import AsyncNetworkBackend
+from ._backends.base import AsyncNetworkStream
+from ._backends.base import NetworkBackend
+from ._backends.base import NetworkStream
+from ._backends.mock import AsyncMockBackend
+from ._backends.mock import AsyncMockStream
+from ._backends.mock import MockBackend
+from ._backends.mock import MockStream
 from ._backends.sync import SyncBackend
-from ._exceptions import (
-    ConnectError,
-    ConnectionNotAvailable,
-    ConnectTimeout,
-    LocalProtocolError,
-    NetworkError,
-    PoolTimeout,
-    ProtocolError,
-    ProxyError,
-    ReadError,
-    ReadTimeout,
-    RemoteProtocolError,
-    TimeoutException,
-    UnsupportedProtocol,
-    WriteError,
-    WriteTimeout,
-)
-from ._models import URL, Origin, Proxy, Request, Response
+from ._exceptions import ConnectError
+from ._exceptions import ConnectionNotAvailable
+from ._exceptions import ConnectTimeout
+from ._exceptions import LocalProtocolError
+from ._exceptions import NetworkError
+from ._exceptions import PoolTimeout
+from ._exceptions import ProtocolError
+from ._exceptions import ProxyError
+from ._exceptions import ReadError
+from ._exceptions import ReadTimeout
+from ._exceptions import RemoteProtocolError
+from ._exceptions import TimeoutException
+from ._exceptions import UnsupportedProtocol
+from ._exceptions import WriteError
+from ._exceptions import WriteTimeout
+from ._models import URL
+from ._models import Origin
+from ._models import Proxy
+from ._models import Request
+from ._models import Response
 from ._ssl import default_ssl_context
-from ._sync import (
-    ConnectionInterface,
-    ConnectionPool,
-    HTTP2Connection,
-    HTTP11Connection,
-    HTTPConnection,
-    HTTPProxy,
-    SOCKSProxy,
-)
+from ._sync import ConnectionInterface
+from ._sync import ConnectionPool
+from ._sync import HTTP2Connection
+from ._sync import HTTP11Connection
+from ._sync import HTTPConnection
+from ._sync import HTTPProxy
+from ._sync import SOCKSProxy
 
 # The 'httpcore2.AnyIOBackend' class is conditional on 'anyio' being installed.
 try:

--- a/src/httpcore2/httpcore2/_api.py
+++ b/src/httpcore2/httpcore2/_api.py
@@ -4,7 +4,10 @@ import contextlib
 import typing
 from collections.abc import Generator
 
-from ._models import URL, Extensions, HeaderTypes, Response
+from ._models import URL
+from ._models import Extensions
+from ._models import HeaderTypes
+from ._models import Response
 from ._sync.connection_pool import ConnectionPool
 
 

--- a/src/httpcore2/httpcore2/_async/connection.py
+++ b/src/httpcore2/httpcore2/_async/connection.py
@@ -7,9 +7,14 @@ import types
 import typing
 
 from .._backends.auto import AutoBackend
-from .._backends.base import SOCKET_OPTION, AsyncNetworkBackend, AsyncNetworkStream
-from .._exceptions import ConnectError, ConnectTimeout
-from .._models import Origin, Request, Response
+from .._backends.base import SOCKET_OPTION
+from .._backends.base import AsyncNetworkBackend
+from .._backends.base import AsyncNetworkStream
+from .._exceptions import ConnectError
+from .._exceptions import ConnectTimeout
+from .._models import Origin
+from .._models import Request
+from .._models import Response
 from .._ssl import default_ssl_context
 from .._synchronization import AsyncLock
 from .._trace import Trace

--- a/src/httpcore2/httpcore2/_async/connection_pool.py
+++ b/src/httpcore2/httpcore2/_async/connection_pool.py
@@ -7,13 +7,21 @@ import typing
 from collections.abc import AsyncGenerator
 
 from .._backends.auto import AutoBackend
-from .._backends.base import SOCKET_OPTION, AsyncNetworkBackend
-from .._exceptions import ConnectionNotAvailable, UnsupportedProtocol
-from .._models import Origin, Proxy, Request, Response
-from .._synchronization import AsyncEvent, AsyncShieldCancellation, AsyncThreadLock
+from .._backends.base import SOCKET_OPTION
+from .._backends.base import AsyncNetworkBackend
+from .._exceptions import ConnectionNotAvailable
+from .._exceptions import UnsupportedProtocol
+from .._models import Origin
+from .._models import Proxy
+from .._models import Request
+from .._models import Response
+from .._synchronization import AsyncEvent
+from .._synchronization import AsyncShieldCancellation
+from .._synchronization import AsyncThreadLock
 from .._utils import safe_async_iterate
 from .connection import AsyncHTTPConnection
-from .interfaces import AsyncConnectionInterface, AsyncRequestInterface
+from .interfaces import AsyncConnectionInterface
+from .interfaces import AsyncRequestInterface
 
 
 class AsyncPoolRequest:

--- a/src/httpcore2/httpcore2/_async/http11.py
+++ b/src/httpcore2/httpcore2/_async/http11.py
@@ -11,15 +11,16 @@ from collections.abc import AsyncGenerator
 import h11
 
 from .._backends.base import AsyncNetworkStream
-from .._exceptions import (
-    ConnectionNotAvailable,
-    LocalProtocolError,
-    RemoteProtocolError,
-    WriteError,
-    map_exceptions,
-)
-from .._models import Origin, Request, Response
-from .._synchronization import AsyncLock, AsyncShieldCancellation
+from .._exceptions import ConnectionNotAvailable
+from .._exceptions import LocalProtocolError
+from .._exceptions import RemoteProtocolError
+from .._exceptions import WriteError
+from .._exceptions import map_exceptions
+from .._models import Origin
+from .._models import Request
+from .._models import Response
+from .._synchronization import AsyncLock
+from .._synchronization import AsyncShieldCancellation
 from .._trace import Trace
 from .._utils import safe_async_iterate
 from .interfaces import AsyncConnectionInterface

--- a/src/httpcore2/httpcore2/_async/http2.py
+++ b/src/httpcore2/httpcore2/_async/http2.py
@@ -14,9 +14,15 @@ import h2.exceptions
 import h2.settings
 
 from .._backends.base import AsyncNetworkStream
-from .._exceptions import ConnectionNotAvailable, LocalProtocolError, RemoteProtocolError
-from .._models import Origin, Request, Response
-from .._synchronization import AsyncLock, AsyncSemaphore, AsyncShieldCancellation
+from .._exceptions import ConnectionNotAvailable
+from .._exceptions import LocalProtocolError
+from .._exceptions import RemoteProtocolError
+from .._models import Origin
+from .._models import Request
+from .._models import Response
+from .._synchronization import AsyncLock
+from .._synchronization import AsyncSemaphore
+from .._synchronization import AsyncShieldCancellation
 from .._trace import Trace
 from .._utils import safe_async_iterate
 from .interfaces import AsyncConnectionInterface

--- a/src/httpcore2/httpcore2/_async/http_proxy.py
+++ b/src/httpcore2/httpcore2/_async/http_proxy.py
@@ -5,17 +5,16 @@ import logging
 import ssl
 import typing
 
-from .._backends.base import SOCKET_OPTION, AsyncNetworkBackend
+from .._backends.base import SOCKET_OPTION
+from .._backends.base import AsyncNetworkBackend
 from .._exceptions import ProxyError
-from .._models import (
-    URL,
-    Origin,
-    Request,
-    Response,
-    enforce_bytes,
-    enforce_headers,
-    enforce_url,
-)
+from .._models import URL
+from .._models import Origin
+from .._models import Request
+from .._models import Response
+from .._models import enforce_bytes
+from .._models import enforce_headers
+from .._models import enforce_url
 from .._ssl import default_ssl_context
 from .._synchronization import AsyncLock
 from .._trace import Trace

--- a/src/httpcore2/httpcore2/_async/interfaces.py
+++ b/src/httpcore2/httpcore2/_async/interfaces.py
@@ -4,18 +4,16 @@ import contextlib
 import typing
 from collections.abc import AsyncGenerator
 
-from .._models import (
-    URL,
-    Extensions,
-    HeaderTypes,
-    Origin,
-    Request,
-    Response,
-    enforce_bytes,
-    enforce_headers,
-    enforce_url,
-    include_request_headers,
-)
+from .._models import URL
+from .._models import Extensions
+from .._models import HeaderTypes
+from .._models import Origin
+from .._models import Request
+from .._models import Response
+from .._models import enforce_bytes
+from .._models import enforce_headers
+from .._models import enforce_url
+from .._models import include_request_headers
 
 
 class AsyncRequestInterface:

--- a/src/httpcore2/httpcore2/_async/socks_proxy.py
+++ b/src/httpcore2/httpcore2/_async/socks_proxy.py
@@ -6,9 +6,16 @@ import ssl
 import socksio
 
 from .._backends.auto import AutoBackend
-from .._backends.base import AsyncNetworkBackend, AsyncNetworkStream
-from .._exceptions import ConnectionNotAvailable, ProxyError
-from .._models import URL, Origin, Request, Response, enforce_bytes, enforce_url
+from .._backends.base import AsyncNetworkBackend
+from .._backends.base import AsyncNetworkStream
+from .._exceptions import ConnectionNotAvailable
+from .._exceptions import ProxyError
+from .._models import URL
+from .._models import Origin
+from .._models import Request
+from .._models import Response
+from .._models import enforce_bytes
+from .._models import enforce_url
 from .._ssl import default_ssl_context
 from .._synchronization import AsyncLock
 from .._trace import Trace

--- a/src/httpcore2/httpcore2/_backends/anyio.py
+++ b/src/httpcore2/httpcore2/_backends/anyio.py
@@ -7,17 +7,17 @@ import anyio
 import anyio.abc
 import anyio.streams.tls
 
-from .._exceptions import (
-    ConnectError,
-    ConnectTimeout,
-    ReadError,
-    ReadTimeout,
-    WriteError,
-    WriteTimeout,
-    map_exceptions,
-)
+from .._exceptions import ConnectError
+from .._exceptions import ConnectTimeout
+from .._exceptions import ReadError
+from .._exceptions import ReadTimeout
+from .._exceptions import WriteError
+from .._exceptions import WriteTimeout
+from .._exceptions import map_exceptions
 from .._utils import is_socket_readable
-from .base import SOCKET_OPTION, AsyncNetworkBackend, AsyncNetworkStream
+from .base import SOCKET_OPTION
+from .base import AsyncNetworkBackend
+from .base import AsyncNetworkStream
 
 
 class AnyIOStream(AsyncNetworkStream):

--- a/src/httpcore2/httpcore2/_backends/auto.py
+++ b/src/httpcore2/httpcore2/_backends/auto.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import typing
 
 from .._synchronization import current_async_library
-from .base import SOCKET_OPTION, AsyncNetworkBackend, AsyncNetworkStream
+from .base import SOCKET_OPTION
+from .base import AsyncNetworkBackend
+from .base import AsyncNetworkStream
 
 
 class AutoBackend(AsyncNetworkBackend):

--- a/src/httpcore2/httpcore2/_backends/mock.py
+++ b/src/httpcore2/httpcore2/_backends/mock.py
@@ -4,13 +4,11 @@ import ssl
 import typing
 
 from .._exceptions import ReadError
-from .base import (
-    SOCKET_OPTION,
-    AsyncNetworkBackend,
-    AsyncNetworkStream,
-    NetworkBackend,
-    NetworkStream,
-)
+from .base import SOCKET_OPTION
+from .base import AsyncNetworkBackend
+from .base import AsyncNetworkStream
+from .base import NetworkBackend
+from .base import NetworkStream
 
 
 class MockSSLObject:

--- a/src/httpcore2/httpcore2/_backends/sync.py
+++ b/src/httpcore2/httpcore2/_backends/sync.py
@@ -6,18 +6,18 @@ import ssl
 import sys
 import typing
 
-from .._exceptions import (
-    ConnectError,
-    ConnectTimeout,
-    ExceptionMapping,
-    ReadError,
-    ReadTimeout,
-    WriteError,
-    WriteTimeout,
-    map_exceptions,
-)
+from .._exceptions import ConnectError
+from .._exceptions import ConnectTimeout
+from .._exceptions import ExceptionMapping
+from .._exceptions import ReadError
+from .._exceptions import ReadTimeout
+from .._exceptions import WriteError
+from .._exceptions import WriteTimeout
+from .._exceptions import map_exceptions
 from .._utils import is_socket_readable
-from .base import SOCKET_OPTION, NetworkBackend, NetworkStream
+from .base import SOCKET_OPTION
+from .base import NetworkBackend
+from .base import NetworkStream
 
 
 class TLSinTLSStream(NetworkStream):  # pragma: no cover

--- a/src/httpcore2/httpcore2/_backends/trio.py
+++ b/src/httpcore2/httpcore2/_backends/trio.py
@@ -5,17 +5,17 @@ import typing
 
 import trio
 
-from .._exceptions import (
-    ConnectError,
-    ConnectTimeout,
-    ExceptionMapping,
-    ReadError,
-    ReadTimeout,
-    WriteError,
-    WriteTimeout,
-    map_exceptions,
-)
-from .base import SOCKET_OPTION, AsyncNetworkBackend, AsyncNetworkStream
+from .._exceptions import ConnectError
+from .._exceptions import ConnectTimeout
+from .._exceptions import ExceptionMapping
+from .._exceptions import ReadError
+from .._exceptions import ReadTimeout
+from .._exceptions import WriteError
+from .._exceptions import WriteTimeout
+from .._exceptions import map_exceptions
+from .base import SOCKET_OPTION
+from .base import AsyncNetworkBackend
+from .base import AsyncNetworkStream
 
 
 class TrioStream(AsyncNetworkStream):

--- a/src/httpcore2/httpcore2/_sync/connection.py
+++ b/src/httpcore2/httpcore2/_sync/connection.py
@@ -7,9 +7,14 @@ import types
 import typing
 
 from .._backends.sync import SyncBackend
-from .._backends.base import SOCKET_OPTION, NetworkBackend, NetworkStream
-from .._exceptions import ConnectError, ConnectTimeout
-from .._models import Origin, Request, Response
+from .._backends.base import SOCKET_OPTION
+from .._backends.base import NetworkBackend
+from .._backends.base import NetworkStream
+from .._exceptions import ConnectError
+from .._exceptions import ConnectTimeout
+from .._models import Origin
+from .._models import Request
+from .._models import Response
 from .._ssl import default_ssl_context
 from .._synchronization import Lock
 from .._trace import Trace

--- a/src/httpcore2/httpcore2/_sync/connection_pool.py
+++ b/src/httpcore2/httpcore2/_sync/connection_pool.py
@@ -7,13 +7,21 @@ import typing
 from collections.abc import Generator
 
 from .._backends.sync import SyncBackend
-from .._backends.base import SOCKET_OPTION, NetworkBackend
-from .._exceptions import ConnectionNotAvailable, UnsupportedProtocol
-from .._models import Origin, Proxy, Request, Response
-from .._synchronization import Event, ShieldCancellation, ThreadLock
+from .._backends.base import SOCKET_OPTION
+from .._backends.base import NetworkBackend
+from .._exceptions import ConnectionNotAvailable
+from .._exceptions import UnsupportedProtocol
+from .._models import Origin
+from .._models import Proxy
+from .._models import Request
+from .._models import Response
+from .._synchronization import Event
+from .._synchronization import ShieldCancellation
+from .._synchronization import ThreadLock
 from .._utils import safe_iterate
 from .connection import HTTPConnection
-from .interfaces import ConnectionInterface, RequestInterface
+from .interfaces import ConnectionInterface
+from .interfaces import RequestInterface
 
 
 class PoolRequest:

--- a/src/httpcore2/httpcore2/_sync/http11.py
+++ b/src/httpcore2/httpcore2/_sync/http11.py
@@ -11,15 +11,16 @@ from collections.abc import Generator
 import h11
 
 from .._backends.base import NetworkStream
-from .._exceptions import (
-    ConnectionNotAvailable,
-    LocalProtocolError,
-    RemoteProtocolError,
-    WriteError,
-    map_exceptions,
-)
-from .._models import Origin, Request, Response
-from .._synchronization import Lock, ShieldCancellation
+from .._exceptions import ConnectionNotAvailable
+from .._exceptions import LocalProtocolError
+from .._exceptions import RemoteProtocolError
+from .._exceptions import WriteError
+from .._exceptions import map_exceptions
+from .._models import Origin
+from .._models import Request
+from .._models import Response
+from .._synchronization import Lock
+from .._synchronization import ShieldCancellation
 from .._trace import Trace
 from .._utils import safe_iterate
 from .interfaces import ConnectionInterface

--- a/src/httpcore2/httpcore2/_sync/http2.py
+++ b/src/httpcore2/httpcore2/_sync/http2.py
@@ -14,9 +14,15 @@ import h2.exceptions
 import h2.settings
 
 from .._backends.base import NetworkStream
-from .._exceptions import ConnectionNotAvailable, LocalProtocolError, RemoteProtocolError
-from .._models import Origin, Request, Response
-from .._synchronization import Lock, Semaphore, ShieldCancellation
+from .._exceptions import ConnectionNotAvailable
+from .._exceptions import LocalProtocolError
+from .._exceptions import RemoteProtocolError
+from .._models import Origin
+from .._models import Request
+from .._models import Response
+from .._synchronization import Lock
+from .._synchronization import Semaphore
+from .._synchronization import ShieldCancellation
 from .._trace import Trace
 from .._utils import safe_iterate
 from .interfaces import ConnectionInterface

--- a/src/httpcore2/httpcore2/_sync/http_proxy.py
+++ b/src/httpcore2/httpcore2/_sync/http_proxy.py
@@ -5,17 +5,16 @@ import logging
 import ssl
 import typing
 
-from .._backends.base import SOCKET_OPTION, NetworkBackend
+from .._backends.base import SOCKET_OPTION
+from .._backends.base import NetworkBackend
 from .._exceptions import ProxyError
-from .._models import (
-    URL,
-    Origin,
-    Request,
-    Response,
-    enforce_bytes,
-    enforce_headers,
-    enforce_url,
-)
+from .._models import URL
+from .._models import Origin
+from .._models import Request
+from .._models import Response
+from .._models import enforce_bytes
+from .._models import enforce_headers
+from .._models import enforce_url
 from .._ssl import default_ssl_context
 from .._synchronization import Lock
 from .._trace import Trace

--- a/src/httpcore2/httpcore2/_sync/interfaces.py
+++ b/src/httpcore2/httpcore2/_sync/interfaces.py
@@ -4,18 +4,16 @@ import contextlib
 import typing
 from collections.abc import Generator
 
-from .._models import (
-    URL,
-    Extensions,
-    HeaderTypes,
-    Origin,
-    Request,
-    Response,
-    enforce_bytes,
-    enforce_headers,
-    enforce_url,
-    include_request_headers,
-)
+from .._models import URL
+from .._models import Extensions
+from .._models import HeaderTypes
+from .._models import Origin
+from .._models import Request
+from .._models import Response
+from .._models import enforce_bytes
+from .._models import enforce_headers
+from .._models import enforce_url
+from .._models import include_request_headers
 
 
 class RequestInterface:

--- a/src/httpcore2/httpcore2/_sync/socks_proxy.py
+++ b/src/httpcore2/httpcore2/_sync/socks_proxy.py
@@ -6,9 +6,16 @@ import ssl
 import socksio
 
 from .._backends.sync import SyncBackend
-from .._backends.base import NetworkBackend, NetworkStream
-from .._exceptions import ConnectionNotAvailable, ProxyError
-from .._models import URL, Origin, Request, Response, enforce_bytes, enforce_url
+from .._backends.base import NetworkBackend
+from .._backends.base import NetworkStream
+from .._exceptions import ConnectionNotAvailable
+from .._exceptions import ProxyError
+from .._models import URL
+from .._models import Origin
+from .._models import Request
+from .._models import Response
+from .._models import enforce_bytes
+from .._models import enforce_url
 from .._ssl import default_ssl_context
 from .._synchronization import Lock
 from .._trace import Trace

--- a/src/httpcore2/httpcore2/_synchronization.py
+++ b/src/httpcore2/httpcore2/_synchronization.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import threading
 import types
 
-from ._exceptions import ExceptionMapping, PoolTimeout, map_exceptions
+from ._exceptions import ExceptionMapping
+from ._exceptions import PoolTimeout
+from ._exceptions import map_exceptions
 
 # Our async synchronization primitives use either 'anyio' or 'trio' depending
 # on if they're running under asyncio or trio.

--- a/src/httpcore2/httpcore2/_utils.py
+++ b/src/httpcore2/httpcore2/_utils.py
@@ -4,15 +4,14 @@ import select
 import socket
 import sys
 import typing
-from collections.abc import (
-    AsyncGenerator,
-    AsyncIterable,
-    AsyncIterator,
-    Generator,
-    Iterable,
-    Iterator,
-)
-from contextlib import asynccontextmanager, contextmanager
+from collections.abc import AsyncGenerator
+from collections.abc import AsyncIterable
+from collections.abc import AsyncIterator
+from collections.abc import Generator
+from collections.abc import Iterable
+from collections.abc import Iterator
+from contextlib import asynccontextmanager
+from contextlib import contextmanager
 from inspect import isasyncgen
 
 T = typing.TypeVar("T")

--- a/src/httpx2/httpx2/__init__.py
+++ b/src/httpx2/httpx2/__init__.py
@@ -1,4 +1,6 @@
-from .__version__ import __description__, __title__, __version__
+from .__version__ import __description__
+from .__version__ import __title__
+from .__version__ import __version__
 from ._alias import *
 from ._api import *
 from ._auth import *

--- a/src/httpx2/httpx2/_api.py
+++ b/src/httpx2/httpx2/_api.py
@@ -5,25 +5,21 @@ from collections.abc import Generator
 from contextlib import contextmanager
 
 from ._client import Client
-from ._config import (
-    DEFAULT_KEEPALIVE_PING_INTERVAL_SECONDS,
-    DEFAULT_KEEPALIVE_PING_TIMEOUT_SECONDS,
-    DEFAULT_MAX_MESSAGE_SIZE_BYTES,
-    DEFAULT_QUEUE_SIZE,
-    DEFAULT_TIMEOUT_CONFIG,
-)
+from ._config import DEFAULT_KEEPALIVE_PING_INTERVAL_SECONDS
+from ._config import DEFAULT_KEEPALIVE_PING_TIMEOUT_SECONDS
+from ._config import DEFAULT_MAX_MESSAGE_SIZE_BYTES
+from ._config import DEFAULT_QUEUE_SIZE
+from ._config import DEFAULT_TIMEOUT_CONFIG
 from ._models import Response
-from ._types import (
-    AuthTypes,
-    CookieTypes,
-    HeaderTypes,
-    ProxyTypes,
-    QueryParamTypes,
-    RequestContent,
-    RequestData,
-    RequestFiles,
-    TimeoutTypes,
-)
+from ._types import AuthTypes
+from ._types import CookieTypes
+from ._types import HeaderTypes
+from ._types import ProxyTypes
+from ._types import QueryParamTypes
+from ._types import RequestContent
+from ._types import RequestData
+from ._types import RequestFiles
+from ._types import TimeoutTypes
 from ._urls import URL
 
 if typing.TYPE_CHECKING:

--- a/src/httpx2/httpx2/_auth.py
+++ b/src/httpx2/httpx2/_auth.py
@@ -9,8 +9,11 @@ from base64 import b64encode
 from urllib.request import parse_http_list
 
 from ._exceptions import ProtocolError
-from ._models import Cookies, Request, Response
-from ._utils import to_bytes, to_str
+from ._models import Cookies
+from ._models import Request
+from ._models import Response
+from ._utils import to_bytes
+from ._utils import to_str
 
 if typing.TYPE_CHECKING:
     from hashlib import _Hash

--- a/src/httpx2/httpx2/_client.py
+++ b/src/httpx2/httpx2/_client.py
@@ -6,59 +6,65 @@ import logging
 import time
 import typing
 import warnings
-from collections.abc import AsyncGenerator, Generator
-from contextlib import asynccontextmanager, contextmanager
+from collections.abc import AsyncGenerator
+from collections.abc import Generator
+from contextlib import asynccontextmanager
+from contextlib import contextmanager
 from types import TracebackType
 
 from .__version__ import __version__
-from ._auth import Auth, BasicAuth, FunctionAuth
-from ._config import (
-    DEFAULT_KEEPALIVE_PING_INTERVAL_SECONDS,
-    DEFAULT_KEEPALIVE_PING_TIMEOUT_SECONDS,
-    DEFAULT_LIMITS,
-    DEFAULT_MAX_EVENT_SIZE_BYTES,
-    DEFAULT_MAX_MESSAGE_SIZE_BYTES,
-    DEFAULT_MAX_REDIRECTS,
-    DEFAULT_QUEUE_SIZE,
-    DEFAULT_TIMEOUT_CONFIG,
-    Limits,
-    Proxy,
-    Timeout,
-)
+from ._auth import Auth
+from ._auth import BasicAuth
+from ._auth import FunctionAuth
+from ._config import DEFAULT_KEEPALIVE_PING_INTERVAL_SECONDS
+from ._config import DEFAULT_KEEPALIVE_PING_TIMEOUT_SECONDS
+from ._config import DEFAULT_LIMITS
+from ._config import DEFAULT_MAX_EVENT_SIZE_BYTES
+from ._config import DEFAULT_MAX_MESSAGE_SIZE_BYTES
+from ._config import DEFAULT_MAX_REDIRECTS
+from ._config import DEFAULT_QUEUE_SIZE
+from ._config import DEFAULT_TIMEOUT_CONFIG
+from ._config import Limits
+from ._config import Proxy
+from ._config import Timeout
 from ._decoders import SUPPORTED_DECODERS
-from ._exceptions import (
-    InvalidURL,
-    RemoteProtocolError,
-    TooManyRedirects,
-    request_context,
-)
-from ._models import Cookies, Headers, Request, Response
+from ._exceptions import InvalidURL
+from ._exceptions import RemoteProtocolError
+from ._exceptions import TooManyRedirects
+from ._exceptions import request_context
+from ._models import Cookies
+from ._models import Headers
+from ._models import Request
+from ._models import Response
 from ._sse import EventSource
 from ._status_codes import codes
-from ._transports import AsyncHTTPTransport, HTTPTransport
-from ._transports.base import AsyncBaseTransport, BaseTransport
-from ._types import (
-    AsyncByteStream,
-    AuthTypes,
-    CertTypes,
-    CookieTypes,
-    HeaderTypes,
-    ProxyTypes,
-    QueryParamTypes,
-    RequestContent,
-    RequestData,
-    RequestExtensions,
-    RequestFiles,
-    SyncByteStream,
-    TimeoutTypes,
-)
-from ._urls import URL, QueryParams
-from ._utils import URLPattern, get_environment_proxies
+from ._transports import AsyncHTTPTransport
+from ._transports import HTTPTransport
+from ._transports.base import AsyncBaseTransport
+from ._transports.base import BaseTransport
+from ._types import AsyncByteStream
+from ._types import AuthTypes
+from ._types import CertTypes
+from ._types import CookieTypes
+from ._types import HeaderTypes
+from ._types import ProxyTypes
+from ._types import QueryParamTypes
+from ._types import RequestContent
+from ._types import RequestData
+from ._types import RequestExtensions
+from ._types import RequestFiles
+from ._types import SyncByteStream
+from ._types import TimeoutTypes
+from ._urls import URL
+from ._urls import QueryParams
+from ._utils import URLPattern
+from ._utils import get_environment_proxies
 
 if typing.TYPE_CHECKING:
     import ssl  # pragma: no cover
 
-    from .websockets._api import AsyncWebSocketSession, WebSocketSession
+    from .websockets._api import AsyncWebSocketSession
+    from .websockets._api import WebSocketSession
 
 __all__ = ["USE_CLIENT_DEFAULT", "AsyncClient", "Client"]
 

--- a/src/httpx2/httpx2/_config.py
+++ b/src/httpx2/httpx2/_config.py
@@ -4,7 +4,9 @@ import os
 import typing
 
 from ._models import Headers
-from ._types import CertTypes, HeaderTypes, TimeoutTypes
+from ._types import CertTypes
+from ._types import HeaderTypes
+from ._types import TimeoutTypes
 from ._urls import URL
 
 if typing.TYPE_CHECKING:

--- a/src/httpx2/httpx2/_content.py
+++ b/src/httpx2/httpx2/_content.py
@@ -2,24 +2,26 @@ from __future__ import annotations
 
 import inspect
 import warnings
-from collections.abc import AsyncIterable, AsyncIterator, Iterable, Iterator, Mapping
+from collections.abc import AsyncIterable
+from collections.abc import AsyncIterator
+from collections.abc import Iterable
+from collections.abc import Iterator
+from collections.abc import Mapping
 from json import dumps as json_dumps
-from typing import (
-    Any,
-)
+from typing import Any
 from urllib.parse import urlencode
 
-from ._exceptions import StreamClosed, StreamConsumed
+from ._exceptions import StreamClosed
+from ._exceptions import StreamConsumed
 from ._multipart import MultipartStream
-from ._types import (
-    AsyncByteStream,
-    RequestContent,
-    RequestData,
-    RequestFiles,
-    ResponseContent,
-    SyncByteStream,
-)
-from ._utils import peek_filelike_length, primitive_value_to_str
+from ._types import AsyncByteStream
+from ._types import RequestContent
+from ._types import RequestData
+from ._types import RequestFiles
+from ._types import ResponseContent
+from ._types import SyncByteStream
+from ._utils import peek_filelike_length
+from ._utils import primitive_value_to_str
 
 __all__ = ["ByteStream"]
 

--- a/src/httpx2/httpx2/_decoders.py
+++ b/src/httpx2/httpx2/_decoders.py
@@ -33,9 +33,11 @@ except ImportError:  # pragma: no cover
 if typing.TYPE_CHECKING:
     # We keep checking Python version in the type checker path because try..except doesn't help type checkers.
     if sys.version_info >= (3, 14):
-        from compression.zstd import ZstdDecompressor, ZstdError
+        from compression.zstd import ZstdDecompressor
+        from compression.zstd import ZstdError
     else:
-        from zstandard import ZstdDecompressor as _ZstdDecompressor, ZstdError
+        from zstandard import ZstdDecompressor as _ZstdDecompressor
+        from zstandard import ZstdError
 
         ZstdDecompressor = functools.partial(_ZstdDecompressor().decompressobj)
 
@@ -43,13 +45,15 @@ if typing.TYPE_CHECKING:
 else:  # pragma: no cover
     _zstandard_installed = False
     try:
-        from compression.zstd import ZstdDecompressor, ZstdError
+        from compression.zstd import ZstdDecompressor
+        from compression.zstd import ZstdError
 
         _zstandard_installed = True
     # Either Python <3.14 or the distro doesn't have `compression.zstd`.
     except ImportError:
         try:
-            from zstandard import ZstdDecompressor as _ZstdDecompressor, ZstdError
+            from zstandard import ZstdDecompressor as _ZstdDecompressor
+            from zstandard import ZstdError
 
             ZstdDecompressor = functools.partial(_ZstdDecompressor().decompressobj)
             _zstandard_installed = True

--- a/src/httpx2/httpx2/_exceptions.py
+++ b/src/httpx2/httpx2/_exceptions.py
@@ -38,7 +38,8 @@ import typing
 from collections.abc import Generator
 
 if typing.TYPE_CHECKING:
-    from ._models import Request, Response  # pragma: no cover
+    from ._models import Request  # pragma: no cover
+    from ._models import Response  # pragma: no cover
 
 __all__ = [
     "CloseError",

--- a/src/httpx2/httpx2/_models.py
+++ b/src/httpx2/httpx2/_models.py
@@ -8,44 +8,43 @@ import re
 import typing
 import urllib.request
 from collections.abc import Mapping
-from http.cookiejar import Cookie, CookieJar
+from http.cookiejar import Cookie
+from http.cookiejar import CookieJar
 
-from ._content import ByteStream, UnattachedStream, encode_request, encode_response
-from ._decoders import (
-    ByteChunker,
-    ContentDecoder,
-    IdentityDecoder,
-    LineDecoder,
-    MultiDecoder,
-    TextChunker,
-    TextDecoder,
-)
-from ._exceptions import (
-    CookieConflict,
-    HTTPStatusError,
-    RequestNotRead,
-    ResponseNotRead,
-    StreamClosed,
-    StreamConsumed,
-    request_context,
-)
+from ._content import ByteStream
+from ._content import UnattachedStream
+from ._content import encode_request
+from ._content import encode_response
+from ._decoders import ByteChunker
+from ._decoders import ContentDecoder
+from ._decoders import IdentityDecoder
+from ._decoders import LineDecoder
+from ._decoders import MultiDecoder
+from ._decoders import TextChunker
+from ._decoders import TextDecoder
+from ._exceptions import CookieConflict
+from ._exceptions import HTTPStatusError
+from ._exceptions import RequestNotRead
+from ._exceptions import ResponseNotRead
+from ._exceptions import StreamClosed
+from ._exceptions import StreamConsumed
+from ._exceptions import request_context
 from ._multipart import get_multipart_boundary_from_content_type
 from ._status_codes import codes
-from ._types import (
-    AsyncByteStream,
-    CookieTypes,
-    HeaderTypes,
-    QueryParamTypes,
-    RequestContent,
-    RequestData,
-    RequestExtensions,
-    RequestFiles,
-    ResponseContent,
-    ResponseExtensions,
-    SyncByteStream,
-)
+from ._types import AsyncByteStream
+from ._types import CookieTypes
+from ._types import HeaderTypes
+from ._types import QueryParamTypes
+from ._types import RequestContent
+from ._types import RequestData
+from ._types import RequestExtensions
+from ._types import RequestFiles
+from ._types import ResponseContent
+from ._types import ResponseExtensions
+from ._types import SyncByteStream
 from ._urls import URL
-from ._utils import to_bytes_or_str, to_str
+from ._utils import to_bytes_or_str
+from ._utils import to_str
 
 __all__ = ["Cookies", "Headers", "Request", "Response"]
 

--- a/src/httpx2/httpx2/_multipart.py
+++ b/src/httpx2/httpx2/_multipart.py
@@ -7,19 +7,15 @@ import re
 import typing
 from pathlib import Path
 
-from ._types import (
-    AsyncByteStream,
-    FileContent,
-    FileTypes,
-    RequestData,
-    RequestFiles,
-    SyncByteStream,
-)
-from ._utils import (
-    peek_filelike_length,
-    primitive_value_to_str,
-    to_bytes,
-)
+from ._types import AsyncByteStream
+from ._types import FileContent
+from ._types import FileTypes
+from ._types import RequestData
+from ._types import RequestFiles
+from ._types import SyncByteStream
+from ._utils import peek_filelike_length
+from ._utils import primitive_value_to_str
+from ._utils import to_bytes
 
 _HTML5_FORM_ENCODING_REPLACEMENTS = {'"': "%22", "\\": "\\\\"}
 _HTML5_FORM_ENCODING_REPLACEMENTS.update({chr(c): f"%{c:02X}" for c in range(0x1F + 1) if c != 0x1B})

--- a/src/httpx2/httpx2/_sse.py
+++ b/src/httpx2/httpx2/_sse.py
@@ -29,11 +29,13 @@ SOFTWARE.
 from __future__ import annotations
 
 import json as jsonlib
-from collections.abc import AsyncIterator, Iterator
+from collections.abc import AsyncIterator
+from collections.abc import Iterator
 from dataclasses import dataclass
 
 from ._config import DEFAULT_MAX_EVENT_SIZE_BYTES
-from ._exceptions import TransportError, request_context
+from ._exceptions import TransportError
+from ._exceptions import request_context
 from ._models import Response
 
 __all__ = ["EventSource", "SSEError", "ServerSentEvent"]

--- a/src/httpx2/httpx2/_status_codes.py
+++ b/src/httpx2/httpx2/_status_codes.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import warnings
-from enum import EnumMeta, IntEnum
+from enum import EnumMeta
+from enum import IntEnum
 
 __all__ = ["codes"]
 

--- a/src/httpx2/httpx2/_transports/__init__.py
+++ b/src/httpx2/httpx2/_transports/__init__.py
@@ -1,7 +1,8 @@
 import sys
 
 from .asgi import ASGITransport
-from .base import AsyncBaseTransport, BaseTransport
+from .base import AsyncBaseTransport
+from .base import BaseTransport
 from .mock import MockTransport
 from .wsgi import WSGITransport
 
@@ -9,12 +10,11 @@ if sys.platform == "emscripten":  # pragma: nocover
     if sys.version_info < (3, 12):
         raise RuntimeError("httpx2 requires Python 3.12+ on Emscripten.")
 
-    from httpx2_jsfetch import (
-        AsyncJavascriptFetchTransport as AsyncHTTPTransport,
-        JavascriptFetchTransport as HTTPTransport,
-    )
+    from httpx2_jsfetch import AsyncJavascriptFetchTransport as AsyncHTTPTransport
+    from httpx2_jsfetch import JavascriptFetchTransport as HTTPTransport
 else:
-    from .default import AsyncHTTPTransport, HTTPTransport
+    from .default import AsyncHTTPTransport
+    from .default import HTTPTransport
 
 __all__ = [
     "ASGITransport",

--- a/src/httpx2/httpx2/_transports/asgi.py
+++ b/src/httpx2/httpx2/_transports/asgi.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import typing
 
-from .._models import Request, Response
+from .._models import Request
+from .._models import Response
 from .._types import AsyncByteStream
 from .base import AsyncBaseTransport
 

--- a/src/httpx2/httpx2/_transports/base.py
+++ b/src/httpx2/httpx2/_transports/base.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import typing
 from types import TracebackType
 
-from .._models import Request, Response
+from .._models import Request
+from .._models import Response
 
 # TODO(Marcelo): When Python 3.10 reaches EOF, we can use `typing.Self` instead of defining those two.
 T = typing.TypeVar("T", bound="BaseTransport")

--- a/src/httpx2/httpx2/_transports/default.py
+++ b/src/httpx2/httpx2/_transports/default.py
@@ -36,27 +36,33 @@ if typing.TYPE_CHECKING:  # pragma: no cover
 
     import httpx2
 
-from .._config import DEFAULT_LIMITS, Limits, Proxy, create_ssl_context
-from .._exceptions import (
-    ConnectError,
-    ConnectTimeout,
-    LocalProtocolError,
-    NetworkError,
-    PoolTimeout,
-    ProtocolError,
-    ProxyError,
-    ReadError,
-    ReadTimeout,
-    RemoteProtocolError,
-    TimeoutException,
-    UnsupportedProtocol,
-    WriteError,
-    WriteTimeout,
-)
-from .._models import Request, Response
-from .._types import AsyncByteStream, CertTypes, ProxyTypes, SyncByteStream
+from .._config import DEFAULT_LIMITS
+from .._config import Limits
+from .._config import Proxy
+from .._config import create_ssl_context
+from .._exceptions import ConnectError
+from .._exceptions import ConnectTimeout
+from .._exceptions import LocalProtocolError
+from .._exceptions import NetworkError
+from .._exceptions import PoolTimeout
+from .._exceptions import ProtocolError
+from .._exceptions import ProxyError
+from .._exceptions import ReadError
+from .._exceptions import ReadTimeout
+from .._exceptions import RemoteProtocolError
+from .._exceptions import TimeoutException
+from .._exceptions import UnsupportedProtocol
+from .._exceptions import WriteError
+from .._exceptions import WriteTimeout
+from .._models import Request
+from .._models import Response
+from .._types import AsyncByteStream
+from .._types import CertTypes
+from .._types import ProxyTypes
+from .._types import SyncByteStream
 from .._urls import URL
-from .base import AsyncBaseTransport, BaseTransport
+from .base import AsyncBaseTransport
+from .base import BaseTransport
 
 T = typing.TypeVar("T", bound="HTTPTransport")
 A = typing.TypeVar("A", bound="AsyncHTTPTransport")

--- a/src/httpx2/httpx2/_transports/mock.py
+++ b/src/httpx2/httpx2/_transports/mock.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import typing
 
-from .._models import Request, Response
-from .base import AsyncBaseTransport, BaseTransport
+from .._models import Request
+from .._models import Response
+from .base import AsyncBaseTransport
+from .base import BaseTransport
 
 SyncHandler = typing.Callable[[Request], Response]
 AsyncHandler = typing.Callable[[Request], typing.Coroutine[None, None, Response]]

--- a/src/httpx2/httpx2/_transports/wsgi.py
+++ b/src/httpx2/httpx2/_transports/wsgi.py
@@ -5,7 +5,8 @@ import itertools
 import sys
 import typing
 
-from .._models import Request, Response
+from .._models import Request
+from .._models import Response
 from .._types import SyncByteStream
 from .base import BaseTransport
 

--- a/src/httpx2/httpx2/_types.py
+++ b/src/httpx2/httpx2/_types.py
@@ -2,15 +2,28 @@
 Type definitions for type checking purposes.
 """
 
-from collections.abc import AsyncIterable, AsyncIterator, Callable, Iterable, Iterator, Mapping, Sequence
+from collections.abc import AsyncIterable
+from collections.abc import AsyncIterator
+from collections.abc import Callable
+from collections.abc import Iterable
+from collections.abc import Iterator
+from collections.abc import Mapping
+from collections.abc import Sequence
 from http.cookiejar import CookieJar
-from typing import IO, TYPE_CHECKING, Any, Union
+from typing import IO
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Union
 
 if TYPE_CHECKING:
     from ._auth import Auth  # noqa: F401
-    from ._config import Proxy, Timeout  # noqa: F401
-    from ._models import Cookies, Headers, Request  # noqa: F401
-    from ._urls import URL, QueryParams  # noqa: F401
+    from ._config import Proxy  # noqa: F401
+    from ._config import Timeout  # noqa: F401
+    from ._models import Cookies  # noqa: F401
+    from ._models import Headers  # noqa: F401
+    from ._models import Request  # noqa: F401
+    from ._urls import URL  # noqa: F401
+    from ._urls import QueryParams  # noqa: F401
 
 
 PrimitiveData = str | int | float | bool | None

--- a/src/httpx2/httpx2/_urls.py
+++ b/src/httpx2/httpx2/_urls.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import sys
 import typing
-from urllib.parse import parse_qs, unquote, urlencode
+from urllib.parse import parse_qs
+from urllib.parse import unquote
+from urllib.parse import urlencode
 
 import idna
 

--- a/src/httpx2/httpx2/websockets/__init__.py
+++ b/src/httpx2/httpx2/websockets/__init__.py
@@ -26,20 +26,16 @@ SOFTWARE.
 ```
 """
 
-from ._api import (
-    AsyncWebSocketClient,
-    AsyncWebSocketSession,
-    JSONMode,
-    WebSocketClient,
-    WebSocketSession,
-)
-from ._exceptions import (
-    HTTPXWSException,
-    WebSocketDisconnect,
-    WebSocketInvalidTypeReceived,
-    WebSocketNetworkError,
-    WebSocketUpgradeError,
-)
+from ._api import AsyncWebSocketClient
+from ._api import AsyncWebSocketSession
+from ._api import JSONMode
+from ._api import WebSocketClient
+from ._api import WebSocketSession
+from ._exceptions import HTTPXWSException
+from ._exceptions import WebSocketDisconnect
+from ._exceptions import WebSocketInvalidTypeReceived
+from ._exceptions import WebSocketNetworkError
+from ._exceptions import WebSocketUpgradeError
 from ._transport import ASGIWebSocketTransport
 
 __all__ = [

--- a/src/httpx2/httpx2/websockets/_api.py
+++ b/src/httpx2/httpx2/websockets/_api.py
@@ -19,40 +19,39 @@ else:
 import anyio
 import wsproto
 import wsproto.utilities
-from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
+from anyio.streams.memory import MemoryObjectReceiveStream
+from anyio.streams.memory import MemoryObjectSendStream
 from wsproto.frame_protocol import CloseReason
 
 from .._client import USE_CLIENT_DEFAULT
-from .._config import (
-    DEFAULT_KEEPALIVE_PING_INTERVAL_SECONDS,
-    DEFAULT_KEEPALIVE_PING_TIMEOUT_SECONDS,
-    DEFAULT_MAX_MESSAGE_SIZE_BYTES,
-    DEFAULT_QUEUE_SIZE,
-)
+from .._config import DEFAULT_KEEPALIVE_PING_INTERVAL_SECONDS
+from .._config import DEFAULT_KEEPALIVE_PING_TIMEOUT_SECONDS
+from .._config import DEFAULT_MAX_MESSAGE_SIZE_BYTES
+from .._config import DEFAULT_QUEUE_SIZE
 from .._models import Headers
-from ._exceptions import (
-    HTTPXWSException,
-    WebSocketDisconnect,
-    WebSocketInvalidTypeReceived,
-    WebSocketNetworkError,
-    WebSocketUpgradeError,
-)
-from ._ping import AsyncPingManager, PingManager
+from ._exceptions import HTTPXWSException
+from ._exceptions import WebSocketDisconnect
+from ._exceptions import WebSocketInvalidTypeReceived
+from ._exceptions import WebSocketNetworkError
+from ._exceptions import WebSocketUpgradeError
+from ._ping import AsyncPingManager
+from ._ping import PingManager
 from ._transport import ASGIWebSocketAsyncNetworkStream
 
 if typing.TYPE_CHECKING:
-    from httpcore2 import AsyncNetworkStream, NetworkStream
+    from httpcore2 import AsyncNetworkStream
+    from httpcore2 import NetworkStream
 
-    from .._client import AsyncClient, Client, UseClientDefault
+    from .._client import AsyncClient
+    from .._client import Client
+    from .._client import UseClientDefault
     from .._models import Response
-    from .._types import (
-        AuthTypes,
-        CookieTypes,
-        HeaderTypes,
-        QueryParamTypes,
-        RequestExtensions,
-        TimeoutTypes,
-    )
+    from .._types import AuthTypes
+    from .._types import CookieTypes
+    from .._types import HeaderTypes
+    from .._types import QueryParamTypes
+    from .._types import RequestExtensions
+    from .._types import TimeoutTypes
 
 JSONMode = typing.Literal["text", "binary"]
 TaskFunction = typing.TypeVar("TaskFunction")

--- a/src/httpx2/httpx2/websockets/_transport.py
+++ b/src/httpx2/httpx2/websockets/_transport.py
@@ -10,10 +10,13 @@ import wsproto
 from anyio.streams.stapled import StapledObjectStream
 from wsproto.frame_protocol import CloseReason
 
-from .._models import Request, Response
-from .._transports.asgi import ASGITransport, _ASGIApp
+from .._models import Request
+from .._models import Response
+from .._transports.asgi import ASGITransport
+from .._transports.asgi import _ASGIApp
 from .._types import AsyncByteStream
-from ._exceptions import WebSocketDisconnect, WebSocketUpgradeError
+from ._exceptions import WebSocketDisconnect
+from ._exceptions import WebSocketUpgradeError
 
 Scope = dict[str, typing.Any]
 Message = dict[str, typing.Any]

--- a/tests/httpcore2/_async/test_connection.py
+++ b/tests/httpcore2/_async/test_connection.py
@@ -5,18 +5,16 @@ import hpack
 import hyperframe.frame
 import pytest
 
-from httpcore2 import (
-    SOCKET_OPTION,
-    AsyncHTTPConnection,
-    AsyncMockBackend,
-    AsyncMockStream,
-    AsyncNetworkStream,
-    ConnectError,
-    ConnectionNotAvailable,
-    Origin,
-    RemoteProtocolError,
-    WriteError,
-)
+from httpcore2 import SOCKET_OPTION
+from httpcore2 import AsyncHTTPConnection
+from httpcore2 import AsyncMockBackend
+from httpcore2 import AsyncMockStream
+from httpcore2 import AsyncNetworkStream
+from httpcore2 import ConnectError
+from httpcore2 import ConnectionNotAvailable
+from httpcore2 import Origin
+from httpcore2 import RemoteProtocolError
+from httpcore2 import WriteError
 
 
 @pytest.mark.anyio

--- a/tests/httpcore2/_async/test_http_proxy.py
+++ b/tests/httpcore2/_async/test_http_proxy.py
@@ -5,16 +5,14 @@ import hpack
 import hyperframe.frame
 import pytest
 
-from httpcore2 import (
-    SOCKET_OPTION,
-    AsyncConnectionPool,
-    AsyncMockBackend,
-    AsyncMockStream,
-    AsyncNetworkStream,
-    Origin,
-    Proxy,
-    ProxyError,
-)
+from httpcore2 import SOCKET_OPTION
+from httpcore2 import AsyncConnectionPool
+from httpcore2 import AsyncMockBackend
+from httpcore2 import AsyncMockStream
+from httpcore2 import AsyncNetworkStream
+from httpcore2 import Origin
+from httpcore2 import Proxy
+from httpcore2 import ProxyError
 
 
 @pytest.mark.anyio

--- a/tests/httpcore2/_sync/test_connection.py
+++ b/tests/httpcore2/_sync/test_connection.py
@@ -5,18 +5,16 @@ import hpack
 import hyperframe.frame
 import pytest
 
-from httpcore2 import (
-    SOCKET_OPTION,
-    HTTPConnection,
-    MockBackend,
-    MockStream,
-    NetworkStream,
-    ConnectError,
-    ConnectionNotAvailable,
-    Origin,
-    RemoteProtocolError,
-    WriteError,
-)
+from httpcore2 import SOCKET_OPTION
+from httpcore2 import HTTPConnection
+from httpcore2 import MockBackend
+from httpcore2 import MockStream
+from httpcore2 import NetworkStream
+from httpcore2 import ConnectError
+from httpcore2 import ConnectionNotAvailable
+from httpcore2 import Origin
+from httpcore2 import RemoteProtocolError
+from httpcore2 import WriteError
 
 
 

--- a/tests/httpcore2/_sync/test_http_proxy.py
+++ b/tests/httpcore2/_sync/test_http_proxy.py
@@ -5,16 +5,14 @@ import hpack
 import hyperframe.frame
 import pytest
 
-from httpcore2 import (
-    SOCKET_OPTION,
-    ConnectionPool,
-    MockBackend,
-    MockStream,
-    NetworkStream,
-    Origin,
-    Proxy,
-    ProxyError,
-)
+from httpcore2 import SOCKET_OPTION
+from httpcore2 import ConnectionPool
+from httpcore2 import MockBackend
+from httpcore2 import MockStream
+from httpcore2 import NetworkStream
+from httpcore2 import Origin
+from httpcore2 import Proxy
+from httpcore2 import ProxyError
 
 
 

--- a/tests/httpcore2/benchmark/client.py
+++ b/tests/httpcore2/benchmark/client.py
@@ -2,7 +2,10 @@ import asyncio
 import os
 import sys
 import time
-from collections.abc import Callable, Coroutine, Generator, Iterator
+from collections.abc import Callable
+from collections.abc import Coroutine
+from collections.abc import Generator
+from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from typing import Any

--- a/tests/httpcore2/benchmark/server.py
+++ b/tests/httpcore2/benchmark/server.py
@@ -1,5 +1,6 @@
 import asyncio
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable
+from collections.abc import Callable
 from typing import Any
 
 import uvicorn

--- a/tests/httpx2/client/test_cookies.py
+++ b/tests/httpx2/client/test_cookies.py
@@ -1,4 +1,5 @@
-from http.cookiejar import Cookie, CookieJar
+from http.cookiejar import Cookie
+from http.cookiejar import CookieJar
 
 import pytest
 

--- a/tests/httpx2/conftest.py
+++ b/tests/httpx2/conftest.py
@@ -9,12 +9,10 @@ import typing
 import pytest
 import trustme
 from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives.serialization import (
-    BestAvailableEncryption,
-    Encoding,
-    PrivateFormat,
-    load_pem_private_key,
-)
+from cryptography.hazmat.primitives.serialization import BestAvailableEncryption
+from cryptography.hazmat.primitives.serialization import Encoding
+from cryptography.hazmat.primitives.serialization import PrivateFormat
+from cryptography.hazmat.primitives.serialization import load_pem_private_key
 from uvicorn.config import Config
 from uvicorn.server import Server
 

--- a/tests/httpx2/test_sse.py
+++ b/tests/httpx2/test_sse.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import AsyncIterator, Iterator
+from collections.abc import AsyncIterator
+from collections.abc import Iterator
 
 import pytest
 

--- a/tests/httpx2/test_utils.py
+++ b/tests/httpx2/test_utils.py
@@ -9,7 +9,8 @@ import typing
 import pytest
 
 import httpx2
-from httpx2._utils import URLPattern, get_environment_proxies
+from httpx2._utils import URLPattern
+from httpx2._utils import get_environment_proxies
 
 if typing.TYPE_CHECKING:
     from conftest import TestServer

--- a/tests/httpx2/test_wsgi.py
+++ b/tests/httpx2/test_wsgi.py
@@ -11,7 +11,9 @@ import pytest
 import httpx2
 
 if typing.TYPE_CHECKING:
-    from _typeshed.wsgi import StartResponse, WSGIApplication, WSGIEnvironment
+    from _typeshed.wsgi import StartResponse
+    from _typeshed.wsgi import WSGIApplication
+    from _typeshed.wsgi import WSGIEnvironment
 
 
 def application_factory(output: typing.Iterable[bytes]) -> WSGIApplication:

--- a/tests/httpx2/websockets/test_api.py
+++ b/tests/httpx2/websockets/test_api.py
@@ -5,32 +5,32 @@ import queue
 import threading
 import time
 import typing
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock
+from unittest.mock import call
+from unittest.mock import patch
 
 import anyio
 import pytest
 import wsproto
-from starlette.websockets import WebSocket, WebSocketDisconnect as StarletteWebSocketDisconnect
+from starlette.websockets import WebSocket
+from starlette.websockets import WebSocketDisconnect as StarletteWebSocketDisconnect
 
 import httpcore2 as httpcore
 import httpx2 as httpx
-from httpcore2 import AsyncNetworkStream, NetworkStream
+from httpcore2 import AsyncNetworkStream
+from httpcore2 import NetworkStream
 from httpx2.websockets import _api
-from httpx2.websockets._api import (
-    AsyncWebSocketClient,
-    AsyncWebSocketSession,
-    JSONMode,
-    WebSocketClient,
-    WebSocketSession,
-    aconnect_ws,
-    connect_ws,
-)
-from httpx2.websockets._exceptions import (
-    WebSocketDisconnect,
-    WebSocketInvalidTypeReceived,
-    WebSocketNetworkError,
-    WebSocketUpgradeError,
-)
+from httpx2.websockets._api import AsyncWebSocketClient
+from httpx2.websockets._api import AsyncWebSocketSession
+from httpx2.websockets._api import JSONMode
+from httpx2.websockets._api import WebSocketClient
+from httpx2.websockets._api import WebSocketSession
+from httpx2.websockets._api import aconnect_ws
+from httpx2.websockets._api import connect_ws
+from httpx2.websockets._exceptions import WebSocketDisconnect
+from httpx2.websockets._exceptions import WebSocketInvalidTypeReceived
+from httpx2.websockets._exceptions import WebSocketNetworkError
+from httpx2.websockets._exceptions import WebSocketUpgradeError
 from tests.httpx2.websockets.conftest import ServerFactoryFixture
 
 

--- a/tests/httpx2/websockets/test_high_level.py
+++ b/tests/httpx2/websockets/test_high_level.py
@@ -11,8 +11,11 @@ import wsproto
 from starlette.websockets import WebSocket
 
 import httpx2 as httpx
-from httpcore2 import AsyncNetworkStream, NetworkStream
-from httpx2.websockets import AsyncWebSocketSession, WebSocketSession, _api
+from httpcore2 import AsyncNetworkStream
+from httpcore2 import NetworkStream
+from httpx2.websockets import AsyncWebSocketSession
+from httpx2.websockets import WebSocketSession
+from httpx2.websockets import _api
 from tests.httpx2.websockets.conftest import ServerFactoryFixture
 
 

--- a/tests/httpx2/websockets/test_transport.py
+++ b/tests/httpx2/websockets/test_transport.py
@@ -8,25 +8,27 @@ from typing import Any
 import anyio
 import pytest
 import wsproto
-from anyio import CancelScope, ClosedResourceError, create_task_group
+from anyio import CancelScope
+from anyio import ClosedResourceError
+from anyio import create_task_group
 from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse
-from starlette.routing import Route, WebSocketRoute
+from starlette.routing import Route
+from starlette.routing import WebSocketRoute
 from starlette.websockets import WebSocket
 
 import httpx2 as httpx
 from httpx2.websockets._api import aconnect_ws
-from httpx2.websockets._exceptions import WebSocketDisconnect, WebSocketUpgradeError
-from httpx2.websockets._transport import (
-    ASGIWebSocketAsyncNetworkStream,
-    ASGIWebSocketTransport,
-    Receive,
-    Scope,
-    Send,
-    UnhandledASGIMessageType,
-    UnhandledWebSocketEvent,
-)
+from httpx2.websockets._exceptions import WebSocketDisconnect
+from httpx2.websockets._exceptions import WebSocketUpgradeError
+from httpx2.websockets._transport import ASGIWebSocketAsyncNetworkStream
+from httpx2.websockets._transport import ASGIWebSocketTransport
+from httpx2.websockets._transport import Receive
+from httpx2.websockets._transport import Scope
+from httpx2.websockets._transport import Send
+from httpx2.websockets._transport import UnhandledASGIMessageType
+from httpx2.websockets._transport import UnhandledWebSocketEvent
 
 if sys.version_info < (3, 11):
     from exceptiongroup import ExceptionGroup  # pragma: no cover

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import gzip
 import json
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
+from typing import Any
 
 import pytest
 
 import httpx2
-from httpx2._decoders import GZipDecoder, LineDecoder
+from httpx2._decoders import GZipDecoder
+from httpx2._decoders import LineDecoder
 
 if TYPE_CHECKING:
     from pytest_codspeed import BenchmarkFixture


### PR DESCRIPTION
Sets `force-single-line = true` in the ruff isort config, so every `from` import gets one binding per line. Opened to evaluate how the style looks across the codebase.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

