### PR TITLE
Replace `--no-verify` flag with `--verify`

### DIFF
--- a/src/httpx2/httpx2/_main.py
+++ b/src/httpx2/httpx2/_main.py
@@ -393,11 +393,11 @@ def handle_help(
     help="Automatically follow redirects.",
 )
 @click.option(
-    "--no-verify",
+    "--verify",
     "verify",
-    is_flag=True,
+    type=bool,
     default=True,
-    help="Disable SSL verification.",
+    help="Enable SSL verification.",
 )
 @click.option(
     "--http2",


### PR DESCRIPTION
# Summary

Fixes the CLI `--no-verify` flag so it actually disables TLS certificate verification when used.

Edit:

After some discussion, the flag was changed from `--no-verify` to `--verify`.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

