### PR TITLE
Validate multipart part headers

### DIFF
--- a/src/httpx2/httpx2/_multipart.py
+++ b/src/httpx2/httpx2/_multipart.py
@@ -24,6 +24,13 @@ from ._utils import (
 _HTML5_FORM_ENCODING_REPLACEMENTS = {'"': "%22", "\\": "\\\\"}
 _HTML5_FORM_ENCODING_REPLACEMENTS.update({chr(c): f"%{c:02X}" for c in range(0x1F + 1) if c != 0x1B})
 _HTML5_FORM_ENCODING_RE = re.compile(r"|".join([re.escape(c) for c in _HTML5_FORM_ENCODING_REPLACEMENTS.keys()]))
+_FORBIDDEN_HEADER_CHARS_RE = re.compile(r"[\x00-\x08\x0a-\x1f\x7f]")
+
+
+def _safe_header(value: str) -> str:
+    if _FORBIDDEN_HEADER_CHARS_RE.search(value) is not None:
+        raise ValueError("Invalid control character in multipart header.")
+    return value
 
 
 def _format_form_param(name: str, value: str) -> bytes:
@@ -176,7 +183,8 @@ class FileField:
                 filename = _format_form_param("filename", self.filename)
                 parts.extend([b"; ", filename])
             for header_name, header_value in self.headers.items():
-                key, val = f"\r\n{header_name}: ".encode(), header_value.encode()
+                key = f"\r\n{_safe_header(header_name)}: ".encode()
+                val = _safe_header(header_value).encode()
                 parts.extend([key, val])
             parts.append(b"\r\n\r\n")
             self._headers = b"".join(parts)

--- a/src/httpx2/httpx2/_multipart.py
+++ b/src/httpx2/httpx2/_multipart.py
@@ -24,13 +24,8 @@ from ._utils import (
 _HTML5_FORM_ENCODING_REPLACEMENTS = {'"': "%22", "\\": "\\\\"}
 _HTML5_FORM_ENCODING_REPLACEMENTS.update({chr(c): f"%{c:02X}" for c in range(0x1F + 1) if c != 0x1B})
 _HTML5_FORM_ENCODING_RE = re.compile(r"|".join([re.escape(c) for c in _HTML5_FORM_ENCODING_REPLACEMENTS.keys()]))
-_FORBIDDEN_HEADER_CHARS_RE = re.compile(r"[\x00-\x08\x0a-\x1f\x7f]")
-
-
-def _safe_header(value: str) -> str:
-    if _FORBIDDEN_HEADER_CHARS_RE.search(value) is not None:
-        raise ValueError("Invalid control character in multipart header.")
-    return value
+_HEADER_NAME_RE = re.compile(r"[!#$%&'*+\-.^_`|~0-9A-Za-z]+")
+_FORBIDDEN_HEADER_VALUE_CHARS_RE = re.compile(r"[\x00-\x08\x0a-\x1f\x7f]")
 
 
 def _format_form_param(name: str, value: str) -> bytes:
@@ -183,8 +178,11 @@ class FileField:
                 filename = _format_form_param("filename", self.filename)
                 parts.extend([b"; ", filename])
             for header_name, header_value in self.headers.items():
-                key = f"\r\n{_safe_header(header_name)}: ".encode()
-                val = _safe_header(header_value).encode()
+                if _HEADER_NAME_RE.fullmatch(header_name) is None:
+                    raise ValueError("Invalid multipart header name.")
+                if _FORBIDDEN_HEADER_VALUE_CHARS_RE.search(header_value) is not None:
+                    raise ValueError("Invalid control character in multipart header value.")
+                key, val = f"\r\n{header_name}: ".encode(), header_value.encode()
                 parts.extend([key, val])
             parts.append(b"\r\n\r\n")
             self._headers = b"".join(parts)

--- a/tests/httpx2/test_multipart.py
+++ b/tests/httpx2/test_multipart.py
@@ -205,6 +205,28 @@ def test_multipart_headers_include_content_type() -> None:
     )
 
 
+@pytest.mark.parametrize("control_character", ["\x00", "\x01", "\x08", "\n", "\r", "\x1f", "\x7f"])
+def test_multipart_rejects_control_characters_in_file_content_type(control_character: str) -> None:
+    files = {"file": ("test.txt", b"<file content>", f"text/plain{control_character}suffix")}
+
+    with pytest.raises(ValueError, match="Invalid control character in multipart header"):
+        httpx2.Request("POST", "https://www.example.com/", files=files)
+
+
+@pytest.mark.parametrize(
+    "file_headers",
+    [
+        {"X-Test\r": "value"},
+        {"X-Test": "value\n"},
+    ],
+)
+def test_multipart_rejects_crlf_in_file_headers(file_headers: dict[str, str]) -> None:
+    files = {"file": ("test.txt", b"<file content>", None, file_headers)}
+
+    with pytest.raises(ValueError, match="Invalid control character in multipart header"):
+        httpx2.Request("POST", "https://www.example.com/", files=files)
+
+
 def test_multipart_encode(tmp_path: typing.Any) -> None:
     path = str(tmp_path / "name.txt")
     with open(path, "wb") as f:

--- a/tests/httpx2/test_multipart.py
+++ b/tests/httpx2/test_multipart.py
@@ -205,25 +205,18 @@ def test_multipart_headers_include_content_type() -> None:
     )
 
 
-@pytest.mark.parametrize("control_character", ["\x00", "\x01", "\x08", "\n", "\r", "\x1f", "\x7f"])
-def test_multipart_rejects_control_characters_in_file_content_type(control_character: str) -> None:
-    files = {"file": ("test.txt", b"<file content>", f"text/plain{control_character}suffix")}
-
-    with pytest.raises(ValueError, match="Invalid control character in multipart header"):
-        httpx2.Request("POST", "https://www.example.com/", files=files)
-
-
 @pytest.mark.parametrize(
-    "file_headers",
+    ("content_type", "file_headers"),
     [
-        {"X-Test\r": "value"},
-        {"X-Test": "value\n"},
+        ("text/plain\r", {}),
+        (None, {"X-Test\t": "value"}),
+        (None, {"X-Test": "value\n"}),
     ],
 )
-def test_multipart_rejects_crlf_in_file_headers(file_headers: dict[str, str]) -> None:
-    files = {"file": ("test.txt", b"<file content>", None, file_headers)}
+def test_multipart_rejects_invalid_file_headers(content_type: str | None, file_headers: dict[str, str]) -> None:
+    files = {"file": ("test.txt", b"<file content>", content_type, file_headers)}
 
-    with pytest.raises(ValueError, match="Invalid control character in multipart header"):
+    with pytest.raises(ValueError, match="Invalid .*multipart header"):
         httpx2.Request("POST", "https://www.example.com/", files=files)
 
 

--- a/tests/httpx2/test_multipart.py
+++ b/tests/httpx2/test_multipart.py
@@ -220,6 +220,14 @@ def test_multipart_rejects_invalid_file_headers(content_type: str | None, file_h
         httpx2.Request("POST", "https://www.example.com/", files=files)
 
 
+@pytest.mark.parametrize("control_character", ["\x00", "\x01", "\x08", "\x1f", "\x7f"])
+def test_multipart_rejects_control_characters_in_file_header_values(control_character: str) -> None:
+    files = {"file": ("test.txt", b"<file content>", None, {"X-Test": f"value{control_character}"})}
+
+    with pytest.raises(ValueError, match="Invalid control character in multipart header value"):
+        httpx2.Request("POST", "https://www.example.com/", files=files)
+
+
 def test_multipart_encode(tmp_path: typing.Any) -> None:
     path = str(tmp_path / "name.txt")
     with open(path, "wb") as f:


### PR DESCRIPTION
## Summary

- validate multipart file header names and values before serialization
- reject control characters disallowed in HTTP field lines
- cover custom file content types and headers

## Validation

- `uv run pytest tests/httpx2/test_multipart.py -q`
- `uv run pytest tests/httpx2 -q`
- `scripts/check`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

