### PR TITLE
fix: handle missing hashlib.md5 on FIPS-enforced Python

### DIFF
--- a/src/httpx2/httpx2/_auth.py
+++ b/src/httpx2/httpx2/_auth.py
@@ -175,9 +175,16 @@ class DigestAuth(Auth):
         "SHA-512": hashlib.sha512,
         "SHA-512-SESS": hashlib.sha512,
     }
+    # MD5 is not FIPS-approved. Some FIPS-enforced Python builds remove hashlib.md5
+    # entirely, while others keep it but raise ValueError when called with
+    # usedforsecurity=True (the default). Only register MD5 if it is actually usable.
     if hasattr(hashlib, "md5"):
-        _ALGORITHM_TO_HASH_FUNCTION["MD5"] = hashlib.md5
-        _ALGORITHM_TO_HASH_FUNCTION["MD5-SESS"] = hashlib.md5
+        try:
+            hashlib.md5(b"", usedforsecurity=True)
+            _ALGORITHM_TO_HASH_FUNCTION["MD5"] = hashlib.md5
+            _ALGORITHM_TO_HASH_FUNCTION["MD5-SESS"] = hashlib.md5
+        except ValueError:
+            pass
 
     def __init__(self, username: str | bytes, password: str | bytes) -> None:
         self._username = to_bytes(username)

--- a/src/httpx2/httpx2/_auth.py
+++ b/src/httpx2/httpx2/_auth.py
@@ -168,8 +168,6 @@ class NetRCAuth(Auth):
 
 class DigestAuth(Auth):
     _ALGORITHM_TO_HASH_FUNCTION: dict[str, typing.Callable[[bytes], _Hash]] = {
-        "MD5": hashlib.md5,
-        "MD5-SESS": hashlib.md5,
         "SHA": hashlib.sha1,
         "SHA-SESS": hashlib.sha1,
         "SHA-256": hashlib.sha256,
@@ -177,6 +175,9 @@ class DigestAuth(Auth):
         "SHA-512": hashlib.sha512,
         "SHA-512-SESS": hashlib.sha512,
     }
+    if hasattr(hashlib, "md5"):
+        _ALGORITHM_TO_HASH_FUNCTION["MD5"] = hashlib.md5
+        _ALGORITHM_TO_HASH_FUNCTION["MD5-SESS"] = hashlib.md5
 
     def __init__(self, username: str | bytes, password: str | bytes) -> None:
         self._username = to_bytes(username)
@@ -239,7 +240,14 @@ class DigestAuth(Auth):
             raise ProtocolError(message, request=request) from exc
 
     def _build_auth_header(self, request: Request, challenge: _DigestAuthChallenge) -> str:
-        hash_func = self._ALGORITHM_TO_HASH_FUNCTION[challenge.algorithm.upper()]
+        try:
+            hash_func = self._ALGORITHM_TO_HASH_FUNCTION[challenge.algorithm.upper()]
+        except KeyError:
+            supported = ", ".join(sorted(self._ALGORITHM_TO_HASH_FUNCTION))
+            message = (
+                f"Unsupported or unavailable digest auth algorithm '{challenge.algorithm}'. Supported: {supported}"
+            )
+            raise ProtocolError(message, request=request)
 
         def digest(data: bytes) -> bytes:
             return hash_func(data).hexdigest().encode()

--- a/tests/httpx2/test_auth.py
+++ b/tests/httpx2/test_auth.py
@@ -273,3 +273,39 @@ def test_digest_auth_empty_realm() -> None:
     request = flow.send(response)
 
     assert request.headers["Authorization"].startswith('Digest username="user", realm="", nonce="..."')
+
+
+def test_digest_auth_fips_missing_md5(monkeypatch: pytest.MonkeyPatch) -> None:
+    # On FIPS-enforced Python, hashlib.md5 may not exist.
+    # Simulate by removing MD5 entries from the algorithm map.
+    fips_algorithms = {k: v for k, v in httpx2.DigestAuth._ALGORITHM_TO_HASH_FUNCTION.items() if "MD5" not in k}
+    monkeypatch.setattr(httpx2.DigestAuth, "_ALGORITHM_TO_HASH_FUNCTION", fips_algorithms)
+
+    # SHA-256 digest auth should still work.
+    auth = httpx2.DigestAuth(username="user", password="pass")
+    request = httpx2.Request("GET", "https://www.example.com")
+
+    flow = auth.sync_auth_flow(request)
+    request = next(flow)
+
+    headers = {"WWW-Authenticate": 'Digest realm="test", qop="auth", algorithm=SHA-256, nonce="abc", opaque="xyz"'}
+    response = httpx2.Response(content=b"Auth required", status_code=401, headers=headers, request=request)
+    request = flow.send(response)
+    assert request.headers["Authorization"].startswith("Digest")
+    assert "algorithm=SHA-256" in request.headers["Authorization"]
+
+
+def test_digest_auth_unavailable_algorithm_raises_protocol_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    # When a server requests an algorithm not in the map, a clear error is raised.
+    monkeypatch.setattr(httpx2.DigestAuth, "_ALGORITHM_TO_HASH_FUNCTION", {})
+
+    auth = httpx2.DigestAuth(username="user", password="pass")
+    request = httpx2.Request("GET", "https://www.example.com")
+
+    flow = auth.sync_auth_flow(request)
+    request = next(flow)
+
+    headers = {"WWW-Authenticate": 'Digest realm="test", qop="auth", algorithm=MD5, nonce="abc", opaque="xyz"'}
+    response = httpx2.Response(content=b"Auth required", status_code=401, headers=headers, request=request)
+    with pytest.raises(httpx2.ProtocolError, match="Unsupported or unavailable digest auth algorithm"):
+        flow.send(response)

--- a/tests/httpx2/test_auth.py
+++ b/tests/httpx2/test_auth.py
@@ -292,6 +292,26 @@ def test_digest_auth_importable_without_hashlib_md5(monkeypatch: pytest.MonkeyPa
         importlib.reload(_auth)
 
 
+def test_digest_auth_importable_with_blocked_hashlib_md5(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Verify the import-time guard works when hashlib.md5 exists but raises
+    # ValueError, simulating a FIPS build that blocks MD5 at call time.
+    import importlib
+
+    from httpx2 import _auth
+
+    def fips_blocked_md5(*args: object, **kwargs: object) -> None:
+        raise ValueError("[digital envelope routines] disabled for FIPS")
+
+    monkeypatch.setattr("hashlib.md5", fips_blocked_md5)
+    try:
+        importlib.reload(_auth)
+        assert "MD5" not in _auth.DigestAuth._ALGORITHM_TO_HASH_FUNCTION
+        assert "SHA-256" in _auth.DigestAuth._ALGORITHM_TO_HASH_FUNCTION
+    finally:
+        monkeypatch.undo()
+        importlib.reload(_auth)
+
+
 def test_digest_auth_fips_missing_md5(monkeypatch: pytest.MonkeyPatch) -> None:
     # On FIPS-enforced Python, hashlib.md5 may not exist.
     # Simulate by removing MD5 entries from the algorithm map.

--- a/tests/httpx2/test_auth.py
+++ b/tests/httpx2/test_auth.py
@@ -282,7 +282,7 @@ def test_digest_auth_importable_without_hashlib_md5(monkeypatch: pytest.MonkeyPa
 
     from httpx2 import _auth
 
-    monkeypatch.delattr("hashlib.md5")
+    monkeypatch.delattr("hashlib.md5", raising=False)
     try:
         importlib.reload(_auth)
         assert "MD5" not in _auth.DigestAuth._ALGORITHM_TO_HASH_FUNCTION

--- a/tests/httpx2/test_auth.py
+++ b/tests/httpx2/test_auth.py
@@ -275,6 +275,23 @@ def test_digest_auth_empty_realm() -> None:
     assert request.headers["Authorization"].startswith('Digest username="user", realm="", nonce="..."')
 
 
+def test_digest_auth_importable_without_hashlib_md5(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Verify the import-time hasattr guard works by reloading the module
+    # with hashlib.md5 removed, simulating a FIPS build that strips it entirely.
+    import importlib
+
+    from httpx2 import _auth
+
+    monkeypatch.delattr("hashlib.md5")
+    try:
+        importlib.reload(_auth)
+        assert "MD5" not in _auth.DigestAuth._ALGORITHM_TO_HASH_FUNCTION
+        assert "SHA-256" in _auth.DigestAuth._ALGORITHM_TO_HASH_FUNCTION
+    finally:
+        monkeypatch.undo()
+        importlib.reload(_auth)
+
+
 def test_digest_auth_fips_missing_md5(monkeypatch: pytest.MonkeyPatch) -> None:
     # On FIPS-enforced Python, hashlib.md5 may not exist.
     # Simulate by removing MD5 entries from the algorithm map.


### PR DESCRIPTION
# Summary

MD5 is not a FIPS-approved algorithm, and some FIPS-enforced Python images remove `hashlib.md5` entirely. Because `DigestAuth` references `hashlib.md5` in a class-level dictionary, this causes an `AttributeError` at import time, making the entire `httpx2` library unusable on these environments, even if MD5 digest auth is never used.

This change conditionally registers the MD5 algorithm entries only when `hashlib.md5` is present, so httpx2 can be imported on FIPS-enforced environments while preserving full MD5 digest auth support elsewhere. When a server requests an unavailable algorithm, a clear `ProtocolError` is raised instead of an opaque `KeyError`.

Discussion: https://github.com/pydantic/httpx2/discussions/1094

# Checklist

- [X] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [X] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [X] I've updated the documentation accordingly. 
 - (No documentation to update?)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

