### PR TITLE
Serialize h2 state machine access for thread-safe HTTP/2 connections

### DIFF
--- a/src/httpcore2/CHANGELOG.md
+++ b/src/httpcore2/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Fixed
+
+* Serialize access to the `h2` state machine so that a single HTTP/2 connection can be safely shared across threads. ([#1153](https://github.com/pydantic/httpx2/pull/1153))
+
 ## 2.12.0 (August 18th, 2026)
 
 No changes since `2.11.0`. Version bumped to stay in lockstep with `httpx2`.

--- a/src/httpcore2/httpcore2/_async/http2.py
+++ b/src/httpcore2/httpcore2/_async/http2.py
@@ -117,6 +117,7 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
         await self._max_streams_semaphore.acquire()
 
         stream_id: int | None = None
+        stream_ids_exhausted = False
         try:
             kwargs: dict[str, typing.Any] = {"request": request}
             async with Trace("send_request_headers", logger, request, kwargs):
@@ -130,13 +131,14 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
                         self._used_all_stream_ids = True
                         self._request_count -= 1
                         await self._max_streams_semaphore.release()
+                        stream_ids_exhausted = True
                         raise ConnectionNotAvailable()
                     self._events[stream_id] = []
                     kwargs["stream_id"] = stream_id
                     await self._send_request_headers(request=request, stream_id=stream_id)
-        except ConnectionNotAvailable:  # pragma: no cover
-            raise
         except BaseException as exc:  # noqa: PIE786
+            if stream_ids_exhausted:  # pragma: no cover
+                raise
             with AsyncShieldCancellation():
                 if stream_id is None:  # pragma: no cover
                     # The request failed before a stream was allocated, for

--- a/src/httpcore2/httpcore2/_async/http2.py
+++ b/src/httpcore2/httpcore2/_async/http2.py
@@ -136,7 +136,15 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
         except BaseException as exc:  # noqa: PIE786
             with AsyncShieldCancellation():
                 if stream_id is None:  # pragma: no cover
+                    # The request failed before a stream was allocated, for
+                    # example within the trace 'started' callback, or by
+                    # cancellation while waiting on the write lock.
                     await self._max_streams_semaphore.release()
+                    async with self._state_lock:
+                        if self._state == HTTPConnectionState.ACTIVE and not self._events:
+                            self._state = HTTPConnectionState.IDLE
+                            if self._keepalive_expiry is not None:
+                                self._expire_at = time.monotonic() + self._keepalive_expiry
                 else:
                     closed_kwargs = {"stream_id": stream_id}
                     async with Trace("response_closed", logger, request, closed_kwargs):

--- a/src/httpcore2/httpcore2/_async/http2.py
+++ b/src/httpcore2/httpcore2/_async/http2.py
@@ -116,30 +116,34 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
 
         await self._max_streams_semaphore.acquire()
 
-        async with self._write_lock:
-            # Stream ID allocation, HPACK encoding of the outgoing headers, and
-            # writing the HEADERS frame to the network must be a single atomic
-            # section with respect to other streams on this connection.
-            try:
-                stream_id = self._h2_state.get_next_available_stream_id()
-                self._events[stream_id] = []
-            except h2.exceptions.NoAvailableStreamIDError:  # pragma: no cover
-                self._used_all_stream_ids = True
-                self._request_count -= 1
-                await self._max_streams_semaphore.release()
-                raise ConnectionNotAvailable()
-
-            try:
-                kwargs = {"request": request, "stream_id": stream_id}
-                async with Trace("send_request_headers", logger, request, kwargs):
+        stream_id: int | None = None
+        try:
+            kwargs: dict[str, typing.Any] = {"request": request}
+            async with Trace("send_request_headers", logger, request, kwargs):
+                async with self._write_lock:
+                    # Stream ID allocation, HPACK encoding of the outgoing headers, and
+                    # writing the HEADERS frame to the network must be a single atomic
+                    # section with respect to other streams on this connection.
+                    stream_id = self._h2_state.get_next_available_stream_id()
+                    self._events[stream_id] = []
+                    kwargs["stream_id"] = stream_id
                     await self._send_request_headers(request=request, stream_id=stream_id)
-            except BaseException as exc:  # noqa: PIE786
-                with AsyncShieldCancellation():
+        except h2.exceptions.NoAvailableStreamIDError:  # pragma: no cover
+            self._used_all_stream_ids = True
+            self._request_count -= 1
+            await self._max_streams_semaphore.release()
+            raise ConnectionNotAvailable()
+        except BaseException as exc:  # noqa: PIE786
+            with AsyncShieldCancellation():
+                if stream_id is None:  # pragma: no cover
+                    await self._max_streams_semaphore.release()
+                else:
                     closed_kwargs = {"stream_id": stream_id}
                     async with Trace("response_closed", logger, request, closed_kwargs):
                         await self._response_closed(stream_id=stream_id)
-                raise self._map_exception(exc)
+            raise self._map_exception(exc)
 
+        assert stream_id is not None
         try:
             async with Trace("send_request_body", logger, request, kwargs):
                 await self._send_request_body(request=request, stream_id=stream_id)

--- a/src/httpcore2/httpcore2/_async/http2.py
+++ b/src/httpcore2/httpcore2/_async/http2.py
@@ -213,7 +213,8 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
 
         self._h2_state.initiate_connection()
         self._h2_state.increment_flow_control_window(2**24)
-        await self._write_outgoing_data(request)
+        async with self._write_lock:
+            await self._flush_outgoing_data(request)
 
     # Sending the request...
 
@@ -370,29 +371,41 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
             # block until we've available flow control, event when we have events
             # pending for the stream ID we're attempting to send on.
             if stream_id is None or not self._events.get(stream_id):
-                events = await self._read_incoming_data(request)
-                for event in events:
-                    if isinstance(event, h2.events.RemoteSettingsChanged):
-                        async with Trace("receive_remote_settings", logger, request) as trace:
-                            await self._receive_remote_settings_change(event)
-                            trace.return_value = event
+                data = await self._read_incoming_data(request)
+                settings_changes: list[h2.events.RemoteSettingsChanged] = []
+                async with self._write_lock:
+                    # Feeding inbound data into the `h2` state machine, recording
+                    # the resulting events, and flushing any outgoing data (such as
+                    # automatic PING responses) must be atomic with respect to
+                    # outgoing frames from concurrently sending streams.
+                    events: list[h2.events.Event] = self._h2_state.receive_data(data)
+                    for event in events:
+                        if isinstance(event, h2.events.RemoteSettingsChanged):
+                            settings_changes.append(event)
 
-                    elif isinstance(
-                        event,
-                        (
-                            h2.events.ResponseReceived,
-                            h2.events.DataReceived,
-                            h2.events.StreamEnded,
-                            h2.events.StreamReset,
-                        ),
-                    ):
-                        if event.stream_id in self._events:
-                            self._events[event.stream_id].append(event)
+                        elif isinstance(
+                            event,
+                            (
+                                h2.events.ResponseReceived,
+                                h2.events.DataReceived,
+                                h2.events.StreamEnded,
+                                h2.events.StreamReset,
+                            ),
+                        ):
+                            if event.stream_id in self._events:
+                                self._events[event.stream_id].append(event)
 
-                    elif isinstance(event, h2.events.ConnectionTerminated):
-                        self._connection_terminated = event
+                        elif isinstance(event, h2.events.ConnectionTerminated):
+                            self._connection_terminated = event
 
-        await self._write_outgoing_data(request)
+                    await self._flush_outgoing_data(request)
+
+                # Adjusting the max streams semaphore may block, and the trace
+                # extension runs user code, so both happen outside the write lock.
+                for settings_change in settings_changes:
+                    async with Trace("receive_remote_settings", logger, request) as trace:
+                        await self._receive_remote_settings_change(settings_change)
+                        trace.return_value = settings_change
 
     async def _receive_remote_settings_change(self, event: h2.events.RemoteSettingsChanged) -> None:
         max_concurrent_streams = event.changed_settings.get(h2.settings.SettingCodes.MAX_CONCURRENT_STREAMS)
@@ -434,7 +447,7 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
 
     # Wrappers around network read/write operations...
 
-    async def _read_incoming_data(self, request: Request) -> list[h2.events.Event]:
+    async def _read_incoming_data(self, request: Request) -> bytes:
         timeouts = request.extensions.get("timeout", {})
         timeout = timeouts.get("read", None)
 
@@ -458,14 +471,7 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
             self._connection_error = True
             raise exc
 
-        async with self._write_lock:
-            events: list[h2.events.Event] = self._h2_state.receive_data(data)
-
-        return events
-
-    async def _write_outgoing_data(self, request: Request) -> None:
-        async with self._write_lock:
-            await self._flush_outgoing_data(request)
+        return data
 
     async def _flush_outgoing_data(self, request: Request) -> None:
         """

--- a/src/httpcore2/httpcore2/_async/http2.py
+++ b/src/httpcore2/httpcore2/_async/http2.py
@@ -54,6 +54,9 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
         self._init_lock = AsyncLock()
         self._state_lock = AsyncLock()
         self._read_lock = AsyncLock()
+        # The write lock guards every mutation of the `h2` state machine and the
+        # flush of its outgoing data, so that concurrent streams cannot interleave
+        # stream ID allocation, HPACK encoder state, or partially written frames.
         self._write_lock = AsyncLock()
         self._sent_connection_init = False
         self._used_all_stream_ids = False
@@ -113,19 +116,31 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
 
         await self._max_streams_semaphore.acquire()
 
-        try:
-            stream_id = self._h2_state.get_next_available_stream_id()
-            self._events[stream_id] = []
-        except h2.exceptions.NoAvailableStreamIDError:  # pragma: no cover
-            self._used_all_stream_ids = True
-            self._request_count -= 1
-            await self._max_streams_semaphore.release()
-            raise ConnectionNotAvailable()
+        async with self._write_lock:
+            # Stream ID allocation, HPACK encoding of the outgoing headers, and
+            # writing the HEADERS frame to the network must be a single atomic
+            # section with respect to other streams on this connection.
+            try:
+                stream_id = self._h2_state.get_next_available_stream_id()
+                self._events[stream_id] = []
+            except h2.exceptions.NoAvailableStreamIDError:  # pragma: no cover
+                self._used_all_stream_ids = True
+                self._request_count -= 1
+                await self._max_streams_semaphore.release()
+                raise ConnectionNotAvailable()
+
+            try:
+                kwargs = {"request": request, "stream_id": stream_id}
+                async with Trace("send_request_headers", logger, request, kwargs):
+                    await self._send_request_headers(request=request, stream_id=stream_id)
+            except BaseException as exc:  # noqa: PIE786
+                with AsyncShieldCancellation():
+                    closed_kwargs = {"stream_id": stream_id}
+                    async with Trace("response_closed", logger, request, closed_kwargs):
+                        await self._response_closed(stream_id=stream_id)
+                raise self._map_exception(exc)
 
         try:
-            kwargs = {"request": request, "stream_id": stream_id}
-            async with Trace("send_request_headers", logger, request, kwargs):
-                await self._send_request_headers(request=request, stream_id=stream_id)
             async with Trace("send_request_body", logger, request, kwargs):
                 await self._send_request_body(request=request, stream_id=stream_id)
             async with Trace("receive_response_headers", logger, request, kwargs) as trace:
@@ -144,27 +159,28 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
             )
         except BaseException as exc:  # noqa: PIE786
             with AsyncShieldCancellation():
-                kwargs = {"stream_id": stream_id}
-                async with Trace("response_closed", logger, request, kwargs):
+                closed_kwargs = {"stream_id": stream_id}
+                async with Trace("response_closed", logger, request, closed_kwargs):
                     await self._response_closed(stream_id=stream_id)
+            raise self._map_exception(exc)
 
-            if isinstance(exc, h2.exceptions.ProtocolError):
-                # One case where h2 can raise a protocol error is when a
-                # closed frame has been seen by the state machine.
-                #
-                # This happens when one stream is reading, and encounters
-                # a GOAWAY event. Other flows of control may then raise
-                # a protocol error at any point they interact with the 'h2_state'.
-                #
-                # In this case we'll have stored the event, and should raise
-                # it as a RemoteProtocolError.
-                if self._connection_terminated:  # pragma: no cover
-                    raise RemoteProtocolError(self._connection_terminated)
-                # If h2 raises a protocol error in some other state then we
-                # must somehow have made a protocol violation.
-                raise LocalProtocolError(exc)  # pragma: no cover
-
-            raise exc
+    def _map_exception(self, exc: BaseException) -> BaseException:
+        if isinstance(exc, h2.exceptions.ProtocolError):
+            # One case where h2 can raise a protocol error is when a
+            # closed frame has been seen by the state machine.
+            #
+            # This happens when one stream is reading, and encounters
+            # a GOAWAY event. Other flows of control may then raise
+            # a protocol error at any point they interact with the 'h2_state'.
+            #
+            # In this case we'll have stored the event, and should raise
+            # it as a RemoteProtocolError.
+            if self._connection_terminated:  # pragma: no cover
+                return RemoteProtocolError(self._connection_terminated)
+            # If h2 raises a protocol error in some other state then we
+            # must somehow have made a protocol violation.
+            return LocalProtocolError(exc)  # pragma: no cover
+        return exc
 
     async def _send_connection_init(self, request: Request) -> None:
         """
@@ -200,6 +216,8 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
     async def _send_request_headers(self, request: Request, stream_id: int) -> None:
         """
         Send the request headers to a given stream ID.
+
+        Must be called while holding the write lock.
         """
         end_stream = not has_body_headers(request)
 
@@ -226,7 +244,7 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
 
         self._h2_state.send_headers(stream_id, headers, end_stream=end_stream)
         self._h2_state.increment_flow_control_window(2**24, stream_id=stream_id)
-        await self._write_outgoing_data(request)
+        await self._flush_outgoing_data(request)
 
     async def _send_request_body(self, request: Request, stream_id: int) -> None:
         """
@@ -245,21 +263,34 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
     async def _send_stream_data(self, request: Request, stream_id: int, data: bytes) -> None:
         """
         Send a single chunk of data in one or more data frames.
+
+        The available outgoing flow must be checked under the write lock, since
+        concurrent streams share the connection-level flow control window.
+        If the allowable flow is zero, then we wait on the network until
+        WindowUpdated frames have increased the flow rate.
+        https://tools.ietf.org/html/rfc7540#section-6.9
         """
         position = 0
         while position < len(data):
-            max_flow = await self._wait_for_outgoing_flow(request, stream_id)
-            chunk = data[position : position + max_flow]
-            position += len(chunk)
-            self._h2_state.send_data(stream_id, chunk)
-            await self._write_outgoing_data(request)
+            async with self._write_lock:
+                local_flow: int = self._h2_state.local_flow_control_window(stream_id)
+                max_frame_size: int = self._h2_state.max_outbound_frame_size
+                max_flow = min(local_flow, max_frame_size)
+                if max_flow > 0:
+                    chunk = data[position : position + max_flow]
+                    position += len(chunk)
+                    self._h2_state.send_data(stream_id, chunk)
+                    await self._flush_outgoing_data(request)
+                    continue
+            await self._receive_events(request)
 
     async def _send_end_stream(self, request: Request, stream_id: int) -> None:
         """
         Send an empty data frame on on a given stream ID with the END_STREAM flag set.
         """
-        self._h2_state.end_stream(stream_id)
-        await self._write_outgoing_data(request)
+        async with self._write_lock:
+            self._h2_state.end_stream(stream_id)
+            await self._flush_outgoing_data(request)
 
     # Receiving the response...
 
@@ -293,8 +324,9 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
                 assert event.flow_controlled_length is not None
                 assert event.data is not None
                 amount = event.flow_controlled_length
-                self._h2_state.acknowledge_received_data(amount, stream_id)
-                await self._write_outgoing_data(request)
+                async with self._write_lock:
+                    self._h2_state.acknowledge_received_data(amount, stream_id)
+                    await self._flush_outgoing_data(request)
                 yield event.data
             elif isinstance(event, h2.events.StreamEnded):
                 break
@@ -422,54 +454,43 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
             self._connection_error = True
             raise exc
 
-        events: list[h2.events.Event] = self._h2_state.receive_data(data)
+        async with self._write_lock:
+            events: list[h2.events.Event] = self._h2_state.receive_data(data)
 
         return events
 
     async def _write_outgoing_data(self, request: Request) -> None:
+        async with self._write_lock:
+            await self._flush_outgoing_data(request)
+
+    async def _flush_outgoing_data(self, request: Request) -> None:
+        """
+        Write any pending outgoing data to the network.
+
+        Must be called while holding the write lock.
+        """
         timeouts = request.extensions.get("timeout", {})
         timeout = timeouts.get("write", None)
 
-        async with self._write_lock:
-            data_to_send = self._h2_state.data_to_send()
+        data_to_send = self._h2_state.data_to_send()
 
-            if self._write_exception is not None:
-                raise self._write_exception  # pragma: no cover
+        if self._write_exception is not None:
+            raise self._write_exception  # pragma: no cover
 
-            try:
-                await self._network_stream.write(data_to_send, timeout)
-            except Exception as exc:  # pragma: no cover
-                # If we get a network error we should:
-                #
-                # 1. Save the exception and just raise it immediately on any future write.
-                #    (For example, this means that a single write timeout or disconnect will
-                #    immediately close all pending streams. Without requiring multiple
-                #    sequential timeouts.)
-                # 2. Mark the connection as errored, so that we don't accept any other
-                #    incoming requests.
-                self._write_exception = exc
-                self._connection_error = True
-                raise exc
-
-    # Flow control...
-
-    async def _wait_for_outgoing_flow(self, request: Request, stream_id: int) -> int:
-        """
-        Returns the maximum allowable outgoing flow for a given stream.
-
-        If the allowable flow is zero, then waits on the network until
-        WindowUpdated frames have increased the flow rate.
-        https://tools.ietf.org/html/rfc7540#section-6.9
-        """
-        local_flow: int = self._h2_state.local_flow_control_window(stream_id)
-        max_frame_size: int = self._h2_state.max_outbound_frame_size
-        flow = min(local_flow, max_frame_size)
-        while flow <= 0:
-            await self._receive_events(request)
-            local_flow = self._h2_state.local_flow_control_window(stream_id)
-            max_frame_size = self._h2_state.max_outbound_frame_size
-            flow = min(local_flow, max_frame_size)
-        return flow
+        try:
+            await self._network_stream.write(data_to_send, timeout)
+        except Exception as exc:  # pragma: no cover
+            # If we get a network error we should:
+            #
+            # 1. Save the exception and just raise it immediately on any future write.
+            #    (For example, this means that a single write timeout or disconnect will
+            #    immediately close all pending streams. Without requiring multiple
+            #    sequential timeouts.)
+            # 2. Mark the connection as errored, so that we don't accept any other
+            #    incoming requests.
+            self._write_exception = exc
+            self._connection_error = True
+            raise exc
 
     # Interface for connection pooling...
 

--- a/src/httpcore2/httpcore2/_async/http2.py
+++ b/src/httpcore2/httpcore2/_async/http2.py
@@ -124,15 +124,18 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
                     # Stream ID allocation, HPACK encoding of the outgoing headers, and
                     # writing the HEADERS frame to the network must be a single atomic
                     # section with respect to other streams on this connection.
-                    stream_id = self._h2_state.get_next_available_stream_id()
+                    try:
+                        stream_id = self._h2_state.get_next_available_stream_id()
+                    except h2.exceptions.NoAvailableStreamIDError:  # pragma: no cover
+                        self._used_all_stream_ids = True
+                        self._request_count -= 1
+                        await self._max_streams_semaphore.release()
+                        raise ConnectionNotAvailable()
                     self._events[stream_id] = []
                     kwargs["stream_id"] = stream_id
                     await self._send_request_headers(request=request, stream_id=stream_id)
-        except h2.exceptions.NoAvailableStreamIDError:  # pragma: no cover
-            self._used_all_stream_ids = True
-            self._request_count -= 1
-            await self._max_streams_semaphore.release()
-            raise ConnectionNotAvailable()
+        except ConnectionNotAvailable:  # pragma: no cover
+            raise
         except BaseException as exc:  # noqa: PIE786
             with AsyncShieldCancellation():
                 if stream_id is None:  # pragma: no cover

--- a/src/httpcore2/httpcore2/_sync/http2.py
+++ b/src/httpcore2/httpcore2/_sync/http2.py
@@ -213,7 +213,8 @@ class HTTP2Connection(ConnectionInterface):
 
         self._h2_state.initiate_connection()
         self._h2_state.increment_flow_control_window(2**24)
-        self._write_outgoing_data(request)
+        with self._write_lock:
+            self._flush_outgoing_data(request)
 
     # Sending the request...
 
@@ -370,29 +371,41 @@ class HTTP2Connection(ConnectionInterface):
             # block until we've available flow control, event when we have events
             # pending for the stream ID we're attempting to send on.
             if stream_id is None or not self._events.get(stream_id):
-                events = self._read_incoming_data(request)
-                for event in events:
-                    if isinstance(event, h2.events.RemoteSettingsChanged):
-                        with Trace("receive_remote_settings", logger, request) as trace:
-                            self._receive_remote_settings_change(event)
-                            trace.return_value = event
+                data = self._read_incoming_data(request)
+                settings_changes: list[h2.events.RemoteSettingsChanged] = []
+                with self._write_lock:
+                    # Feeding inbound data into the `h2` state machine, recording
+                    # the resulting events, and flushing any outgoing data (such as
+                    # automatic PING responses) must be atomic with respect to
+                    # outgoing frames from concurrently sending streams.
+                    events: list[h2.events.Event] = self._h2_state.receive_data(data)
+                    for event in events:
+                        if isinstance(event, h2.events.RemoteSettingsChanged):
+                            settings_changes.append(event)
 
-                    elif isinstance(
-                        event,
-                        (
-                            h2.events.ResponseReceived,
-                            h2.events.DataReceived,
-                            h2.events.StreamEnded,
-                            h2.events.StreamReset,
-                        ),
-                    ):
-                        if event.stream_id in self._events:
-                            self._events[event.stream_id].append(event)
+                        elif isinstance(
+                            event,
+                            (
+                                h2.events.ResponseReceived,
+                                h2.events.DataReceived,
+                                h2.events.StreamEnded,
+                                h2.events.StreamReset,
+                            ),
+                        ):
+                            if event.stream_id in self._events:
+                                self._events[event.stream_id].append(event)
 
-                    elif isinstance(event, h2.events.ConnectionTerminated):
-                        self._connection_terminated = event
+                        elif isinstance(event, h2.events.ConnectionTerminated):
+                            self._connection_terminated = event
 
-        self._write_outgoing_data(request)
+                    self._flush_outgoing_data(request)
+
+                # Adjusting the max streams semaphore may block, and the trace
+                # extension runs user code, so both happen outside the write lock.
+                for settings_change in settings_changes:
+                    with Trace("receive_remote_settings", logger, request) as trace:
+                        self._receive_remote_settings_change(settings_change)
+                        trace.return_value = settings_change
 
     def _receive_remote_settings_change(self, event: h2.events.RemoteSettingsChanged) -> None:
         max_concurrent_streams = event.changed_settings.get(h2.settings.SettingCodes.MAX_CONCURRENT_STREAMS)
@@ -434,7 +447,7 @@ class HTTP2Connection(ConnectionInterface):
 
     # Wrappers around network read/write operations...
 
-    def _read_incoming_data(self, request: Request) -> list[h2.events.Event]:
+    def _read_incoming_data(self, request: Request) -> bytes:
         timeouts = request.extensions.get("timeout", {})
         timeout = timeouts.get("read", None)
 
@@ -458,14 +471,7 @@ class HTTP2Connection(ConnectionInterface):
             self._connection_error = True
             raise exc
 
-        with self._write_lock:
-            events: list[h2.events.Event] = self._h2_state.receive_data(data)
-
-        return events
-
-    def _write_outgoing_data(self, request: Request) -> None:
-        with self._write_lock:
-            self._flush_outgoing_data(request)
+        return data
 
     def _flush_outgoing_data(self, request: Request) -> None:
         """

--- a/src/httpcore2/httpcore2/_sync/http2.py
+++ b/src/httpcore2/httpcore2/_sync/http2.py
@@ -117,6 +117,7 @@ class HTTP2Connection(ConnectionInterface):
         self._max_streams_semaphore.acquire()
 
         stream_id: int | None = None
+        stream_ids_exhausted = False
         try:
             kwargs: dict[str, typing.Any] = {"request": request}
             with Trace("send_request_headers", logger, request, kwargs):
@@ -130,13 +131,14 @@ class HTTP2Connection(ConnectionInterface):
                         self._used_all_stream_ids = True
                         self._request_count -= 1
                         self._max_streams_semaphore.release()
+                        stream_ids_exhausted = True
                         raise ConnectionNotAvailable()
                     self._events[stream_id] = []
                     kwargs["stream_id"] = stream_id
                     self._send_request_headers(request=request, stream_id=stream_id)
-        except ConnectionNotAvailable:  # pragma: no cover
-            raise
         except BaseException as exc:  # noqa: PIE786
+            if stream_ids_exhausted:  # pragma: no cover
+                raise
             with ShieldCancellation():
                 if stream_id is None:  # pragma: no cover
                     # The request failed before a stream was allocated, for

--- a/src/httpcore2/httpcore2/_sync/http2.py
+++ b/src/httpcore2/httpcore2/_sync/http2.py
@@ -54,6 +54,9 @@ class HTTP2Connection(ConnectionInterface):
         self._init_lock = Lock()
         self._state_lock = Lock()
         self._read_lock = Lock()
+        # The write lock guards every mutation of the `h2` state machine and the
+        # flush of its outgoing data, so that concurrent streams cannot interleave
+        # stream ID allocation, HPACK encoder state, or partially written frames.
         self._write_lock = Lock()
         self._sent_connection_init = False
         self._used_all_stream_ids = False
@@ -113,19 +116,31 @@ class HTTP2Connection(ConnectionInterface):
 
         self._max_streams_semaphore.acquire()
 
-        try:
-            stream_id = self._h2_state.get_next_available_stream_id()
-            self._events[stream_id] = []
-        except h2.exceptions.NoAvailableStreamIDError:  # pragma: no cover
-            self._used_all_stream_ids = True
-            self._request_count -= 1
-            self._max_streams_semaphore.release()
-            raise ConnectionNotAvailable()
+        with self._write_lock:
+            # Stream ID allocation, HPACK encoding of the outgoing headers, and
+            # writing the HEADERS frame to the network must be a single atomic
+            # section with respect to other streams on this connection.
+            try:
+                stream_id = self._h2_state.get_next_available_stream_id()
+                self._events[stream_id] = []
+            except h2.exceptions.NoAvailableStreamIDError:  # pragma: no cover
+                self._used_all_stream_ids = True
+                self._request_count -= 1
+                self._max_streams_semaphore.release()
+                raise ConnectionNotAvailable()
+
+            try:
+                kwargs = {"request": request, "stream_id": stream_id}
+                with Trace("send_request_headers", logger, request, kwargs):
+                    self._send_request_headers(request=request, stream_id=stream_id)
+            except BaseException as exc:  # noqa: PIE786
+                with ShieldCancellation():
+                    closed_kwargs = {"stream_id": stream_id}
+                    with Trace("response_closed", logger, request, closed_kwargs):
+                        self._response_closed(stream_id=stream_id)
+                raise self._map_exception(exc)
 
         try:
-            kwargs = {"request": request, "stream_id": stream_id}
-            with Trace("send_request_headers", logger, request, kwargs):
-                self._send_request_headers(request=request, stream_id=stream_id)
             with Trace("send_request_body", logger, request, kwargs):
                 self._send_request_body(request=request, stream_id=stream_id)
             with Trace("receive_response_headers", logger, request, kwargs) as trace:
@@ -144,27 +159,28 @@ class HTTP2Connection(ConnectionInterface):
             )
         except BaseException as exc:  # noqa: PIE786
             with ShieldCancellation():
-                kwargs = {"stream_id": stream_id}
-                with Trace("response_closed", logger, request, kwargs):
+                closed_kwargs = {"stream_id": stream_id}
+                with Trace("response_closed", logger, request, closed_kwargs):
                     self._response_closed(stream_id=stream_id)
+            raise self._map_exception(exc)
 
-            if isinstance(exc, h2.exceptions.ProtocolError):
-                # One case where h2 can raise a protocol error is when a
-                # closed frame has been seen by the state machine.
-                #
-                # This happens when one stream is reading, and encounters
-                # a GOAWAY event. Other flows of control may then raise
-                # a protocol error at any point they interact with the 'h2_state'.
-                #
-                # In this case we'll have stored the event, and should raise
-                # it as a RemoteProtocolError.
-                if self._connection_terminated:  # pragma: no cover
-                    raise RemoteProtocolError(self._connection_terminated)
-                # If h2 raises a protocol error in some other state then we
-                # must somehow have made a protocol violation.
-                raise LocalProtocolError(exc)  # pragma: no cover
-
-            raise exc
+    def _map_exception(self, exc: BaseException) -> BaseException:
+        if isinstance(exc, h2.exceptions.ProtocolError):
+            # One case where h2 can raise a protocol error is when a
+            # closed frame has been seen by the state machine.
+            #
+            # This happens when one stream is reading, and encounters
+            # a GOAWAY event. Other flows of control may then raise
+            # a protocol error at any point they interact with the 'h2_state'.
+            #
+            # In this case we'll have stored the event, and should raise
+            # it as a RemoteProtocolError.
+            if self._connection_terminated:  # pragma: no cover
+                return RemoteProtocolError(self._connection_terminated)
+            # If h2 raises a protocol error in some other state then we
+            # must somehow have made a protocol violation.
+            return LocalProtocolError(exc)  # pragma: no cover
+        return exc
 
     def _send_connection_init(self, request: Request) -> None:
         """
@@ -200,6 +216,8 @@ class HTTP2Connection(ConnectionInterface):
     def _send_request_headers(self, request: Request, stream_id: int) -> None:
         """
         Send the request headers to a given stream ID.
+
+        Must be called while holding the write lock.
         """
         end_stream = not has_body_headers(request)
 
@@ -226,7 +244,7 @@ class HTTP2Connection(ConnectionInterface):
 
         self._h2_state.send_headers(stream_id, headers, end_stream=end_stream)
         self._h2_state.increment_flow_control_window(2**24, stream_id=stream_id)
-        self._write_outgoing_data(request)
+        self._flush_outgoing_data(request)
 
     def _send_request_body(self, request: Request, stream_id: int) -> None:
         """
@@ -245,21 +263,34 @@ class HTTP2Connection(ConnectionInterface):
     def _send_stream_data(self, request: Request, stream_id: int, data: bytes) -> None:
         """
         Send a single chunk of data in one or more data frames.
+
+        The available outgoing flow must be checked under the write lock, since
+        concurrent streams share the connection-level flow control window.
+        If the allowable flow is zero, then we wait on the network until
+        WindowUpdated frames have increased the flow rate.
+        https://tools.ietf.org/html/rfc7540#section-6.9
         """
         position = 0
         while position < len(data):
-            max_flow = self._wait_for_outgoing_flow(request, stream_id)
-            chunk = data[position : position + max_flow]
-            position += len(chunk)
-            self._h2_state.send_data(stream_id, chunk)
-            self._write_outgoing_data(request)
+            with self._write_lock:
+                local_flow: int = self._h2_state.local_flow_control_window(stream_id)
+                max_frame_size: int = self._h2_state.max_outbound_frame_size
+                max_flow = min(local_flow, max_frame_size)
+                if max_flow > 0:
+                    chunk = data[position : position + max_flow]
+                    position += len(chunk)
+                    self._h2_state.send_data(stream_id, chunk)
+                    self._flush_outgoing_data(request)
+                    continue
+            self._receive_events(request)
 
     def _send_end_stream(self, request: Request, stream_id: int) -> None:
         """
         Send an empty data frame on on a given stream ID with the END_STREAM flag set.
         """
-        self._h2_state.end_stream(stream_id)
-        self._write_outgoing_data(request)
+        with self._write_lock:
+            self._h2_state.end_stream(stream_id)
+            self._flush_outgoing_data(request)
 
     # Receiving the response...
 
@@ -293,8 +324,9 @@ class HTTP2Connection(ConnectionInterface):
                 assert event.flow_controlled_length is not None
                 assert event.data is not None
                 amount = event.flow_controlled_length
-                self._h2_state.acknowledge_received_data(amount, stream_id)
-                self._write_outgoing_data(request)
+                with self._write_lock:
+                    self._h2_state.acknowledge_received_data(amount, stream_id)
+                    self._flush_outgoing_data(request)
                 yield event.data
             elif isinstance(event, h2.events.StreamEnded):
                 break
@@ -422,54 +454,43 @@ class HTTP2Connection(ConnectionInterface):
             self._connection_error = True
             raise exc
 
-        events: list[h2.events.Event] = self._h2_state.receive_data(data)
+        with self._write_lock:
+            events: list[h2.events.Event] = self._h2_state.receive_data(data)
 
         return events
 
     def _write_outgoing_data(self, request: Request) -> None:
+        with self._write_lock:
+            self._flush_outgoing_data(request)
+
+    def _flush_outgoing_data(self, request: Request) -> None:
+        """
+        Write any pending outgoing data to the network.
+
+        Must be called while holding the write lock.
+        """
         timeouts = request.extensions.get("timeout", {})
         timeout = timeouts.get("write", None)
 
-        with self._write_lock:
-            data_to_send = self._h2_state.data_to_send()
+        data_to_send = self._h2_state.data_to_send()
 
-            if self._write_exception is not None:
-                raise self._write_exception  # pragma: no cover
+        if self._write_exception is not None:
+            raise self._write_exception  # pragma: no cover
 
-            try:
-                self._network_stream.write(data_to_send, timeout)
-            except Exception as exc:  # pragma: no cover
-                # If we get a network error we should:
-                #
-                # 1. Save the exception and just raise it immediately on any future write.
-                #    (For example, this means that a single write timeout or disconnect will
-                #    immediately close all pending streams. Without requiring multiple
-                #    sequential timeouts.)
-                # 2. Mark the connection as errored, so that we don't accept any other
-                #    incoming requests.
-                self._write_exception = exc
-                self._connection_error = True
-                raise exc
-
-    # Flow control...
-
-    def _wait_for_outgoing_flow(self, request: Request, stream_id: int) -> int:
-        """
-        Returns the maximum allowable outgoing flow for a given stream.
-
-        If the allowable flow is zero, then waits on the network until
-        WindowUpdated frames have increased the flow rate.
-        https://tools.ietf.org/html/rfc7540#section-6.9
-        """
-        local_flow: int = self._h2_state.local_flow_control_window(stream_id)
-        max_frame_size: int = self._h2_state.max_outbound_frame_size
-        flow = min(local_flow, max_frame_size)
-        while flow <= 0:
-            self._receive_events(request)
-            local_flow = self._h2_state.local_flow_control_window(stream_id)
-            max_frame_size = self._h2_state.max_outbound_frame_size
-            flow = min(local_flow, max_frame_size)
-        return flow
+        try:
+            self._network_stream.write(data_to_send, timeout)
+        except Exception as exc:  # pragma: no cover
+            # If we get a network error we should:
+            #
+            # 1. Save the exception and just raise it immediately on any future write.
+            #    (For example, this means that a single write timeout or disconnect will
+            #    immediately close all pending streams. Without requiring multiple
+            #    sequential timeouts.)
+            # 2. Mark the connection as errored, so that we don't accept any other
+            #    incoming requests.
+            self._write_exception = exc
+            self._connection_error = True
+            raise exc
 
     # Interface for connection pooling...
 

--- a/src/httpcore2/httpcore2/_sync/http2.py
+++ b/src/httpcore2/httpcore2/_sync/http2.py
@@ -116,30 +116,34 @@ class HTTP2Connection(ConnectionInterface):
 
         self._max_streams_semaphore.acquire()
 
-        with self._write_lock:
-            # Stream ID allocation, HPACK encoding of the outgoing headers, and
-            # writing the HEADERS frame to the network must be a single atomic
-            # section with respect to other streams on this connection.
-            try:
-                stream_id = self._h2_state.get_next_available_stream_id()
-                self._events[stream_id] = []
-            except h2.exceptions.NoAvailableStreamIDError:  # pragma: no cover
-                self._used_all_stream_ids = True
-                self._request_count -= 1
-                self._max_streams_semaphore.release()
-                raise ConnectionNotAvailable()
-
-            try:
-                kwargs = {"request": request, "stream_id": stream_id}
-                with Trace("send_request_headers", logger, request, kwargs):
+        stream_id: int | None = None
+        try:
+            kwargs: dict[str, typing.Any] = {"request": request}
+            with Trace("send_request_headers", logger, request, kwargs):
+                with self._write_lock:
+                    # Stream ID allocation, HPACK encoding of the outgoing headers, and
+                    # writing the HEADERS frame to the network must be a single atomic
+                    # section with respect to other streams on this connection.
+                    stream_id = self._h2_state.get_next_available_stream_id()
+                    self._events[stream_id] = []
+                    kwargs["stream_id"] = stream_id
                     self._send_request_headers(request=request, stream_id=stream_id)
-            except BaseException as exc:  # noqa: PIE786
-                with ShieldCancellation():
+        except h2.exceptions.NoAvailableStreamIDError:  # pragma: no cover
+            self._used_all_stream_ids = True
+            self._request_count -= 1
+            self._max_streams_semaphore.release()
+            raise ConnectionNotAvailable()
+        except BaseException as exc:  # noqa: PIE786
+            with ShieldCancellation():
+                if stream_id is None:  # pragma: no cover
+                    self._max_streams_semaphore.release()
+                else:
                     closed_kwargs = {"stream_id": stream_id}
                     with Trace("response_closed", logger, request, closed_kwargs):
                         self._response_closed(stream_id=stream_id)
-                raise self._map_exception(exc)
+            raise self._map_exception(exc)
 
+        assert stream_id is not None
         try:
             with Trace("send_request_body", logger, request, kwargs):
                 self._send_request_body(request=request, stream_id=stream_id)

--- a/src/httpcore2/httpcore2/_sync/http2.py
+++ b/src/httpcore2/httpcore2/_sync/http2.py
@@ -136,7 +136,15 @@ class HTTP2Connection(ConnectionInterface):
         except BaseException as exc:  # noqa: PIE786
             with ShieldCancellation():
                 if stream_id is None:  # pragma: no cover
+                    # The request failed before a stream was allocated, for
+                    # example within the trace 'started' callback, or by
+                    # cancellation while waiting on the write lock.
                     self._max_streams_semaphore.release()
+                    with self._state_lock:
+                        if self._state == HTTPConnectionState.ACTIVE and not self._events:
+                            self._state = HTTPConnectionState.IDLE
+                            if self._keepalive_expiry is not None:
+                                self._expire_at = time.monotonic() + self._keepalive_expiry
                 else:
                     closed_kwargs = {"stream_id": stream_id}
                     with Trace("response_closed", logger, request, closed_kwargs):

--- a/src/httpcore2/httpcore2/_sync/http2.py
+++ b/src/httpcore2/httpcore2/_sync/http2.py
@@ -124,15 +124,18 @@ class HTTP2Connection(ConnectionInterface):
                     # Stream ID allocation, HPACK encoding of the outgoing headers, and
                     # writing the HEADERS frame to the network must be a single atomic
                     # section with respect to other streams on this connection.
-                    stream_id = self._h2_state.get_next_available_stream_id()
+                    try:
+                        stream_id = self._h2_state.get_next_available_stream_id()
+                    except h2.exceptions.NoAvailableStreamIDError:  # pragma: no cover
+                        self._used_all_stream_ids = True
+                        self._request_count -= 1
+                        self._max_streams_semaphore.release()
+                        raise ConnectionNotAvailable()
                     self._events[stream_id] = []
                     kwargs["stream_id"] = stream_id
                     self._send_request_headers(request=request, stream_id=stream_id)
-        except h2.exceptions.NoAvailableStreamIDError:  # pragma: no cover
-            self._used_all_stream_ids = True
-            self._request_count -= 1
-            self._max_streams_semaphore.release()
-            raise ConnectionNotAvailable()
+        except ConnectionNotAvailable:  # pragma: no cover
+            raise
         except BaseException as exc:  # noqa: PIE786
             with ShieldCancellation():
                 if stream_id is None:  # pragma: no cover

--- a/tests/httpcore2/_async/test_http2.py
+++ b/tests/httpcore2/_async/test_http2.py
@@ -1,6 +1,9 @@
+import sys
+
 import hpack
 import hyperframe.frame
 import pytest
+import trio as concurrency
 
 import httpcore2
 
@@ -97,6 +100,54 @@ async def test_http2_response_closed_twice() -> None:
 
         # The stream was closed when the response completed.
         await conn._response_closed(stream_id=1)
+
+
+@pytest.mark.trio
+async def test_http2_connection_concurrent_requests() -> None:
+    """
+    Concurrent requests over a single HTTP/2 connection must not corrupt the
+    shared `h2` state machine. In the sync case this exercises multiple threads
+    sharing one connection. See https://github.com/pydantic/httpx2/discussions/1152
+    """
+    switch_interval = sys.getswitchinterval()
+    sys.setswitchinterval(1e-6)
+    requests_count = 10
+    origin = httpcore2.Origin(b"https", b"example.com", 443)
+    encoder = hpack.Encoder()
+    buffer = [
+        hyperframe.frame.SettingsFrame(
+            settings={hyperframe.frame.SettingsFrame.MAX_CONCURRENT_STREAMS: 100}
+        ).serialize()
+    ]
+    for stream_id in range(1, requests_count * 2, 2):
+        buffer.append(
+            hyperframe.frame.HeadersFrame(
+                stream_id=stream_id,
+                data=encoder.encode([(b":status", b"200"), (b"content-type", b"plain/text")]),
+                flags=["END_HEADERS"],
+            ).serialize()
+        )
+        buffer.append(
+            hyperframe.frame.DataFrame(stream_id=stream_id, data=b"Hello, world!", flags=["END_STREAM"]).serialize()
+        )
+    stream = httpcore2.AsyncMockStream(buffer)
+
+    async def fetch(conn: httpcore2.AsyncHTTP2Connection, responses: list[httpcore2.Response]) -> None:
+        response = await conn.request("GET", "https://example.com/")
+        responses.append(response)
+
+    async with httpcore2.AsyncHTTP2Connection(origin=origin, stream=stream) as conn:
+        responses: list[httpcore2.Response] = []
+        async with concurrency.open_nursery() as nursery:
+            for _ in range(requests_count):
+                nursery.start_soon(fetch, conn, responses)
+
+        assert len(responses) == requests_count
+        for response in responses:
+            assert response.status == 200
+            assert response.content == b"Hello, world!"
+
+    sys.setswitchinterval(switch_interval)
 
 
 @pytest.mark.anyio

--- a/tests/httpcore2/_async/test_http2.py
+++ b/tests/httpcore2/_async/test_http2.py
@@ -111,43 +111,44 @@ async def test_http2_connection_concurrent_requests() -> None:
     """
     switch_interval = sys.getswitchinterval()
     sys.setswitchinterval(1e-6)
-    requests_count = 10
-    origin = httpcore2.Origin(b"https", b"example.com", 443)
-    encoder = hpack.Encoder()
-    buffer = [
-        hyperframe.frame.SettingsFrame(
-            settings={hyperframe.frame.SettingsFrame.MAX_CONCURRENT_STREAMS: 100}
-        ).serialize()
-    ]
-    for stream_id in range(1, requests_count * 2, 2):
-        buffer.append(
-            hyperframe.frame.HeadersFrame(
-                stream_id=stream_id,
-                data=encoder.encode([(b":status", b"200"), (b"content-type", b"plain/text")]),
-                flags=["END_HEADERS"],
+    try:
+        requests_count = 10
+        origin = httpcore2.Origin(b"https", b"example.com", 443)
+        encoder = hpack.Encoder()
+        buffer = [
+            hyperframe.frame.SettingsFrame(
+                settings={hyperframe.frame.SettingsFrame.MAX_CONCURRENT_STREAMS: 100}
             ).serialize()
-        )
-        buffer.append(
-            hyperframe.frame.DataFrame(stream_id=stream_id, data=b"Hello, world!", flags=["END_STREAM"]).serialize()
-        )
-    stream = httpcore2.AsyncMockStream(buffer)
+        ]
+        for stream_id in range(1, requests_count * 2, 2):
+            buffer.append(
+                hyperframe.frame.HeadersFrame(
+                    stream_id=stream_id,
+                    data=encoder.encode([(b":status", b"200"), (b"content-type", b"plain/text")]),
+                    flags=["END_HEADERS"],
+                ).serialize()
+            )
+            buffer.append(
+                hyperframe.frame.DataFrame(stream_id=stream_id, data=b"Hello, world!", flags=["END_STREAM"]).serialize()
+            )
+        stream = httpcore2.AsyncMockStream(buffer)
 
-    async def fetch(conn: httpcore2.AsyncHTTP2Connection, responses: list[httpcore2.Response]) -> None:
-        response = await conn.request("GET", "https://example.com/")
-        responses.append(response)
+        async def fetch(conn: httpcore2.AsyncHTTP2Connection, responses: list[httpcore2.Response]) -> None:
+            response = await conn.request("GET", "https://example.com/")
+            responses.append(response)
 
-    async with httpcore2.AsyncHTTP2Connection(origin=origin, stream=stream) as conn:
-        responses: list[httpcore2.Response] = []
-        async with concurrency.open_nursery() as nursery:
-            for _ in range(requests_count):
-                nursery.start_soon(fetch, conn, responses)
+        async with httpcore2.AsyncHTTP2Connection(origin=origin, stream=stream) as conn:
+            responses: list[httpcore2.Response] = []
+            async with concurrency.open_nursery() as nursery:
+                for _ in range(requests_count):
+                    nursery.start_soon(fetch, conn, responses)
 
-        assert len(responses) == requests_count
-        for response in responses:
-            assert response.status == 200
-            assert response.content == b"Hello, world!"
-
-    sys.setswitchinterval(switch_interval)
+            assert len(responses) == requests_count
+            for response in responses:
+                assert response.status == 200
+                assert response.content == b"Hello, world!"
+    finally:
+        sys.setswitchinterval(switch_interval)
 
 
 @pytest.mark.anyio

--- a/tests/httpcore2/_sync/test_http2.py
+++ b/tests/httpcore2/_sync/test_http2.py
@@ -1,6 +1,9 @@
+import sys
+
 import hpack
 import hyperframe.frame
 import pytest
+from tests.httpcore2 import concurrency
 
 import httpcore2
 
@@ -97,6 +100,54 @@ def test_http2_response_closed_twice() -> None:
 
         # The stream was closed when the response completed.
         conn._response_closed(stream_id=1)
+
+
+
+def test_http2_connection_concurrent_requests() -> None:
+    """
+    Concurrent requests over a single HTTP/2 connection must not corrupt the
+    shared `h2` state machine. In the sync case this exercises multiple threads
+    sharing one connection. See https://github.com/pydantic/httpx2/discussions/1152
+    """
+    switch_interval = sys.getswitchinterval()
+    sys.setswitchinterval(1e-6)
+    requests_count = 10
+    origin = httpcore2.Origin(b"https", b"example.com", 443)
+    encoder = hpack.Encoder()
+    buffer = [
+        hyperframe.frame.SettingsFrame(
+            settings={hyperframe.frame.SettingsFrame.MAX_CONCURRENT_STREAMS: 100}
+        ).serialize()
+    ]
+    for stream_id in range(1, requests_count * 2, 2):
+        buffer.append(
+            hyperframe.frame.HeadersFrame(
+                stream_id=stream_id,
+                data=encoder.encode([(b":status", b"200"), (b"content-type", b"plain/text")]),
+                flags=["END_HEADERS"],
+            ).serialize()
+        )
+        buffer.append(
+            hyperframe.frame.DataFrame(stream_id=stream_id, data=b"Hello, world!", flags=["END_STREAM"]).serialize()
+        )
+    stream = httpcore2.MockStream(buffer)
+
+    def fetch(conn: httpcore2.HTTP2Connection, responses: list[httpcore2.Response]) -> None:
+        response = conn.request("GET", "https://example.com/")
+        responses.append(response)
+
+    with httpcore2.HTTP2Connection(origin=origin, stream=stream) as conn:
+        responses: list[httpcore2.Response] = []
+        with concurrency.open_nursery() as nursery:
+            for _ in range(requests_count):
+                nursery.start_soon(fetch, conn, responses)
+
+        assert len(responses) == requests_count
+        for response in responses:
+            assert response.status == 200
+            assert response.content == b"Hello, world!"
+
+    sys.setswitchinterval(switch_interval)
 
 
 

--- a/tests/httpcore2/_sync/test_http2.py
+++ b/tests/httpcore2/_sync/test_http2.py
@@ -111,43 +111,44 @@ def test_http2_connection_concurrent_requests() -> None:
     """
     switch_interval = sys.getswitchinterval()
     sys.setswitchinterval(1e-6)
-    requests_count = 10
-    origin = httpcore2.Origin(b"https", b"example.com", 443)
-    encoder = hpack.Encoder()
-    buffer = [
-        hyperframe.frame.SettingsFrame(
-            settings={hyperframe.frame.SettingsFrame.MAX_CONCURRENT_STREAMS: 100}
-        ).serialize()
-    ]
-    for stream_id in range(1, requests_count * 2, 2):
-        buffer.append(
-            hyperframe.frame.HeadersFrame(
-                stream_id=stream_id,
-                data=encoder.encode([(b":status", b"200"), (b"content-type", b"plain/text")]),
-                flags=["END_HEADERS"],
+    try:
+        requests_count = 10
+        origin = httpcore2.Origin(b"https", b"example.com", 443)
+        encoder = hpack.Encoder()
+        buffer = [
+            hyperframe.frame.SettingsFrame(
+                settings={hyperframe.frame.SettingsFrame.MAX_CONCURRENT_STREAMS: 100}
             ).serialize()
-        )
-        buffer.append(
-            hyperframe.frame.DataFrame(stream_id=stream_id, data=b"Hello, world!", flags=["END_STREAM"]).serialize()
-        )
-    stream = httpcore2.MockStream(buffer)
+        ]
+        for stream_id in range(1, requests_count * 2, 2):
+            buffer.append(
+                hyperframe.frame.HeadersFrame(
+                    stream_id=stream_id,
+                    data=encoder.encode([(b":status", b"200"), (b"content-type", b"plain/text")]),
+                    flags=["END_HEADERS"],
+                ).serialize()
+            )
+            buffer.append(
+                hyperframe.frame.DataFrame(stream_id=stream_id, data=b"Hello, world!", flags=["END_STREAM"]).serialize()
+            )
+        stream = httpcore2.MockStream(buffer)
 
-    def fetch(conn: httpcore2.HTTP2Connection, responses: list[httpcore2.Response]) -> None:
-        response = conn.request("GET", "https://example.com/")
-        responses.append(response)
+        def fetch(conn: httpcore2.HTTP2Connection, responses: list[httpcore2.Response]) -> None:
+            response = conn.request("GET", "https://example.com/")
+            responses.append(response)
 
-    with httpcore2.HTTP2Connection(origin=origin, stream=stream) as conn:
-        responses: list[httpcore2.Response] = []
-        with concurrency.open_nursery() as nursery:
-            for _ in range(requests_count):
-                nursery.start_soon(fetch, conn, responses)
+        with httpcore2.HTTP2Connection(origin=origin, stream=stream) as conn:
+            responses: list[httpcore2.Response] = []
+            with concurrency.open_nursery() as nursery:
+                for _ in range(requests_count):
+                    nursery.start_soon(fetch, conn, responses)
 
-        assert len(responses) == requests_count
-        for response in responses:
-            assert response.status == 200
-            assert response.content == b"Hello, world!"
-
-    sys.setswitchinterval(switch_interval)
+            assert len(responses) == requests_count
+            for response in responses:
+                assert response.status == 200
+                assert response.content == b"Hello, world!"
+    finally:
+        sys.setswitchinterval(switch_interval)
 
 
 


### PR DESCRIPTION
Closes #908, addresses discussion #1152.

A sync `Client(http2=True)` shared across threads corrupts the connection's `h2` state machine: stream ID allocation, HPACK encoding, and frame writes were not atomic with respect to each other, producing `StreamIDTooLowError`, `LocalProtocolError`, `KeyError`, and interleaved HEADERS frames on the wire.

## Changes

- Stream ID allocation, `_events` registration, and sending the HEADERS frame now happen as a single atomic section under the write lock. Two streams can no longer send HEADERS out of stream ID order or interleave HPACK encoder state.
- Every `h2` state mutation (`send_data`, `end_stream`, `acknowledge_received_data`, `receive_data`) is now paired with its `data_to_send()` flush under the write lock, so frames from concurrent streams cannot interleave mid-sequence.
- `_wait_for_outgoing_flow` is folded into `_send_stream_data`: the flow control window is checked and consumed under the same lock as the `send_data` that spends it, closing the window where two streams could both observe the same credit.
- The `h2.ProtocolError` -> `RemoteProtocolError`/`LocalProtocolError` mapping is extracted into `_map_exception` since the request flow now has two exception paths.

The async connection gets the same structure via unasync. Async locks are no-op-cheap under a single event loop, so behaviour there is unchanged.

## Testing

New `test_http2_connection_concurrent_requests` runs 10 concurrent requests over one connection - threads in the sync case, trio tasks in the async case. With a reduced `sys.setswitchinterval` the sync test fails deterministically on `main` (`StreamIDTooLowError` / `LocalProtocolError`) and passes with this change.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

