### PR TITLE
Avoid quadratic copying when sending large HTTP/2 request bodies

### DIFF
--- a/src/httpcore2/httpcore2/_async/http2.py
+++ b/src/httpcore2/httpcore2/_async/http2.py
@@ -246,10 +246,11 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
         """
         Send a single chunk of data in one or more data frames.
         """
-        while data:
+        position = 0
+        while position < len(data):
             max_flow = await self._wait_for_outgoing_flow(request, stream_id)
-            chunk_size = min(len(data), max_flow)
-            chunk, data = data[:chunk_size], data[chunk_size:]
+            chunk = data[position : position + max_flow]
+            position += len(chunk)
             self._h2_state.send_data(stream_id, chunk)
             await self._write_outgoing_data(request)
 

--- a/src/httpcore2/httpcore2/_sync/http2.py
+++ b/src/httpcore2/httpcore2/_sync/http2.py
@@ -246,10 +246,11 @@ class HTTP2Connection(ConnectionInterface):
         """
         Send a single chunk of data in one or more data frames.
         """
-        while data:
+        position = 0
+        while position < len(data):
             max_flow = self._wait_for_outgoing_flow(request, stream_id)
-            chunk_size = min(len(data), max_flow)
-            chunk, data = data[:chunk_size], data[chunk_size:]
+            chunk = data[position : position + max_flow]
+            position += len(chunk)
             self._h2_state.send_data(stream_id, chunk)
             self._write_outgoing_data(request)
 


### PR DESCRIPTION
Closes #1039.

`_send_stream_data` rebuilt the remaining body tail as a fresh `bytes` object on every frame, copying ~`n²/2k` bytes for an `n` byte body sent in `k` byte frames. This replaces it with an offset-based loop so each byte is sliced once.

Benchmark sending a single `bytes` body through `HTTP2Connection` over a `MockStream` (16 KiB frames):

| Body size | Before | After |
|---|---|---|
| 16 MiB | 0.153s | 0.005s |
| 64 MiB | 2.226s | 0.021s |
| 256 MiB | 35.748s | 0.088s |

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

