### PR TITLE
Respect explicit Transfer-Encoding headers

### DIFF
--- a/src/httpx2/httpx2/_models.py
+++ b/src/httpx2/httpx2/_models.py
@@ -452,7 +452,10 @@ class Request:
 
     def _prepare(self, default_headers: dict[str, str]) -> None:
         for key, value in default_headers.items():
-            # Ignore Transfer-Encoding if the Content-Length has been set explicitly.
+            # Ignore Content-Length if Transfer-Encoding has been set explicitly.
+            if key.lower() == "content-length" and "Transfer-Encoding" in self.headers:
+                continue
+            # Ignore Transfer-Encoding if Content-Length has been set explicitly.
             if key.lower() == "transfer-encoding" and "Content-Length" in self.headers:
                 continue
             self.headers.setdefault(key, value)

--- a/src/httpx2/httpx2/_transports/wsgi.py
+++ b/src/httpx2/httpx2/_transports/wsgi.py
@@ -107,6 +107,8 @@ class WSGITransport(BaseTransport):
             "SERVER_PROTOCOL": "HTTP/1.1",
             "REMOTE_ADDR": self.remote_addr,
         }
+        if request.content and "Content-Length" not in request.headers:
+            environ["CONTENT_LENGTH"] = str(len(request.content))
         for header_key, header_value in request.headers.raw:
             key = header_key.decode("ascii").upper().replace("-", "_")
             if key not in ("CONTENT_TYPE", "CONTENT_LENGTH"):

--- a/tests/httpx2/models/test_requests.py
+++ b/tests/httpx2/models/test_requests.py
@@ -23,6 +23,13 @@ def test_content_length_header() -> None:
     assert request.headers["Content-Length"] == "8"
 
 
+def test_ignore_content_length_header_if_transfer_encoding_exists() -> None:
+    headers = {"Transfer-Encoding": "chunked"}
+    request = httpx2.Request("POST", "http://example.org", content=b"test 123", headers=headers)
+    assert request.headers["Transfer-Encoding"] == "chunked"
+    assert "Content-Length" not in request.headers
+
+
 def test_iterable_content() -> None:
     class Content:
         def __iter__(self) -> typing.Iterator[bytes]:

--- a/tests/httpx2/test_wsgi.py
+++ b/tests/httpx2/test_wsgi.py
@@ -102,6 +102,24 @@ def test_wsgi_upload() -> None:
     assert response.text == "example"
 
 
+def test_wsgi_upload_with_transfer_encoding() -> None:
+    def app(environ: WSGIEnvironment, start_response: StartResponse) -> typing.Iterable[bytes]:
+        content_length = int(environ.get("CONTENT_LENGTH", "0"))
+        output = environ["wsgi.input"].read(content_length)
+        start_response("200 OK", [("Content-Type", "text/plain")])
+        return [output]
+
+    transport = httpx2.WSGITransport(app=app)
+    client = httpx2.Client(transport=transport)
+    response = client.post(
+        "http://www.example.org/",
+        headers={"Transfer-Encoding": "chunked"},
+        content=b"example",
+    )
+    assert response.status_code == 200
+    assert response.text == "example"
+
+
 def test_wsgi_upload_with_response_stream() -> None:
     transport = httpx2.WSGITransport(app=echo_body_with_response_stream)
     client = httpx2.Client(transport=transport)


### PR DESCRIPTION
# Summary

`Request._prepare()` already keeps an explicit `Content-Length` when the content encoder provides a default `Transfer-Encoding`. This applies the same precedence in the other direction: an explicit `Transfer-Encoding` now takes precedence over a body-derived `Content-Length`.

This makes handling of explicit framing headers consistent for fixed and streaming request content, and adds regression coverage for fixed content.

`WSGITransport` buffers request bodies before constructing the WSGI environment. When a buffered body has no explicit `Content-Length`, the transport now exposes its known length as `CONTENT_LENGTH` so WSGI applications can consume the input normally.

## Validation

- `pytest tests/httpx2/models/test_requests.py tests/httpx2/test_wsgi.py -q` — 38 passed
- `pytest tests/httpx2 -q` — 1721 passed, 1 skipped
- `scripts/check` — passed

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] No documentation update is needed for this internal request-preparation consistency change.
