### PR TITLE
Restore deprecated status code aliases

### DIFF
--- a/src/httpx2/httpx2/_status_codes.py
+++ b/src/httpx2/httpx2/_status_codes.py
@@ -16,7 +16,7 @@ _DEPRECATED_CODES = {
 
 
 class _CodesMeta(EnumMeta):
-    def __getattr__(cls, name: str) -> codes:
+    def __getattribute__(cls, name: str) -> object:
         if name in _DEPRECATED_CODES:
             new_name = _DEPRECATED_CODES[name]
             warnings.warn(
@@ -24,8 +24,7 @@ class _CodesMeta(EnumMeta):
                 category=DeprecationWarning,
                 stacklevel=2,
             )
-            return cls[new_name]
-        raise AttributeError(name)
+        return super().__getattribute__(name)
 
 
 class codes(IntEnum, metaclass=_CodesMeta):
@@ -178,7 +177,13 @@ class codes(IntEnum, metaclass=_CodesMeta):
     NOT_EXTENDED = 510, "Not Extended"
     NETWORK_AUTHENTICATION_REQUIRED = 511, "Network Authentication Required"
 
+    # Deprecated aliases for names replaced by RFC 9110.
+    REQUEST_ENTITY_TOO_LARGE = CONTENT_TOO_LARGE
+    REQUEST_URI_TOO_LONG = URI_TOO_LONG
+    REQUESTED_RANGE_NOT_SATISFIABLE = RANGE_NOT_SATISFIABLE
+    UNPROCESSABLE_ENTITY = UNPROCESSABLE_CONTENT
+
 
 # Include lower-case styles for `requests` compatibility.
-for code in codes:
-    setattr(codes, code._name_.lower(), int(code))
+for name, code in codes.__members__.items():
+    setattr(codes, name.lower(), int(code))

--- a/tests/httpx2/test_status_codes.py
+++ b/tests/httpx2/test_status_codes.py
@@ -51,6 +51,10 @@ def test_pre_rfc9110_aliases_are_deprecated(old_name: str, new_name: str) -> Non
     with pytest.warns(DeprecationWarning, match=msg):
         assert getattr(httpx2.codes, old_name) == httpx2.codes[new_name]
 
+    assert old_name in httpx2.codes.__members__
+    assert httpx2.codes[old_name] == httpx2.codes[new_name]
+    assert getattr(httpx2.codes, old_name.lower()) == httpx2.codes[new_name]
+
 
 def test_unknown_status_code_attribute_raises() -> None:
     name = "NOT_A_REAL_CODE"


### PR DESCRIPTION
# Summary

Restore the pre-RFC 9110 status-code names as real enum aliases while retaining deprecation warnings for uppercase attribute access.

This restores compatibility for:

- enum by-name lookup, such as `codes["REQUEST_ENTITY_TOO_LARGE"]`
- membership in `codes.__members__`
- lowercase requests-style attributes, such as `codes.request_entity_too_large`

Tests now cover all supported deprecated-alias access patterns.

# Tests

- `uv run pytest tests/httpx2/test_status_codes.py`
- `uv run ruff check src/httpx2/httpx2/_status_codes.py tests/httpx2/test_status_codes.py`
- `uv run ruff format --check src/httpx2/httpx2/_status_codes.py tests/httpx2/test_status_codes.py`
- `uv run mypy src/httpx2/httpx2/_status_codes.py tests/httpx2/test_status_codes.py`

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] Documentation is not affected by this compatibility fix.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

