### PR TITLE
Support async file objects in `content=` and `files=`

### DIFF
--- a/docs/advanced/clients.md
+++ b/docs/advanced/clients.md
@@ -263,6 +263,34 @@ httpx2.post("https://httpbin.org/post", content=gen())
 
 ![tqdm progress bar](../img/tqdm-progress.gif)
 
+## Async file uploads
+
+`AsyncClient` accepts file objects with awaitable reads, such as those returned by
+[`anyio.open_file()`](https://anyio.readthedocs.io/en/stable/fileio.html),
+[`trio.open_file()`](https://trio.readthedocs.io/en/stable/reference-io.html#asynchronous-path-objects)
+or [`aiofiles.open()`](https://github.com/Tinche/aiofiles), both as raw request
+content and as a multipart file upload.
+
+```python
+import anyio
+import httpx2
+
+
+async def main():
+    async with httpx2.AsyncClient() as client:
+        async with await anyio.open_file("report.xls", "rb") as f:
+            await client.post("https://httpbin.org/post", content=f)
+
+        async with await anyio.open_file("report.xls", "rb") as f:
+            await client.post("https://httpbin.org/post", files={"upload-file": f})
+
+
+anyio.run(main)
+```
+
+The file is read one chunk at a time, so uploads are streaming and only one chunk is
+held in memory. As with sync file uploads, files must be opened in binary mode.
+
 ## Multipart file encoding
 
 As mentioned in the [quickstart](../quickstart.md#sending-multipart-file-uploads)

--- a/src/httpx2/CHANGELOG.md
+++ b/src/httpx2/CHANGELOG.md
@@ -10,6 +10,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 * Add the public `Origin` value object and `URL.origin` property for normalized,
   hashable origin comparisons. ([#1134](https://github.com/pydantic/httpx2/pull/1134))
+* Support async file objects, such as those returned by `anyio.open_file()`,
+  `trio.open_file()` or `aiofiles.open()`, as `content=...` and as multipart
+  `files=...` uploads.
+
+### Fixed
+
+* Read async file objects passed as `content=...` in chunks, rather than a line at a
+  time, and set `Content-Length` rather than `Transfer-Encoding: chunked` when the
+  length is known upfront.
+* Raise `TypeError` instead of looping indefinitely when a multipart upload from an
+  async file object is sent with a sync `Client`.
 
 ## 2.10.0 (August 9th, 2026)
 

--- a/src/httpx2/CHANGELOG.md
+++ b/src/httpx2/CHANGELOG.md
@@ -12,15 +12,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   hashable origin comparisons. ([#1134](https://github.com/pydantic/httpx2/pull/1134))
 * Support async file objects, such as those returned by `anyio.open_file()`,
   `trio.open_file()` or `aiofiles.open()`, as `content=...` and as multipart
-  `files=...` uploads.
+  `files=...` uploads. ([#1145](https://github.com/pydantic/httpx2/pull/1145))
 
 ### Fixed
 
 * Read async file objects passed as `content=...` in chunks, rather than a line at a
   time, and set `Content-Length` rather than `Transfer-Encoding: chunked` when the
-  length is known upfront.
+  length is known upfront. ([#1145](https://github.com/pydantic/httpx2/pull/1145))
 * Raise `TypeError` instead of looping indefinitely when a multipart upload from an
   async file object is sent with a sync `Client`.
+  ([#1145](https://github.com/pydantic/httpx2/pull/1145))
 
 ## 2.10.0 (August 9th, 2026)
 

--- a/src/httpx2/httpx2/_content.py
+++ b/src/httpx2/httpx2/_content.py
@@ -18,8 +18,9 @@ from ._types import (
     RequestFiles,
     ResponseContent,
     SyncByteStream,
+    is_async_readable_file,
 )
-from ._utils import peek_filelike_length, primitive_value_to_str
+from ._utils import peek_async_filelike_length, peek_filelike_length, primitive_value_to_str
 
 __all__ = ["ByteStream"]
 
@@ -78,6 +79,13 @@ class AsyncIteratorByteStream(AsyncByteStream):
             while chunk:
                 yield chunk
                 chunk = await self._stream.aread(self.CHUNK_SIZE)
+        elif is_async_readable_file(self._stream):
+            # Async file objects are iterable, but iterating yields one *line*
+            # at a time, so read explicitly instead.
+            chunk = await self._stream.read(self.CHUNK_SIZE)
+            while chunk:
+                yield chunk
+                chunk = await self._stream.read(self.CHUNK_SIZE)
         else:
             # Otherwise iterate.
             async for part in self._stream:
@@ -122,7 +130,12 @@ def encode_content(
         return headers, IteratorByteStream(content)
 
     elif isinstance(content, AsyncIterable):
-        headers = {"Transfer-Encoding": "chunked"}
+        content_length_or_none = peek_async_filelike_length(content) if is_async_readable_file(content) else None
+
+        if content_length_or_none is None:
+            headers = {"Transfer-Encoding": "chunked"}
+        else:
+            headers = {"Content-Length": str(content_length_or_none)}
         return headers, AsyncIteratorByteStream(content)
 
     raise TypeError(f"Unexpected type for 'content', {type(content)!r}")

--- a/src/httpx2/httpx2/_content.py
+++ b/src/httpx2/httpx2/_content.py
@@ -83,6 +83,10 @@ class AsyncIteratorByteStream(AsyncByteStream):
             # Async file objects are iterable, but iterating yields one *line*
             # at a time, so read explicitly instead.
             chunk = await self._stream.read(self.CHUNK_SIZE)
+            if chunk and not isinstance(chunk, bytes):
+                # Content-Length is derived from the file size on disk, which only
+                # matches the uploaded bytes for binary mode reads.
+                raise TypeError("Async file uploads must be opened in binary mode, not text mode.")
             while chunk:
                 yield chunk
                 chunk = await self._stream.read(self.CHUNK_SIZE)

--- a/src/httpx2/httpx2/_content.py
+++ b/src/httpx2/httpx2/_content.py
@@ -83,7 +83,7 @@ class AsyncIteratorByteStream(AsyncByteStream):
             # Async file objects are iterable, but iterating yields one *line*
             # at a time, so read explicitly instead.
             chunk = await self._stream.read(self.CHUNK_SIZE)
-            if chunk and not isinstance(chunk, bytes):
+            if not isinstance(chunk, bytes):
                 # Content-Length is derived from the file size on disk, which only
                 # matches the uploaded bytes for binary mode reads.
                 raise TypeError("Async file uploads must be opened in binary mode, not text mode.")

--- a/src/httpx2/httpx2/_multipart.py
+++ b/src/httpx2/httpx2/_multipart.py
@@ -221,7 +221,7 @@ class FileField:
                 pass
 
         chunk = await self.file.read(self.CHUNK_SIZE)
-        if chunk and not isinstance(chunk, bytes):
+        if not isinstance(chunk, bytes):
             # `get_length()` derives Content-Length from the file size on disk,
             # which only matches the uploaded bytes for binary mode reads.
             raise TypeError("Multipart file uploads must be opened in binary mode, not text mode.")

--- a/src/httpx2/httpx2/_multipart.py
+++ b/src/httpx2/httpx2/_multipart.py
@@ -5,6 +5,7 @@ import mimetypes
 import os
 import re
 import typing
+from contextlib import aclosing
 from pathlib import Path
 
 from ._types import (
@@ -14,8 +15,10 @@ from ._types import (
     RequestData,
     RequestFiles,
     SyncByteStream,
+    is_async_readable_file,
 )
 from ._utils import (
+    peek_async_filelike_length,
     peek_filelike_length,
     primitive_value_to_str,
     to_bytes,
@@ -157,7 +160,10 @@ class FileField:
         if isinstance(self.file, (str, bytes)):
             return len(headers) + len(to_bytes(self.file))
 
-        file_length = peek_filelike_length(self.file)
+        if is_async_readable_file(self.file):
+            file_length = peek_async_filelike_length(self.file)
+        else:
+            file_length = peek_filelike_length(self.file)
 
         # If we can't determine the filesize without reading it into memory,
         # then return `None` here, to indicate an unknown file length.
@@ -184,6 +190,9 @@ class FileField:
         return self._headers
 
     def render_data(self) -> typing.Iterator[bytes]:
+        if is_async_readable_file(self.file):
+            raise TypeError("Async file uploads are only supported by 'httpx2.AsyncClient'.")
+
         if isinstance(self.file, (str, bytes)):
             yield to_bytes(self.file)
             return
@@ -198,6 +207,27 @@ class FileField:
         while chunk:
             yield to_bytes(chunk)
             chunk = self.file.read(self.CHUNK_SIZE)
+
+    async def arender_data(self) -> typing.AsyncGenerator[bytes, None]:
+        if not is_async_readable_file(self.file):
+            for chunk in self.render_data():
+                yield chunk
+            return
+
+        if hasattr(self.file, "seek"):
+            try:
+                await self.file.seek(0)
+            except io.UnsupportedOperation:
+                pass
+
+        chunk = await self.file.read(self.CHUNK_SIZE)
+        if chunk and not isinstance(chunk, bytes):
+            # `get_length()` derives Content-Length from the file size on disk,
+            # which only matches the uploaded bytes for binary mode reads.
+            raise TypeError("Multipart file uploads must be opened in binary mode, not text mode.")
+        while chunk:
+            yield chunk
+            chunk = await self.file.read(self.CHUNK_SIZE)
 
     def render(self) -> typing.Iterator[bytes]:
         yield self.render_headers()
@@ -241,6 +271,20 @@ class MultipartStream(SyncByteStream, AsyncByteStream):
             yield b"\r\n"
         yield b"--%s--\r\n" % self.boundary
 
+    async def aiter_chunks(self) -> typing.AsyncGenerator[bytes, None]:
+        for field in self.fields:
+            yield b"--%s\r\n" % self.boundary
+            if isinstance(field, FileField):
+                yield field.render_headers()
+                async with aclosing(field.arender_data()) as data:
+                    async for chunk in data:
+                        yield chunk
+            else:
+                for chunk in field.render():
+                    yield chunk
+            yield b"\r\n"
+        yield b"--%s--\r\n" % self.boundary
+
     def get_content_length(self) -> int | None:
         """
         Return the length of the multipart encoded content, or `None` if
@@ -274,5 +318,6 @@ class MultipartStream(SyncByteStream, AsyncByteStream):
         yield from self.iter_chunks()
 
     async def __aiter__(self) -> typing.AsyncIterator[bytes]:
-        for chunk in self.iter_chunks():
-            yield chunk
+        async with aclosing(self.aiter_chunks()) as chunks:
+            async for chunk in chunks:
+                yield chunk

--- a/src/httpx2/httpx2/_types.py
+++ b/src/httpx2/httpx2/_types.py
@@ -2,9 +2,17 @@
 Type definitions for type checking purposes.
 """
 
+import inspect
+import sys
 from collections.abc import AsyncIterable, AsyncIterator, Callable, Iterable, Iterator, Mapping, Sequence
 from http.cookiejar import CookieJar
-from typing import IO, TYPE_CHECKING, Any, Union
+from types import BuiltinFunctionType
+from typing import IO, TYPE_CHECKING, Any, Protocol, Union
+
+if sys.version_info >= (3, 13):
+    from typing import TypeIs  # pragma: no cover
+else:
+    from typing_extensions import TypeIs  # pragma: no cover
 
 if TYPE_CHECKING:
     from ._auth import Auth  # noqa: F401
@@ -48,7 +56,36 @@ ResponseExtensions = Mapping[str, Any]
 
 RequestData = Mapping[str, Any]
 
-FileContent = IO[bytes] | bytes | str
+
+class AsyncReadableFile(Protocol):
+    """
+    A file-like object with awaitable reads, as returned by `anyio.open_file()`,
+    `trio.open_file()` or `aiofiles.open()`.
+    """
+
+    async def read(self, size: int = -1, /) -> bytes: ...
+
+    async def seek(self, offset: int, whence: int = ..., /) -> int: ...
+
+
+def is_async_readable_file(fileobj: Any) -> TypeIs[AsyncReadableFile]:
+    """
+    Determine whether a file-like object has to be read with `await`.
+
+    Only an awaitable `read()` is required. `seek()` and `fileno()` are used
+    when present, so that non-seekable or in-memory async streams still upload.
+    """
+    read = getattr(fileobj, "read", None)
+    if read is None or isinstance(read, BuiltinFunctionType):
+        # `iscoroutinefunction()` is an order of magnitude more expensive than
+        # this, and always answers `False` for C callables such as the `read()`
+        # of `open(...)` or `io.BytesIO`, which can carry neither `CO_COROUTINE`
+        # nor the `markcoroutinefunction()` marker.
+        return False
+    return inspect.iscoroutinefunction(read)
+
+
+FileContent = IO[bytes] | bytes | str | AsyncReadableFile
 FileTypes = (
     # # file (or bytes)
     FileContent

--- a/src/httpx2/httpx2/_utils.py
+++ b/src/httpx2/httpx2/_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import ipaddress
 import os
 import re
@@ -113,6 +114,25 @@ def peek_filelike_length(stream: typing.Any) -> int | None:
             return None
 
     return length
+
+
+def peek_async_filelike_length(stream: typing.Any) -> int | None:
+    """
+    Given an async file-like stream object, return its length in number of bytes
+    without reading it into memory.
+
+    Async file wrappers expose a synchronous `fileno()`, so the underlying
+    descriptor can be stat'ed. There is no `tell()`/`seek()` fallback as in the
+    sync case, because those would have to be awaited.
+    """
+    fileno = getattr(stream, "fileno", None)
+    if not callable(fileno) or inspect.iscoroutinefunction(fileno):
+        return None
+
+    try:
+        return os.fstat(fileno()).st_size
+    except (OSError, TypeError):
+        return None
 
 
 class URLPattern:

--- a/src/httpx2/httpx2/_utils.py
+++ b/src/httpx2/httpx2/_utils.py
@@ -125,6 +125,17 @@ def peek_async_filelike_length(stream: typing.Any) -> int | None:
     descriptor can be stat'ed. There is no `tell()`/`seek()` fallback as in the
     sync case, because those would have to be awaited.
     """
+    seekable = getattr(stream, "seekable", None)
+    if callable(seekable) and not inspect.iscoroutinefunction(seekable):
+        try:
+            rewindable = seekable()
+        except OSError:
+            return None
+        if not rewindable:
+            # We rewind before sending, so for a stream that can't be rewound the
+            # descriptor size wouldn't match the bytes we'd actually upload.
+            return None
+
     fileno = getattr(stream, "fileno", None)
     if not callable(fileno) or inspect.iscoroutinefunction(fileno):
         return None

--- a/src/httpx2/pyproject.toml
+++ b/src/httpx2/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "anyio>=4.10; sys_platform != 'emscripten'",
     "httpx2-jsfetch; sys_platform == 'emscripten' and python_version >= '3.12'",
     "idna>=3.18",
-    "typing_extensions>=4.5.0; python_version < '3.13'",
+    "typing_extensions>=4.10.0; python_version < '3.13'",
 ]
 
 [project.optional-dependencies]

--- a/tests/httpx2/test_content.py
+++ b/tests/httpx2/test_content.py
@@ -593,3 +593,30 @@ async def test_async_file_content_in_text_mode(tmp_path: pathlib.Path) -> None:
         assert isinstance(request.stream, typing.AsyncIterable)
         with pytest.raises(TypeError, match="must be opened in binary mode"):
             [part async for part in request.stream]
+
+
+@pytest.mark.anyio
+async def test_empty_async_file_content_in_text_mode(tmp_path: pathlib.Path) -> None:
+    path = tmp_path / "upload.txt"
+    path.write_text("")
+
+    async with await anyio.open_file(path) as upload:
+        request = httpx2.Request(method, url, content=upload)  # type: ignore[arg-type]
+        assert isinstance(request.stream, typing.AsyncIterable)
+        # An empty read still has to be rejected, rather than silently uploading nothing.
+        with pytest.raises(TypeError, match="must be opened in binary mode"):
+            [part async for part in request.stream]
+
+
+@pytest.mark.anyio
+async def test_empty_async_file_content(tmp_path: pathlib.Path) -> None:
+    path = tmp_path / "upload.bin"
+    path.write_bytes(b"")
+
+    async with await anyio.open_file(path, "rb") as upload:
+        request = httpx2.Request(method, url, content=upload)
+        assert isinstance(request.stream, typing.AsyncIterable)
+        chunks = [part async for part in request.stream]
+
+    assert request.headers == {"Host": "www.example.com", "Content-Length": "0"}
+    assert chunks == []

--- a/tests/httpx2/test_content.py
+++ b/tests/httpx2/test_content.py
@@ -1,9 +1,12 @@
 import io
+import pathlib
 import typing
 
+import anyio
 import pytest
 
 import httpx2
+from httpx2._content import AsyncIteratorByteStream
 
 method = "POST"
 url = "https://www.example.com"
@@ -515,3 +518,64 @@ def test_allow_nan_false() -> None:
         httpx2.Response(200, json=data_with_nan)
     with pytest.raises(ValueError, match="Out of range float values are not JSON compliant"):
         httpx2.Response(200, json=data_with_inf)
+
+
+@pytest.mark.anyio
+async def test_async_file_content(tmp_path: pathlib.Path) -> None:
+    # No newlines, so iterating the file would yield the whole thing in one go.
+    body = b"x" * (2 * AsyncIteratorByteStream.CHUNK_SIZE + 7)
+    path = tmp_path / "upload.bin"
+    path.write_bytes(body)
+
+    async with await anyio.open_file(path, "rb") as upload:
+        request = httpx2.Request(method, url, content=upload)
+        assert not isinstance(request.stream, typing.Iterable)
+        assert isinstance(request.stream, typing.AsyncIterable)
+
+        chunks = [part async for part in request.stream]
+
+    assert request.headers == {
+        "Host": "www.example.com",
+        "Content-Length": str(len(body)),
+    }
+    assert b"".join(chunks) == body
+    # Read in chunks, rather than buffering the whole file as a single line.
+    assert len(chunks) == 3
+
+
+@pytest.mark.anyio
+async def test_async_file_content_without_fileno(tmp_path: pathlib.Path) -> None:
+    class AsyncBytesIO:
+        def __init__(self, content: bytes) -> None:
+            self._buffer = io.BytesIO(content)
+
+        async def read(self, size: int = -1) -> bytes:
+            return self._buffer.read(size)
+
+        async def __aiter__(self) -> typing.AsyncIterator[bytes]:
+            yield self._buffer.read()  # pragma: no cover
+
+    request = httpx2.Request(method, url, content=AsyncBytesIO(b"Hello, world!"))
+    assert isinstance(request.stream, typing.AsyncIterable)
+    content = b"".join([part async for part in request.stream])
+
+    # There's no file descriptor to stat, so we can't determine the length upfront.
+    assert request.headers == {
+        "Host": "www.example.com",
+        "Transfer-Encoding": "chunked",
+    }
+    assert content == b"Hello, world!"
+
+
+@pytest.mark.anyio
+async def test_async_file_content_with_sync_client(tmp_path: pathlib.Path) -> None:
+    path = tmp_path / "upload.bin"
+    path.write_bytes(b"<file content>")
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(200)  # pragma: no cover
+
+    async with await anyio.open_file(path, "rb") as upload:
+        with httpx2.Client(transport=httpx2.MockTransport(handler)) as client:
+            with pytest.raises(RuntimeError, match="Attempted to send an async request"):
+                client.post(url, content=upload)

--- a/tests/httpx2/test_content.py
+++ b/tests/httpx2/test_content.py
@@ -579,3 +579,17 @@ async def test_async_file_content_with_sync_client(tmp_path: pathlib.Path) -> No
         with httpx2.Client(transport=httpx2.MockTransport(handler)) as client:
             with pytest.raises(RuntimeError, match="Attempted to send an async request"):
                 client.post(url, content=upload)
+
+
+@pytest.mark.anyio
+async def test_async_file_content_in_text_mode(tmp_path: pathlib.Path) -> None:
+    path = tmp_path / "upload.txt"
+    path.write_text("<file content>")
+
+    async with await anyio.open_file(path) as upload:
+        # Text mode is rejected statically by the `AsyncReadableFile` protocol, and
+        # at runtime for file objects that aren't type checked.
+        request = httpx2.Request(method, url, content=upload)  # type: ignore[arg-type]
+        assert isinstance(request.stream, typing.AsyncIterable)
+        with pytest.raises(TypeError, match="must be opened in binary mode"):
+            [part async for part in request.stream]

--- a/tests/httpx2/test_multipart.py
+++ b/tests/httpx2/test_multipart.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import io
+import pathlib
 import tempfile
 import typing
 
+import anyio
 import pytest
 
 import httpx2
+from httpx2._multipart import FileField
 
 
 def echo_request_content(request: httpx2.Request) -> httpx2.Response:
@@ -465,3 +468,156 @@ class TestHeaderParamHTML5Formatting:
         files = {"upload": (filename, b"<file content>")}
         request = httpx2.Request("GET", "https://www.example.com", files=files)
         assert expected in request.read()
+
+
+@pytest.mark.anyio
+async def test_multipart_encode_async_file(tmp_path: pathlib.Path) -> None:
+    # No newlines, so iterating the file would yield the whole thing in one go.
+    body = b"x" * (2 * FileField.CHUNK_SIZE + 7)
+    path = tmp_path / "name.txt"
+    path.write_bytes(body)
+
+    url = "https://www.example.com/"
+    headers = {"Content-Type": "multipart/form-data; boundary=BOUNDARY"}
+
+    async with await anyio.open_file(path, "rb") as upload:
+        request = httpx2.Request("POST", url, headers=headers, files={"file": upload})
+        assert isinstance(request.stream, typing.AsyncIterable)
+        chunks = [chunk async for chunk in request.stream]
+
+    content = b"".join(
+        [
+            b"--BOUNDARY\r\n",
+            b'Content-Disposition: form-data; name="file"; filename="name.txt"\r\n',
+            b"Content-Type: text/plain\r\n",
+            b"\r\n",
+            body,
+            b"\r\n",
+            b"--BOUNDARY--\r\n",
+        ]
+    )
+    assert request.headers == {
+        "Host": "www.example.com",
+        "Content-Type": "multipart/form-data; boundary=BOUNDARY",
+        "Content-Length": str(len(content)),
+    }
+    assert b"".join(chunks) == content
+    # The file body is read in chunks, rather than buffered as a single line.
+    assert [len(chunk) for chunk in chunks if len(chunk) > 1000] == [FileField.CHUNK_SIZE, FileField.CHUNK_SIZE]
+
+
+@pytest.mark.anyio
+async def test_multipart_encode_async_file_and_data(tmp_path: pathlib.Path) -> None:
+    path = tmp_path / "name.txt"
+    path.write_bytes(b"<file content>")
+
+    url = "https://www.example.com/"
+    headers = {"Content-Type": "multipart/form-data; boundary=BOUNDARY"}
+
+    async with await anyio.open_file(path, "rb") as upload:
+        request = httpx2.Request("POST", url, headers=headers, data={"a": "1"}, files={"file": upload})
+        assert isinstance(request.stream, typing.AsyncIterable)
+        content = b"".join([chunk async for chunk in request.stream])
+
+    assert content == b"".join(
+        [
+            b"--BOUNDARY\r\n",
+            b'Content-Disposition: form-data; name="a"\r\n',
+            b"\r\n",
+            b"1\r\n",
+            b"--BOUNDARY\r\n",
+            b'Content-Disposition: form-data; name="file"; filename="name.txt"\r\n',
+            b"Content-Type: text/plain\r\n",
+            b"\r\n",
+            b"<file content>\r\n",
+            b"--BOUNDARY--\r\n",
+        ]
+    )
+
+
+@pytest.mark.anyio
+async def test_multipart_encode_async_file_without_fileno() -> None:
+    class AsyncBytesIO:
+        def __init__(self, content: bytes) -> None:
+            self._buffer = io.BytesIO(content)
+
+        async def read(self, size: int = -1) -> bytes:
+            return self._buffer.read(size)
+
+        async def seek(self, offset: int, whence: int = io.SEEK_SET) -> int:
+            return self._buffer.seek(offset, whence)
+
+    url = "https://www.example.com/"
+    headers = {"Content-Type": "multipart/form-data; boundary=BOUNDARY"}
+    files = {"file": ("name.txt", AsyncBytesIO(b"<file content>"))}
+
+    request = httpx2.Request("POST", url, headers=headers, files=files)
+    assert isinstance(request.stream, typing.AsyncIterable)
+    content = b"".join([chunk async for chunk in request.stream])
+
+    # There's no file descriptor to stat, so we can't determine the length upfront.
+    assert request.headers == {
+        "Host": "www.example.com",
+        "Content-Type": "multipart/form-data; boundary=BOUNDARY",
+        "Transfer-Encoding": "chunked",
+    }
+    assert content == b"".join(
+        [
+            b"--BOUNDARY\r\n",
+            b'Content-Disposition: form-data; name="file"; filename="name.txt"\r\n',
+            b"Content-Type: text/plain\r\n",
+            b"\r\n",
+            b"<file content>\r\n",
+            b"--BOUNDARY--\r\n",
+        ]
+    )
+
+
+@pytest.mark.anyio
+async def test_multipart_encode_async_file_in_text_mode(tmp_path: pathlib.Path) -> None:
+    path = tmp_path / "name.txt"
+    path.write_text("<file content>")
+
+    url = "https://www.example.com/"
+
+    async with await anyio.open_file(path) as upload:
+        # Text mode is rejected statically by the `AsyncReadableFile` protocol,
+        # and at runtime for file objects that aren't type checked.
+        request = httpx2.Request("POST", url, files={"file": upload})  # type: ignore[dict-item]
+        assert isinstance(request.stream, typing.AsyncIterable)
+        with pytest.raises(TypeError, match="must be opened in binary mode"):
+            [chunk async for chunk in request.stream]
+
+
+@pytest.mark.anyio
+async def test_multipart_encode_async_file_with_sync_client(tmp_path: pathlib.Path) -> None:
+    path = tmp_path / "name.txt"
+    path.write_bytes(b"<file content>")
+
+    async with await anyio.open_file(path, "rb") as upload:
+        client = httpx2.Client(transport=httpx2.MockTransport(echo_request_content))
+        with pytest.raises(TypeError, match="only supported by 'httpx2.AsyncClient'"):
+            client.post("https://www.example.com/", files={"file": upload})
+
+
+@pytest.mark.anyio
+async def test_multipart_encode_async_file_that_is_not_seekable() -> None:
+    class AsyncPipe:
+        def __init__(self, content: bytes) -> None:
+            self._buffer = io.BytesIO(content)
+
+        async def read(self, size: int = -1) -> bytes:
+            return self._buffer.read(size)
+
+        async def seek(self, offset: int, whence: int = io.SEEK_SET) -> int:
+            raise io.UnsupportedOperation("seek")
+
+    url = "https://www.example.com/"
+    headers = {"Content-Type": "multipart/form-data; boundary=BOUNDARY"}
+    files = {"file": ("name.txt", AsyncPipe(b"<file content>"))}
+
+    request = httpx2.Request("POST", url, headers=headers, files=files)
+    assert isinstance(request.stream, typing.AsyncIterable)
+    content = b"".join([chunk async for chunk in request.stream])
+
+    assert b"<file content>" in content

--- a/tests/httpx2/test_multipart.py
+++ b/tests/httpx2/test_multipart.py
@@ -621,3 +621,42 @@ async def test_multipart_encode_async_file_that_is_not_seekable() -> None:
     content = b"".join([chunk async for chunk in request.stream])
 
     assert b"<file content>" in content
+
+
+@pytest.mark.anyio
+async def test_multipart_encode_empty_async_file_in_text_mode(tmp_path: pathlib.Path) -> None:
+    path = tmp_path / "name.txt"
+    path.write_text("")
+
+    async with await anyio.open_file(path) as upload:
+        request = httpx2.Request("POST", "https://www.example.com/", files={"file": upload})  # type: ignore[dict-item]
+        assert isinstance(request.stream, typing.AsyncIterable)
+        # An empty read still has to be rejected, rather than silently uploading nothing.
+        with pytest.raises(TypeError, match="must be opened in binary mode"):
+            [chunk async for chunk in request.stream]
+
+
+@pytest.mark.anyio
+async def test_multipart_encode_empty_async_file(tmp_path: pathlib.Path) -> None:
+    path = tmp_path / "name.txt"
+    path.write_bytes(b"")
+
+    url = "https://www.example.com/"
+    headers = {"Content-Type": "multipart/form-data; boundary=BOUNDARY"}
+
+    async with await anyio.open_file(path, "rb") as upload:
+        request = httpx2.Request("POST", url, headers=headers, files={"file": upload})
+        assert isinstance(request.stream, typing.AsyncIterable)
+        content = b"".join([chunk async for chunk in request.stream])
+
+    assert content == b"".join(
+        [
+            b"--BOUNDARY\r\n",
+            b'Content-Disposition: form-data; name="file"; filename="name.txt"\r\n',
+            b"Content-Type: text/plain\r\n",
+            b"\r\n",
+            b"\r\n",
+            b"--BOUNDARY--\r\n",
+        ]
+    )
+    assert request.headers["Content-Length"] == str(len(content))

--- a/tests/httpx2/test_utils.py
+++ b/tests/httpx2/test_utils.py
@@ -9,7 +9,7 @@ import typing
 import pytest
 
 import httpx2
-from httpx2._utils import URLPattern, get_environment_proxies
+from httpx2._utils import URLPattern, get_environment_proxies, peek_async_filelike_length
 
 if typing.TYPE_CHECKING:
     from conftest import TestServer
@@ -157,3 +157,28 @@ def test_pattern_priority() -> None:
         URLPattern("http://"),
         URLPattern("all://"),
     ]
+
+
+def test_peek_async_filelike_length_without_fileno() -> None:
+    class AsyncBytesIO:
+        async def read(self, size: int = -1) -> bytes:
+            return b""  # pragma: no cover
+
+    assert peek_async_filelike_length(AsyncBytesIO()) is None
+
+
+def test_peek_async_filelike_length_with_async_fileno() -> None:
+    class AsyncFileno:
+        async def fileno(self) -> int:
+            return 0  # pragma: no cover
+
+    assert peek_async_filelike_length(AsyncFileno()) is None
+
+
+@pytest.mark.parametrize("fileno", (lambda: -1, lambda: None))
+def test_peek_async_filelike_length_with_unstatable_fileno(fileno: typing.Callable[[], typing.Any]) -> None:
+    class Unstatable:
+        def __init__(self) -> None:
+            self.fileno = fileno
+
+    assert peek_async_filelike_length(Unstatable()) is None

--- a/tests/httpx2/test_utils.py
+++ b/tests/httpx2/test_utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import pathlib
 import random
 import typing
 
@@ -182,3 +183,43 @@ def test_peek_async_filelike_length_with_unstatable_fileno(fileno: typing.Callab
             self.fileno = fileno
 
     assert peek_async_filelike_length(Unstatable()) is None
+
+
+def test_peek_async_filelike_length_with_non_seekable_stream() -> None:
+    class AsyncPipe:
+        def seekable(self) -> bool:
+            return False
+
+        def fileno(self) -> int:
+            return 0  # pragma: no cover
+
+    assert peek_async_filelike_length(AsyncPipe()) is None
+
+
+def test_peek_async_filelike_length_with_unusable_seekable() -> None:
+    class Closed:
+        def seekable(self) -> bool:
+            raise OSError("closed")
+
+        def fileno(self) -> int:
+            return 0  # pragma: no cover
+
+    assert peek_async_filelike_length(Closed()) is None
+
+
+def test_peek_async_filelike_length_with_async_seekable(tmp_path: pathlib.Path) -> None:
+    path = tmp_path / "upload.bin"
+    path.write_bytes(b"<file content>")
+
+    class AsyncSeekable:
+        def __init__(self, fileno: int) -> None:
+            self._fileno = fileno
+
+        async def seekable(self) -> bool:
+            return True  # pragma: no cover
+
+        def fileno(self) -> int:
+            return self._fileno
+
+    with path.open("rb") as file:
+        assert peek_async_filelike_length(AsyncSeekable(file.fileno())) == len(b"<file content>")

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -4,7 +4,8 @@ import asyncio
 import gzip
 import io
 import json
-from collections.abc import AsyncIterable, AsyncIterator
+import tempfile
+from collections.abc import AsyncIterable, AsyncIterator, Iterator
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -195,11 +196,19 @@ def test_bench_client_post_json(benchmark: BenchmarkFixture) -> None:
 class AsyncFile:
     """
     Emulates the file interface returned by `anyio`, `trio` and `aiofiles`, which
-    reads with `await` and iterates a line at a time.
+    reads with `await`, iterates a line at a time, and exposes a synchronous
+    `fileno()` so the upload length can be determined upfront.
     """
 
-    def __init__(self, content: bytes) -> None:
+    def __init__(self, content: bytes, fileno: int) -> None:
         self._buffer = io.BytesIO(content)
+        self._fileno = fileno
+
+    def fileno(self) -> int:
+        return self._fileno
+
+    def seekable(self) -> bool:
+        return True
 
     async def read(self, size: int = -1) -> bytes:
         return self._buffer.read(size)
@@ -216,23 +225,43 @@ class AsyncFile:
 UPLOAD_BODY = b"".join([b"x" * 63 + b"\n"] * (64 * 1024))
 
 
+@pytest.fixture(scope="module")
+def upload_fd() -> Iterator[int]:
+    """A descriptor whose `st_size` matches `UPLOAD_BODY`, so `Content-Length` applies."""
+    with tempfile.TemporaryFile() as file:
+        file.write(UPLOAD_BODY)
+        file.flush()
+        yield file.fileno()
+
+
 async def _drain(request: httpx2.Request) -> int:
     assert isinstance(request.stream, AsyncIterable)
     return sum([len(chunk) async for chunk in request.stream])
 
 
-def test_bench_async_file_upload(benchmark: BenchmarkFixture) -> None:
-    def upload() -> int:
-        request = httpx2.Request("POST", TYPICAL_URL, content=AsyncFile(UPLOAD_BODY))
-        return asyncio.run(_drain(request))
+def test_bench_async_file_upload(benchmark: BenchmarkFixture, upload_fd: int) -> None:
+    def build() -> httpx2.Request:
+        return httpx2.Request("POST", TYPICAL_URL, content=AsyncFile(UPLOAD_BODY, upload_fd))
 
-    assert benchmark(upload) == len(UPLOAD_BODY)
+    assert build().headers["Content-Length"] == str(len(UPLOAD_BODY))
+
+    # A single loop, reused across samples, so that loop bootstrap isn't measured.
+    loop = asyncio.new_event_loop()
+    try:
+        assert benchmark(lambda: loop.run_until_complete(_drain(build()))) == len(UPLOAD_BODY)
+    finally:
+        loop.close()
 
 
-def test_bench_async_file_multipart_upload(benchmark: BenchmarkFixture) -> None:
-    def upload() -> int:
-        files = {"upload": ("upload.bin", AsyncFile(UPLOAD_BODY))}
-        request = httpx2.Request("POST", TYPICAL_URL, files=files)
-        return asyncio.run(_drain(request))
+def test_bench_async_file_multipart_upload(benchmark: BenchmarkFixture, upload_fd: int) -> None:
+    def build() -> httpx2.Request:
+        files = {"upload": ("upload.bin", AsyncFile(UPLOAD_BODY, upload_fd))}
+        return httpx2.Request("POST", TYPICAL_URL, files=files)
 
-    assert benchmark(upload) > len(UPLOAD_BODY)
+    assert "Content-Length" in build().headers
+
+    loop = asyncio.new_event_loop()
+    try:
+        assert benchmark(lambda: loop.run_until_complete(_drain(build()))) > len(UPLOAD_BODY)
+    finally:
+        loop.close()

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import asyncio
 import gzip
+import io
 import json
+from collections.abc import AsyncIterable, AsyncIterator
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -184,3 +187,52 @@ def _json_handler(request: httpx2.Request) -> httpx2.Response:
 def test_bench_client_post_json(benchmark: BenchmarkFixture) -> None:
     with httpx2.Client(transport=httpx2.MockTransport(_json_handler)) as client:
         benchmark(lambda: client.post(TYPICAL_URL, json=MEDIUM_JSON).json())
+
+
+# --- Async file uploads -----------------------------------------------------------
+
+
+class AsyncFile:
+    """
+    Emulates the file interface returned by `anyio`, `trio` and `aiofiles`, which
+    reads with `await` and iterates a line at a time.
+    """
+
+    def __init__(self, content: bytes) -> None:
+        self._buffer = io.BytesIO(content)
+
+    async def read(self, size: int = -1) -> bytes:
+        return self._buffer.read(size)
+
+    async def seek(self, offset: int, whence: int = io.SEEK_SET) -> int:
+        return self._buffer.seek(offset, whence)
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        for line in self._buffer:
+            yield line
+
+
+# Short lines, so that iterating rather than reading in chunks is markedly slower.
+UPLOAD_BODY = b"".join([b"x" * 63 + b"\n"] * (64 * 1024))
+
+
+async def _drain(request: httpx2.Request) -> int:
+    assert isinstance(request.stream, AsyncIterable)
+    return sum([len(chunk) async for chunk in request.stream])
+
+
+def test_bench_async_file_upload(benchmark: BenchmarkFixture) -> None:
+    def upload() -> int:
+        request = httpx2.Request("POST", TYPICAL_URL, content=AsyncFile(UPLOAD_BODY))
+        return asyncio.run(_drain(request))
+
+    assert benchmark(upload) == len(UPLOAD_BODY)
+
+
+def test_bench_async_file_multipart_upload(benchmark: BenchmarkFixture) -> None:
+    def upload() -> int:
+        files = {"upload": ("upload.bin", AsyncFile(UPLOAD_BODY))}
+        request = httpx2.Request("POST", TYPICAL_URL, files=files)
+        return asyncio.run(_drain(request))
+
+    assert benchmark(upload) > len(UPLOAD_BODY)

--- a/uv.lock
+++ b/uv.lock
@@ -1526,7 +1526,7 @@ requires-dist = [
     { name = "rich", marker = "extra == 'cli'", specifier = ">=10,<16" },
     { name = "socksio", marker = "extra == 'socks'", specifier = "==1.*" },
     { name = "truststore", marker = "sys_platform != 'emscripten'", specifier = ">=0.10" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'", specifier = ">=4.5.0" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'", specifier = ">=4.10.0" },
     { name = "wsproto", marker = "extra == 'ws'", specifier = ">=1.2" },
     { name = "zstandard", marker = "python_full_version < '3.14' and extra == 'zstd'", specifier = ">=0.18.0" },
 ]


### PR DESCRIPTION
# Summary

This is my third attempt at this. This PR resolves #597 and implements chunked upload for `anyio.open_file`, `trio.open_file` and `aiofiles.open` when used as `content=` parameter for `post` and `put` request and implements support for multipart file upload for the same libraries. Previous attempts were https://github.com/encode/httpx/pull/3339 and https://github.com/encode/httpx/pull/3698 against `encode/httpx`, both went stale while the library was unmaintained. Most of the code is reworked from https://github.com/encode/httpx/pull/3698, with the review comments left on https://github.com/encode/httpx/pull/3339 applied.

Currently `content=` with an async file iterates it a line at a time instead of reading in chunks, so a file without newlines gets buffered whole, and `files=` with an async file loops forever on both clients, since `MultipartStream.__aiter__` just delegates to the sync `iter_chunks()` and `read()` returns a coroutine, which is always truthy.

## changes

- `_types.AsyncReadableFile` protocol was added along with `is_async_readable_file` type predicate function to detect and perform type narrowing for trio/anyio/aiofiles async files
- `_types.FileContent` was extended to include the `_types.AsyncReadableFile` protocol
- `_utils.peek_async_filelike_length` was added, async wrappers expose a sync `fileno()` so the fd can be stat'ed, there's no `tell()`/`seek()` fallback like the sync version because those would need awaiting
- `_content.AsyncIteratorByteStream` updated to use `await read()` for async files instead of looping over lines
- `_content.encode_content` updated to attach content length header for async files when it's known upfront
- `_multipart.FileField` updated with `arender_data`, and `get_length` / `render_data` made async-aware, sync `Client` now raises `TypeError` instead of looping
- `_multipart.MultipartStream` updated with `aiter_chunks`, and `__aiter__` updated to use it, both wrapped in `contextlib.aclosing`
- async files must be opened in binary mode, same as sync ones, otherwise the `Content-Length` taken from `os.fstat` wouldn't match the encoded body
- `typing_extensions` bumped to >=4.10 for `TypeIs` (already a dep for python < 3.13), lockfile updated
- tests added to `test_content.py`, `test_multipart.py` and `test_utils.py`, benchmarks added to `test_benchmark.py`, docs and changelog updated

## perf

- `content=` over 4 MiB with 64-byte lines: 9.18 ms -> 0.33 ms (encoding path, in-memory file, so no disk I/O in the number)
- the type predicate runs 0-3 times per request, never per chunk, and short circuits C callables so `io.BytesIO` / `open()` cost 57 ns instead of ~630 ns. Benchmarked against a clean `main` worktree, sync multipart is unchanged within noise.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

