### PR TITLE
Add public Origin API

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -156,10 +156,27 @@ what gets sent over the wire.*
 * `.query` - **str**
 * `.raw_path` - **str**
 * `.fragment` - **str**
+* `.origin` - **Origin**
 * `.is_ssl` - **bool**
 * `.is_absolute_url` - **bool**
 * `.is_relative_url` - **bool**
 * `def .copy_with([scheme], [authority], [path], [query], [fragment])` - **URL**
+
+## `Origin`
+
+*An immutable, hashable set of normalized scheme, host, and effective port information.*
+
+```pycon
+>>> URL('https://example.org').origin == URL('HTTPS://EXAMPLE.ORG:443').origin
+True
+>>> URL('wss://[::1]/socket').origin
+Origin(scheme='wss', host='::1', port=443)
+```
+
+* `def __init__(url)`
+* `.scheme` - **str**
+* `.host` - **str**
+* `.port` - **int** or **None**
 
 ## `Headers`
 

--- a/src/httpx2/CHANGELOG.md
+++ b/src/httpx2/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Added
+
+* Add the public `Origin` value object and `URL.origin` property for normalized,
+  hashable origin comparisons.
+
 ## 2.10.0 (August 9th, 2026)
 
 ### Added

--- a/src/httpx2/CHANGELOG.md
+++ b/src/httpx2/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 * Add the public `Origin` value object and `URL.origin` property for normalized,
-  hashable origin comparisons.
+  hashable origin comparisons. ([#1134](https://github.com/pydantic/httpx2/pull/1134))
 
 ## 2.10.0 (August 9th, 2026)
 

--- a/src/httpx2/httpx2/__init__.py
+++ b/src/httpx2/httpx2/__init__.py
@@ -53,6 +53,7 @@ __all__ = [
     "NetRCAuth",
     "NetworkError",
     "options",
+    "Origin",
     "patch",
     "PoolTimeout",
     "post",

--- a/src/httpx2/httpx2/_client.py
+++ b/src/httpx2/httpx2/_client.py
@@ -72,28 +72,23 @@ def _is_https_redirect(url: URL, location: URL) -> bool:
     """
     Return 'True' if 'location' is a HTTPS upgrade of 'url'
     """
-    if url.host != location.host:
-        return False
+    origin = url.origin
+    location_origin = location.origin
 
     return (
-        url.scheme == "http"
-        and _port_or_default(url) == 80
-        and location.scheme == "https"
-        and _port_or_default(location) == 443
+        origin.host == location_origin.host
+        and origin.scheme == "http"
+        and origin.port == 80
+        and location_origin.scheme == "https"
+        and location_origin.port == 443
     )
-
-
-def _port_or_default(url: URL) -> int | None:
-    if url.port is not None:
-        return url.port
-    return {"http": 80, "https": 443}.get(url.scheme)
 
 
 def _same_origin(url: URL, other: URL) -> bool:
     """
     Return 'True' if the given URLs share the same origin.
     """
-    return url.scheme == other.scheme and url.host == other.host and _port_or_default(url) == _port_or_default(other)
+    return url.origin == other.origin
 
 
 class UseClientDefault:

--- a/src/httpx2/httpx2/_client.py
+++ b/src/httpx2/httpx2/_client.py
@@ -84,13 +84,6 @@ def _is_https_redirect(url: URL, location: URL) -> bool:
     )
 
 
-def _same_origin(url: URL, other: URL) -> bool:
-    """
-    Return 'True' if the given URLs share the same origin.
-    """
-    return url.origin == other.origin
-
-
 class UseClientDefault:
     """
     For some parameters such as `auth=...` and `timeout=...` we need to be able
@@ -529,7 +522,7 @@ class BaseClient:
         """
         headers = Headers(request.headers)
 
-        if not _same_origin(url, request.url):
+        if url.origin != request.url.origin:
             if not _is_https_redirect(request.url, url):
                 # Strip Authorization headers when responses are redirected
                 # away from the origin. (Except for direct HTTP to HTTPS redirects.)

--- a/src/httpx2/httpx2/_urls.py
+++ b/src/httpx2/httpx2/_urls.py
@@ -445,6 +445,8 @@ class Origin:
     The scheme, host, and effective port of a URL.
 
     Origins are normalized, immutable, comparable, and hashable.
+    See RFC 9110, Section 4.3.1:
+    https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin
     """
 
     scheme: str

--- a/src/httpx2/httpx2/_urls.py
+++ b/src/httpx2/httpx2/_urls.py
@@ -445,8 +445,8 @@ class Origin:
     The scheme, host, and effective port of a URL.
 
     Origins are normalized, immutable, comparable, and hashable.
-    See RFC 9110, Section 4.3.1:
-    https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin
+
+    See RFC 9110, Section 4.3.1: https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin
     """
 
     scheme: str
@@ -464,7 +464,7 @@ class Origin:
         if b":" in url.raw_host:
             # IPv6 addresses may have multiple equivalent string forms. Store
             # their canonical compressed form so origin equality is numeric.
-            host = str(ipaddress.IPv6Address(unquote(url.raw_host.decode("ascii"))))
+            host = str(ipaddress.IPv6Address(url.raw_host.decode("ascii")))
 
         port = url.port
         if port is None:

--- a/src/httpx2/httpx2/_urls.py
+++ b/src/httpx2/httpx2/_urls.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ipaddress
 import sys
 import typing
+from dataclasses import dataclass
 from urllib.parse import parse_qs, unquote, urlencode
 
 import idna
@@ -18,15 +19,6 @@ from ._urlparse import urlparse
 from ._utils import primitive_value_to_str
 
 __all__ = ["URL", "Origin", "QueryParams"]
-
-
-_ORIGIN_DEFAULT_PORTS = {
-    "ftp": 21,
-    "http": 80,
-    "https": 443,
-    "ws": 80,
-    "wss": 443,
-}
 
 
 class URL:
@@ -438,6 +430,16 @@ class URL:
         )
 
 
+_ORIGIN_DEFAULT_PORTS = {
+    "ftp": 21,
+    "http": 80,
+    "https": 443,
+    "ws": 80,
+    "wss": 443,
+}
+
+
+@dataclass(frozen=True, slots=True, init=False)
 class Origin:
     """
     The scheme, host, and effective port of a URL.
@@ -445,7 +447,9 @@ class Origin:
     Origins are normalized, immutable, comparable, and hashable.
     """
 
-    __slots__ = ("_scheme", "_host", "_port")
+    scheme: str
+    host: str
+    port: int | None
 
     def __init__(self, url: URL | str) -> None:
         if not isinstance(url, URL):
@@ -458,41 +462,15 @@ class Origin:
         if b":" in url.raw_host:
             # IPv6 addresses may have multiple equivalent string forms. Store
             # their canonical compressed form so origin equality is numeric.
-            host = str(ipaddress.IPv6Address(url.raw_host.decode("ascii")))
+            host = str(ipaddress.IPv6Address(unquote(url.raw_host.decode("ascii"))))
 
         port = url.port
         if port is None:
             port = _ORIGIN_DEFAULT_PORTS.get(url.scheme)
 
-        self._scheme = url.scheme
-        self._host = host
-        self._port = port
-
-    @property
-    def scheme(self) -> str:
-        return self._scheme
-
-    @property
-    def host(self) -> str:
-        return self._host
-
-    @property
-    def port(self) -> int | None:
-        return self._port
-
-    def __eq__(self, other: typing.Any) -> bool:
-        return (
-            isinstance(other, Origin)
-            and self.scheme == other.scheme
-            and self.host == other.host
-            and self.port == other.port
-        )
-
-    def __hash__(self) -> int:
-        return hash((self.scheme, self.host, self.port))
-
-    def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(scheme={self.scheme!r}, host={self.host!r}, port={self.port!r})"
+        object.__setattr__(self, "scheme", url.scheme)
+        object.__setattr__(self, "host", host)
+        object.__setattr__(self, "port", port)
 
 
 class QueryParams(typing.Mapping[str, str]):

--- a/src/httpx2/httpx2/_urls.py
+++ b/src/httpx2/httpx2/_urls.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ipaddress
 import sys
 import typing
 from urllib.parse import parse_qs, unquote, urlencode
@@ -16,7 +17,16 @@ from ._types import QueryParamTypes
 from ._urlparse import urlparse
 from ._utils import primitive_value_to_str
 
-__all__ = ["URL", "QueryParams"]
+__all__ = ["URL", "Origin", "QueryParams"]
+
+
+_ORIGIN_DEFAULT_PORTS = {
+    "ftp": 21,
+    "http": 80,
+    "https": 443,
+    "ws": 80,
+    "wss": 443,
+}
 
 
 class URL:
@@ -328,6 +338,16 @@ class URL:
         """
         return not self.is_absolute_url
 
+    @property
+    def origin(self) -> Origin:
+        """
+        The URL origin as an immutable, hashable `Origin` value.
+
+        The origin consists of the URL scheme, host, and effective port.
+        User information, path, query, and fragment components are excluded.
+        """
+        return Origin(self)
+
     def copy_with(self, **kwargs: typing.Any) -> URL:
         """
         Copy this URL, returning a new URL with some components altered.
@@ -416,6 +436,63 @@ class URL:
             port=self.port,
             raw_path=self.raw_path,
         )
+
+
+class Origin:
+    """
+    The scheme, host, and effective port of a URL.
+
+    Origins are normalized, immutable, comparable, and hashable.
+    """
+
+    __slots__ = ("_scheme", "_host", "_port")
+
+    def __init__(self, url: URL | str) -> None:
+        if not isinstance(url, URL):
+            url = URL(url)
+
+        if url.is_relative_url:
+            raise ValueError("URL must be absolute to have an origin")
+
+        host = url.host
+        if b":" in url.raw_host:
+            # IPv6 addresses may have multiple equivalent string forms. Store
+            # their canonical compressed form so origin equality is numeric.
+            host = str(ipaddress.IPv6Address(url.raw_host.decode("ascii")))
+
+        port = url.port
+        if port is None:
+            port = _ORIGIN_DEFAULT_PORTS.get(url.scheme)
+
+        self._scheme = url.scheme
+        self._host = host
+        self._port = port
+
+    @property
+    def scheme(self) -> str:
+        return self._scheme
+
+    @property
+    def host(self) -> str:
+        return self._host
+
+    @property
+    def port(self) -> int | None:
+        return self._port
+
+    def __eq__(self, other: typing.Any) -> bool:
+        return (
+            isinstance(other, Origin)
+            and self.scheme == other.scheme
+            and self.host == other.host
+            and self.port == other.port
+        )
+
+    def __hash__(self) -> int:
+        return hash((self.scheme, self.host, self.port))
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(scheme={self.scheme!r}, host={self.host!r}, port={self.port!r})"
 
 
 class QueryParams(typing.Mapping[str, str]):

--- a/tests/httpx2/client/test_headers.py
+++ b/tests/httpx2/client/test_headers.py
@@ -258,6 +258,16 @@ def test_not_same_origin() -> None:
     assert headers["Host"] == origin.netloc.decode("ascii")
 
 
+def test_not_same_origin_with_percent_encoded_ipv6_scope() -> None:
+    origin = httpx2.URL("https://[2001:db8::10]")
+    request = httpx2.Request("GET", "https://[2001:db8::1%30]", headers={"Authorization": "secret"})
+
+    client = httpx2.Client()
+    headers = client._redirect_headers(request, origin, "GET")
+
+    assert "Authorization" not in headers
+
+
 def test_is_https_redirect() -> None:
     url = httpx2.URL("https://example.com")
     request = httpx2.Request("GET", "http://example.com", headers={"Authorization": "empty"})

--- a/tests/httpx2/client/test_headers.py
+++ b/tests/httpx2/client/test_headers.py
@@ -238,6 +238,16 @@ def test_same_origin() -> None:
     assert headers["Host"] == request.url.netloc.decode("ascii")
 
 
+def test_same_origin_with_equivalent_ipv6_addresses() -> None:
+    origin = httpx2.URL("https://[0:0:0:0:0:0:0:1]/redirected")
+    request = httpx2.Request("GET", "https://[::1]/", headers={"Authorization": "secret"})
+
+    client = httpx2.Client()
+    headers = client._redirect_headers(request, origin, "GET")
+
+    assert headers["Authorization"] == "secret"
+
+
 def test_not_same_origin() -> None:
     origin = httpx2.URL("https://example.com")
     request = httpx2.Request("GET", "HTTP://EXAMPLE.COM:80")
@@ -256,6 +266,16 @@ def test_is_https_redirect() -> None:
     headers = client._redirect_headers(request, url, "GET")
 
     assert "Authorization" in headers
+
+
+def test_is_https_redirect_with_equivalent_ipv6_addresses() -> None:
+    url = httpx2.URL("https://[0:0:0:0:0:0:0:1]")
+    request = httpx2.Request("GET", "http://[::1]", headers={"Authorization": "secret"})
+
+    client = httpx2.Client()
+    headers = client._redirect_headers(request, url, "GET")
+
+    assert headers["Authorization"] == "secret"
 
 
 def test_is_not_https_redirect() -> None:

--- a/tests/httpx2/models/test_url.py
+++ b/tests/httpx2/models/test_url.py
@@ -116,6 +116,7 @@ def test_origin_effective_port(url: str, scheme: str, port: int | None) -> None:
         ("https://[2001:db8::1]", "https://[2001:0db8:0:0:0:0:0:1]"),
         ("https://[::ffff:192.168.0.1]", "https://[::ffff:c0a8:1]"),
         ("https://[fe80::1%25eth0]", "https://[fe80:0:0:0:0:0:0:1%25eth0]"),
+        ("https://[fe80::1%eth0]", "https://[fe80::1%25eth0]"),
     ],
 )
 def test_equivalent_origins(left: str, right: str) -> None:

--- a/tests/httpx2/models/test_url.py
+++ b/tests/httpx2/models/test_url.py
@@ -116,7 +116,6 @@ def test_origin_effective_port(url: str, scheme: str, port: int | None) -> None:
         ("https://[2001:db8::1]", "https://[2001:0db8:0:0:0:0:0:1]"),
         ("https://[::ffff:192.168.0.1]", "https://[::ffff:c0a8:1]"),
         ("https://[fe80::1%25eth0]", "https://[fe80:0:0:0:0:0:0:1%25eth0]"),
-        ("https://[fe80::1%eth0]", "https://[fe80::1%25eth0]"),
     ],
 )
 def test_equivalent_origins(left: str, right: str) -> None:
@@ -132,6 +131,8 @@ def test_equivalent_origins(left: str, right: str) -> None:
         ("https://example.com", "https://example.com:444"),
         ("https://[::1]", "https://[::2]"),
         ("https://[fe80::1%25eth0]", "https://[fe80::1%25eth1]"),
+        ("https://[fe80::1%eth0]", "https://[fe80::1%25eth0]"),
+        ("https://[2001:db8::1%30]", "https://[2001:db8::10]"),
     ],
 )
 def test_distinct_origins(left: str, right: str) -> None:
@@ -142,6 +143,10 @@ def test_distinct_origins(left: str, right: str) -> None:
 def test_relative_url_does_not_have_origin(url: str) -> None:
     with pytest.raises(ValueError, match="URL must be absolute to have an origin"):
         _ = httpx2.URL(url).origin
+
+
+def test_origin_preserves_percent_escaped_ipv6_scope() -> None:
+    assert httpx2.Origin("https://[2001:db8::1%2e]").host == "2001:db8::1%2e"
 
 
 # Tests for percent encoding across path, query, and fragment...

--- a/tests/httpx2/models/test_url.py
+++ b/tests/httpx2/models/test_url.py
@@ -67,6 +67,82 @@ def test_url_no_authority() -> None:
     assert url.path == "/"
 
 
+def test_origin() -> None:
+    url = httpx2.URL("https://user:password@example.com/path?query#fragment")
+
+    assert url.origin == httpx2.Origin("https://example.com")
+    assert url.origin.scheme == "https"
+    assert url.origin.host == "example.com"
+    assert url.origin.port == 443
+    assert repr(url.origin) == "Origin(scheme='https', host='example.com', port=443)"
+
+
+def test_origin_is_immutable_and_hashable() -> None:
+    origin = httpx2.Origin("https://example.com")
+
+    with pytest.raises(AttributeError):
+        origin.host = "other.example.com"  # type: ignore[misc]
+
+    assert {origin, httpx2.Origin("HTTPS://EXAMPLE.COM:443")} == {origin}
+
+
+@pytest.mark.parametrize(
+    "url,scheme,port",
+    [
+        ("ftp://example.com", "ftp", 21),
+        ("http://example.com", "http", 80),
+        ("https://example.com", "https", 443),
+        ("ws://example.com/socket", "ws", 80),
+        ("wss://example.com/socket", "wss", 443),
+        ("custom://example.com", "custom", None),
+        ("custom://example.com:1234", "custom", 1234),
+    ],
+)
+def test_origin_effective_port(url: str, scheme: str, port: int | None) -> None:
+    origin = httpx2.Origin(url)
+
+    assert origin.scheme == scheme
+    assert origin.port == port
+
+
+@pytest.mark.parametrize(
+    "left,right",
+    [
+        ("https://example.com", "HTTPS://EXAMPLE.COM:443"),
+        ("https://中国.icom.museum", "https://xn--fiqs8s.icom.museum:443"),
+        ("ws://example.com/socket", "ws://example.com:80/other"),
+        ("wss://example.com/socket", "wss://example.com:443/other"),
+        ("https://[::1]", "https://[0:0:0:0:0:0:0:1]"),
+        ("https://[2001:db8::1]", "https://[2001:0db8:0:0:0:0:0:1]"),
+        ("https://[::ffff:192.168.0.1]", "https://[::ffff:c0a8:1]"),
+        ("https://[fe80::1%25eth0]", "https://[fe80:0:0:0:0:0:0:1%25eth0]"),
+    ],
+)
+def test_equivalent_origins(left: str, right: str) -> None:
+    assert httpx2.URL(left).origin == httpx2.URL(right).origin
+
+
+@pytest.mark.parametrize(
+    "left,right",
+    [
+        ("http://example.com", "https://example.com"),
+        ("http://example.com", "ws://example.com"),
+        ("https://example.com", "wss://example.com"),
+        ("https://example.com", "https://example.com:444"),
+        ("https://[::1]", "https://[::2]"),
+        ("https://[fe80::1%25eth0]", "https://[fe80::1%25eth1]"),
+    ],
+)
+def test_distinct_origins(left: str, right: str) -> None:
+    assert httpx2.URL(left).origin != httpx2.URL(right).origin
+
+
+@pytest.mark.parametrize("url", ["", "/path", "mailto:user@example.com", "file:///tmp/example"])
+def test_relative_url_does_not_have_origin(url: str) -> None:
+    with pytest.raises(ValueError, match="URL must be absolute to have an origin"):
+        _ = httpx2.URL(url).origin
+
+
 # Tests for percent encoding across path, query, and fragment...
 
 


### PR DESCRIPTION
## Summary

- add a public, immutable, and hashable `Origin` value object
- expose normalized origins through `URL.origin`
- support effective ports for FTP, HTTP(S), and WS(S), including canonical IPv6 comparison
- use the shared value object for existing origin comparisons
- document and test the public API

## Motivation

Applications and integrations sometimes need a reusable representation of a URL's scheme, host, and effective port. `Origin` provides that representation without including user information, paths, queries, or fragments.

## Testing

- `pytest`: 1,967 passed, 1 skipped
- `ruff format --check --diff`
- `ruff check`
- `mypy src/httpx2 tests/httpx2 src/httpcore2 tests/httpcore2`
- `python scripts/unasync.py --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

