### PR TITLE
Fix changelog extraction regex for H2 release headings

### DIFF
--- a/src/httpx2/pyproject.toml
+++ b/src/httpx2/pyproject.toml
@@ -106,7 +106,7 @@ text = "\n## Release Information\n\n"
 
 [[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
 path = "CHANGELOG.md"
-pattern = "\n(###.+?\n)## "
+pattern = "\n(## [0-9].+?)(?=\n## |$)"
 
 [[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
 text = "\n---\n\n[Full changelog](https://github.com/pydantic/httpx2/blob/main/src/httpx2/CHANGELOG.md)\n"


### PR DESCRIPTION
The changelog now uses H2 headings for releases (`## 2.10.0`), but the `hatch-fancy-pypi-readme` fragment pattern in `src/httpx2/pyproject.toml` still expected the extracted release section to start with an H3 heading (`\n(###.+?\n)## `). As a result, the generated PyPI README's Release Information section started at the first subsection (e.g. `### Added`) and omitted the release heading and any leading bullets.

This updates the pattern to `\n(## [0-9].+?)(?=\n## |$)`, which skips the `Unreleased` section, captures the complete latest release section, and stops at the next release heading (or end of file when only one release exists).

Validated by building the `httpx2` wheel and confirming the metadata now contains the full `2.10.0` section while excluding `Unreleased` and `2.9.1`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

