### PR TITLE
httpcore2: prefer h2 for ALPN protocol if requesting HTTP/2

### DIFF
--- a/src/httpcore2/httpcore2/_async/connection.py
+++ b/src/httpcore2/httpcore2/_async/connection.py
@@ -128,8 +128,9 @@ class AsyncHTTPConnection(AsyncConnectionInterface):
 
                 if self._origin.scheme in (b"https", b"wss"):
                     ssl_context = default_ssl_context() if self._ssl_context is None else self._ssl_context
-                    alpn_protocols = ["http/1.1", "h2"] if self._http2 else ["http/1.1"]
-                    ssl_context.set_alpn_protocols(alpn_protocols)
+                    ssl_context.set_alpn_protocols(
+                        (["h2", "http/1.1"] if self._http1 else ["h2"]) if self._http2 else ["http/1.1"]
+                    )
 
                     kwargs = {
                         "ssl_context": ssl_context,

--- a/src/httpcore2/httpcore2/_async/http_proxy.py
+++ b/src/httpcore2/httpcore2/_async/http_proxy.py
@@ -289,8 +289,9 @@ class AsyncTunnelHTTPConnection(AsyncConnectionInterface):
 
                 # Upgrade the stream to SSL
                 ssl_context = default_ssl_context() if self._ssl_context is None else self._ssl_context
-                alpn_protocols = ["http/1.1", "h2"] if self._http2 else ["http/1.1"]
-                ssl_context.set_alpn_protocols(alpn_protocols)
+                ssl_context.set_alpn_protocols(
+                    (["h2", "http/1.1"] if self._http1 else ["h2"]) if self._http2 else ["http/1.1"]
+                )
 
                 kwargs = {
                     "ssl_context": ssl_context,

--- a/src/httpcore2/httpcore2/_async/socks_proxy.py
+++ b/src/httpcore2/httpcore2/_async/socks_proxy.py
@@ -242,8 +242,9 @@ class AsyncSocks5Connection(AsyncConnectionInterface):
                     # Upgrade the stream to SSL
                     if self._remote_origin.scheme in (b"https", b"wss"):
                         ssl_context = default_ssl_context() if self._ssl_context is None else self._ssl_context
-                        alpn_protocols = ["http/1.1", "h2"] if self._http2 else ["http/1.1"]
-                        ssl_context.set_alpn_protocols(alpn_protocols)
+                        ssl_context.set_alpn_protocols(
+                            (["h2", "http/1.1"] if self._http1 else ["h2"]) if self._http2 else ["http/1.1"]
+                        )
 
                         kwargs = {
                             "ssl_context": ssl_context,

--- a/src/httpcore2/httpcore2/_sync/connection.py
+++ b/src/httpcore2/httpcore2/_sync/connection.py
@@ -128,8 +128,9 @@ class HTTPConnection(ConnectionInterface):
 
                 if self._origin.scheme in (b"https", b"wss"):
                     ssl_context = default_ssl_context() if self._ssl_context is None else self._ssl_context
-                    alpn_protocols = ["http/1.1", "h2"] if self._http2 else ["http/1.1"]
-                    ssl_context.set_alpn_protocols(alpn_protocols)
+                    ssl_context.set_alpn_protocols(
+                        (["h2", "http/1.1"] if self._http1 else ["h2"]) if self._http2 else ["http/1.1"]
+                    )
 
                     kwargs = {
                         "ssl_context": ssl_context,

--- a/src/httpcore2/httpcore2/_sync/http_proxy.py
+++ b/src/httpcore2/httpcore2/_sync/http_proxy.py
@@ -289,8 +289,9 @@ class TunnelHTTPConnection(ConnectionInterface):
 
                 # Upgrade the stream to SSL
                 ssl_context = default_ssl_context() if self._ssl_context is None else self._ssl_context
-                alpn_protocols = ["http/1.1", "h2"] if self._http2 else ["http/1.1"]
-                ssl_context.set_alpn_protocols(alpn_protocols)
+                ssl_context.set_alpn_protocols(
+                    (["h2", "http/1.1"] if self._http1 else ["h2"]) if self._http2 else ["http/1.1"]
+                )
 
                 kwargs = {
                     "ssl_context": ssl_context,

--- a/src/httpcore2/httpcore2/_sync/socks_proxy.py
+++ b/src/httpcore2/httpcore2/_sync/socks_proxy.py
@@ -242,8 +242,9 @@ class Socks5Connection(ConnectionInterface):
                     # Upgrade the stream to SSL
                     if self._remote_origin.scheme in (b"https", b"wss"):
                         ssl_context = default_ssl_context() if self._ssl_context is None else self._ssl_context
-                        alpn_protocols = ["http/1.1", "h2"] if self._http2 else ["http/1.1"]
-                        ssl_context.set_alpn_protocols(alpn_protocols)
+                        ssl_context.set_alpn_protocols(
+                            (["h2", "http/1.1"] if self._http1 else ["h2"]) if self._http2 else ["http/1.1"]
+                        )
 
                         kwargs = {
                             "ssl_context": ssl_context,


### PR DESCRIPTION
# Summary

When building the list of ALPN protocols for negotiation in the SSL context:
- If HTTP/2 is requested, prioritize "h2" first. This is critical, as some servers (e.g., lighttpd) select the first protocol in the list.
- If HTTP/1.1 is not disabled, include "http/1.1". If HTTP/1.1 was disabled we do not want to advertise that, otherwise the server may select HTTP/1.1 as protocol in the SSL context, but the client (httpx2) is still going to send the request using HTTP/2, which is going to confuse the server.
- If both HTTP/2 and HTTP/1.1 are disabled, still include "http/1.1" as a fallback.

# Checklist

- [X] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
      - I was not able to find the test infrastructure to test against an server with TLS and HTTP/2.
      - Maybe somebody could point me in the right direction.
- [ ] I've updated the documentation accordingly.
      - It does not seem necessary to update the documentation.

I will try to add test and to update the documentation if nobody is against this change :)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

