### PR TITLE
Publish distributions with uv trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - "**"
   workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref to build and publish
+        required: false
+        type: string
 
 permissions: {}
 
@@ -20,6 +25,7 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
@@ -64,8 +70,13 @@ jobs:
           name: package-distributions
           path: dist/
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: false
+
       - name: Publish distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
+        run: uv publish --trusted-publishing always dist/*
 
   docs-cloudflare:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,11 +5,6 @@ on:
     tags:
       - "**"
   workflow_dispatch:
-    inputs:
-      ref:
-        description: Git ref to build and publish
-        required: false
-        type: string
 
 permissions: {}
 
@@ -25,7 +20,6 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
-          ref: ${{ inputs.ref || github.ref }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0


### PR DESCRIPTION
## Summary

Publish distributions with `uv publish --trusted-publishing always`.

## Motivation

The `2.11.0` publish job failed before uploading because the existing publisher rejected Core Metadata `2.5`. `uv publish --dry-run` accepts all four release artifacts.

## Validation

- `scripts/check`
- `uv publish --dry-run /tmp/httpx2-dist/*`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
