### PR TITLE
Require brotli 1.2.0 in the brotli extra

### DIFF
--- a/src/httpx2/pyproject.toml
+++ b/src/httpx2/pyproject.toml
@@ -55,8 +55,8 @@ dependencies = [
 
 [project.optional-dependencies]
 brotli = [
-    "brotli; platform_python_implementation == 'CPython'",
-    "brotlicffi; platform_python_implementation != 'CPython'",
+    "brotli>=1.2.0; platform_python_implementation == 'CPython'",
+    "brotlicffi>=1.2.0.0; platform_python_implementation != 'CPython'",
 ]
 cli = [
     "click>=8.4.2",

--- a/uv.lock
+++ b/uv.lock
@@ -1515,8 +1515,8 @@ zstd = [
 [package.metadata]
 requires-dist = [
     { name = "anyio", marker = "sys_platform != 'emscripten'", specifier = ">=4.10" },
-    { name = "brotli", marker = "platform_python_implementation == 'CPython' and extra == 'brotli'" },
-    { name = "brotlicffi", marker = "platform_python_implementation != 'CPython' and extra == 'brotli'" },
+    { name = "brotli", marker = "platform_python_implementation == 'CPython' and extra == 'brotli'", specifier = ">=1.2.0" },
+    { name = "brotlicffi", marker = "platform_python_implementation != 'CPython' and extra == 'brotli'", specifier = ">=1.2.0.0" },
     { name = "click", marker = "extra == 'cli'", specifier = ">=8.4.2" },
     { name = "h2", marker = "extra == 'http2'", specifier = ">=3,<5" },
     { name = "httpcore2", marker = "sys_platform != 'emscripten'", editable = "src/httpcore2" },


### PR DESCRIPTION
# Summary

Raise the minimum `brotli` / `brotlicffi` in the `brotli` extra to the first release that can bound decompression output.

`brotli 1.2.0` (2025-11-05) adds an `output_buffer_limit` argument to `Decompressor.process()`, along with a companion `can_accept_more_data()` method:

```
process(data, output_buffer_limit=int) -> bytes
```

Without it, a single `process()` call inflates a whole chunk in one allocation, so there is no way to decode a brotli body in bounded pieces. Requiring `1.2.0` lets the decoders rely on that argument being present rather than probing for it at runtime.

This is split out from #1126 so the packaging change lands on its own, ahead of the decoder work that depends on it.

Wheel coverage is not reduced for any supported interpreter: `1.2.0` ships wheels for cp310–cp314, whereas `1.1.0` stopped at cp313.

## Validation

- `pytest tests/httpx2 -q` — 1721 passed, 1 skipped
- `scripts/check` — passed

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] No test accompanies this change, as it only raises a dependency floor.
- [x] No documentation update is needed for this dependency change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

