### PR TITLE
Fixed a grammatical mistake.

### DIFF
--- a/src/httpx2/httpx2/websockets/_exceptions.py
+++ b/src/httpx2/httpx2/websockets/_exceptions.py
@@ -41,7 +41,7 @@ class WebSocketDisconnect(HTTPXWSException):
 
 class WebSocketInvalidTypeReceived(HTTPXWSException):
     """
-    Raised when a event is not of the expected type.
+    Raised when an event is not of the expected type.
     """
 
     def __init__(self, event: wsproto.events.Event) -> None:


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX2! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->
Fixed a small grammatical mistake in the documentation for the WebSocket errors.

# Checklist

- [X] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [X] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [X] I've updated the documentation accordingly.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

