### PR TITLE
Version 2.11.0

### DIFF
--- a/src/httpcore2/CHANGELOG.md
+++ b/src/httpcore2/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2.11.0 (August 18th, 2026)
+
+### Changed
+
+* Cache sniffio availability instead of importing it on every synchronization call.
+  ([#1132](https://github.com/pydantic/httpx2/pull/1132))
+
 ## 2.10.0 (August 9th, 2026)
 
 ### Added

--- a/src/httpx2/CHANGELOG.md
+++ b/src/httpx2/CHANGELOG.md
@@ -4,12 +4,25 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
+## 2.11.0 (August 18th, 2026)
 
 ### Added
 
 * Add the public `Origin` value object and `URL.origin` property for normalized,
   hashable origin comparisons. ([#1134](https://github.com/pydantic/httpx2/pull/1134))
+
+### Changed
+
+* Require Brotli 1.2.0 or later for the `brotli` extra. ([#1141](https://github.com/pydantic/httpx2/pull/1141))
+
+### Fixed
+
+* Restore deprecated status code aliases. ([#1135](https://github.com/pydantic/httpx2/pull/1135))
+* Extract HTTP/2 release notes from changelog headings correctly. ([#1136](https://github.com/pydantic/httpx2/pull/1136))
+* Respect explicit `Transfer-Encoding` headers and expose buffered request body lengths to WSGI applications.
+  ([#1137](https://github.com/pydantic/httpx2/pull/1137))
+* Validate multipart part header names and values before serialization.
+  ([#1142](https://github.com/pydantic/httpx2/pull/1142))
 
 ## 2.10.0 (August 9th, 2026)
 


### PR DESCRIPTION
Cut `2.11.0` for `httpx2` and `httpcore2`.

## Validation

- `scripts/check`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

