### PR TITLE
Use fully qualified URLs in docstring links

### DIFF
--- a/src/httpx2/httpx2/_api.py
+++ b/src/httpx2/httpx2/_api.py
@@ -146,7 +146,7 @@ def stream(
 
     See also: [Streaming Responses][0]
 
-    [0]: /quickstart#streaming-responses
+    [0]: https://www.python-httpx2.org/quickstart#streaming-responses
     """
     with Client(
         cookies=cookies,

--- a/src/httpx2/httpx2/_api.py
+++ b/src/httpx2/httpx2/_api.py
@@ -146,7 +146,7 @@ def stream(
 
     See also: [Streaming Responses][0]
 
-    [0]: https://www.python-httpx2.org/quickstart#streaming-responses
+    [0]: https://httpx2.pydantic.dev/quickstart#streaming-responses
     """
     with Client(
         cookies=cookies,

--- a/src/httpx2/httpx2/_client.py
+++ b/src/httpx2/httpx2/_client.py
@@ -262,7 +262,7 @@ class BaseClient:
 
         See also [Authentication][0].
 
-        [0]: https://www.python-httpx2.org/quickstart/#authentication
+        [0]: https://httpx2.pydantic.dev/quickstart/#authentication
         """
         return self._auth
 
@@ -347,7 +347,7 @@ class BaseClient:
 
         See also: [Request instances][0]
 
-        [0]: https://www.python-httpx2.org/advanced/clients/#request-instances
+        [0]: https://httpx2.pydantic.dev/advanced/clients/#request-instances
         """
         url = self._merge_url(url)
         headers = self._merge_headers(headers)
@@ -771,7 +771,7 @@ class Client(BaseClient):
         [Merging of configuration][0] for how the various parameters
         are merged with client-level configuration.
 
-        [0]: https://www.python-httpx2.org/advanced/clients/#merging-of-configuration
+        [0]: https://httpx2.pydantic.dev/advanced/clients/#merging-of-configuration
         """
         if cookies is not None:
             message = (
@@ -822,7 +822,7 @@ class Client(BaseClient):
 
         See also: [Streaming Responses][0]
 
-        [0]: https://www.python-httpx2.org/quickstart#streaming-responses
+        [0]: https://httpx2.pydantic.dev/quickstart#streaming-responses
         """
         request = self.build_request(
             method=method,
@@ -965,7 +965,7 @@ class Client(BaseClient):
 
         See also: [Request instances][0]
 
-        [0]: https://www.python-httpx2.org/advanced/clients/#request-instances
+        [0]: https://httpx2.pydantic.dev/advanced/clients/#request-instances
         """
         if self._state == ClientState.CLOSED:
             raise RuntimeError("Cannot send a request, as the client has been closed.")
@@ -1608,7 +1608,7 @@ class AsyncClient(BaseClient):
         and [Merging of configuration][0] for how the various parameters
         are merged with client-level configuration.
 
-        [0]: https://www.python-httpx2.org/advanced/clients/#merging-of-configuration
+        [0]: https://httpx2.pydantic.dev/advanced/clients/#merging-of-configuration
         """
 
         if cookies is not None:  # pragma: no cover
@@ -1660,7 +1660,7 @@ class AsyncClient(BaseClient):
 
         See also: [Streaming Responses][0]
 
-        [0]: https://www.python-httpx2.org/quickstart#streaming-responses
+        [0]: https://httpx2.pydantic.dev/quickstart#streaming-responses
         """
         request = self.build_request(
             method=method,
@@ -1803,7 +1803,7 @@ class AsyncClient(BaseClient):
 
         See also: [Request instances][0]
 
-        [0]: https://www.python-httpx2.org/advanced/clients/#request-instances
+        [0]: https://httpx2.pydantic.dev/advanced/clients/#request-instances
         """
         if self._state == ClientState.CLOSED:
             raise RuntimeError("Cannot send a request, as the client has been closed.")

--- a/src/httpx2/httpx2/_client.py
+++ b/src/httpx2/httpx2/_client.py
@@ -262,7 +262,7 @@ class BaseClient:
 
         See also [Authentication][0].
 
-        [0]: /quickstart/#authentication
+        [0]: https://www.python-httpx2.org/quickstart/#authentication
         """
         return self._auth
 
@@ -347,7 +347,7 @@ class BaseClient:
 
         See also: [Request instances][0]
 
-        [0]: /advanced/clients/#request-instances
+        [0]: https://www.python-httpx2.org/advanced/clients/#request-instances
         """
         url = self._merge_url(url)
         headers = self._merge_headers(headers)
@@ -771,7 +771,7 @@ class Client(BaseClient):
         [Merging of configuration][0] for how the various parameters
         are merged with client-level configuration.
 
-        [0]: /advanced/clients/#merging-of-configuration
+        [0]: https://www.python-httpx2.org/advanced/clients/#merging-of-configuration
         """
         if cookies is not None:
             message = (
@@ -822,7 +822,7 @@ class Client(BaseClient):
 
         See also: [Streaming Responses][0]
 
-        [0]: /quickstart#streaming-responses
+        [0]: https://www.python-httpx2.org/quickstart#streaming-responses
         """
         request = self.build_request(
             method=method,
@@ -965,7 +965,7 @@ class Client(BaseClient):
 
         See also: [Request instances][0]
 
-        [0]: /advanced/clients/#request-instances
+        [0]: https://www.python-httpx2.org/advanced/clients/#request-instances
         """
         if self._state == ClientState.CLOSED:
             raise RuntimeError("Cannot send a request, as the client has been closed.")
@@ -1608,7 +1608,7 @@ class AsyncClient(BaseClient):
         and [Merging of configuration][0] for how the various parameters
         are merged with client-level configuration.
 
-        [0]: /advanced/clients/#merging-of-configuration
+        [0]: https://www.python-httpx2.org/advanced/clients/#merging-of-configuration
         """
 
         if cookies is not None:  # pragma: no cover
@@ -1660,7 +1660,7 @@ class AsyncClient(BaseClient):
 
         See also: [Streaming Responses][0]
 
-        [0]: /quickstart#streaming-responses
+        [0]: https://www.python-httpx2.org/quickstart#streaming-responses
         """
         request = self.build_request(
             method=method,
@@ -1803,7 +1803,7 @@ class AsyncClient(BaseClient):
 
         See also: [Request instances][0]
 
-        [0]: /advanced/clients/#request-instances
+        [0]: https://www.python-httpx2.org/advanced/clients/#request-instances
         """
         if self._state == ClientState.CLOSED:
             raise RuntimeError("Cannot send a request, as the client has been closed.")


### PR DESCRIPTION
Docstrings in `_api.py` and `_client.py` linked to site-absolute paths like `/quickstart` and `/advanced/clients/`, which 404 for any consumer publishing them under a prefix (e.g. the unified Pydantic docs site). They now use fully qualified URLs with the site origin.

Closes #1138.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

