### PR TITLE
Update Emscripten documentation with emscripten-forge

### DIFF
--- a/docs/advanced/emscripten.md
+++ b/docs/advanced/emscripten.md
@@ -5,13 +5,15 @@ template: pyodide.html
 # Emscripten Support
 
 httpx2 has support for running on WebAssembly / Emscripten using
-[Pyodide](https://github.com/pyodide/pyodide/). It uses the
-[httpx2-jsfetch](https://github.com/hoodmane/httpx2-jsfetch) package to define
-the `JavascriptFetchTransport`.
+[Pyodide](https://github.com/pyodide/pyodide/) or
+[emscripten-forge](https://emscripten-forge.org/). It uses the `httpx2-jsfetch`
+package ([for Pyodide](https://github.com/hoodmane/httpx2-jsfetch) or
+[for emscripten-forge](https://github.com/davidbrochart/httpx2-jsfetch-emscripten-forge))
+to define the `JavascriptFetchTransport` and `AsyncJavascriptFetchTransport`.
 
 Asynchronous requests always use `fetch`. Synchronous requests use the following
 methods:
-1. If [Javascript Promise Integration](https://github.com/WebAssembly/js-promise-integration/blob/main/proposals/js-promise-integration/Overview.md)
+1. If [JavaScript Promise Integration](https://github.com/WebAssembly/js-promise-integration/blob/main/proposals/js-promise-integration/Overview.md)
    (JSPI) is supported by the JavaScript runtime, the request will be made with
    `fetch` and stack switching.
 2. Otherwise, if in a browser, the request will be made using a synchronous
@@ -19,14 +21,14 @@ methods:
 3. Otherwise, if in Node, the request will fail. Synchronous requests in Node
    require JSPI.
 
-In Emscripten, all network connections are handled by the enclosing Javascript
+In Emscripten, all network connections are handled by the enclosing JavaScript
 runtime. As such, there is limited control over various features. In particular:
 
 - Proxy servers are handled by the runtime, so httpx2 cannot control them.
 - httpx2 has no control over connection pooling.
 - Certificate handling is done by the browser, so httpx2 cannot modify it.
 - Requests are constrained by cross-origin isolation settings in the same way as
-  any request that is originated by Javascript code.
+  any request that is originated by JavaScript code.
 - Timeouts will not work in the main browser thread unless the browser supports
   JSPI because main thread synchronous `XMLHttpRequest` does not support
   timeouts.


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX2! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

`httpx2` has support for Emscripten through @hoodmane's [httpx2-jsfetch](https://github.com/hoodmane/httpx2-jsfetch) package for pyodide. I created the [equivalent package](https://github.com/davidbrochart/httpx2-jsfetch-emscripten-forge) for [emscripten-forge](https://github.com/emscripten-forge/recipes/tree/8ad16be748382fbd14a07aadcc61125973fa89d8/recipes/recipes_emscripten/httpx2-jsfetch). It's basically swapping `pyodide.ffi` with [pyjs](https://github.com/emscripten-forge/pyjs) (and dropping JSPI since emscripten-forge doesn't support it yet). The main difference between pyodide and emscripten-forge in terms of packaging is that pyodide is PyPI-based (IIUC) while emscripten-forge is based on [conda-forge](https://conda-forge.org/).

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

