### PR TITLE
Recheck HTTP/2 flow after acquiring read lock

### DIFF
--- a/src/httpcore2/httpcore2/_async/http2.py
+++ b/src/httpcore2/httpcore2/_async/http2.py
@@ -314,7 +314,12 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
             raise RemoteProtocolError(event)
         return event
 
-    async def _receive_events(self, request: Request, stream_id: int | None = None) -> None:
+    async def _receive_events(
+        self,
+        request: Request,
+        stream_id: int | None = None,
+        awaiting_flow_on: int | None = None,
+    ) -> None:
         """
         Read some data from the network until we see one or more events
         for a given stream ID.
@@ -326,6 +331,11 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
                     self._request_count -= 1
                     raise ConnectionNotAvailable()
                 raise RemoteProtocolError(self._connection_terminated)
+
+            # Another task may have received the WINDOW_UPDATE while this task
+            # was queued for the read lock. Avoid blocking on a redundant read.
+            if awaiting_flow_on is not None and self._h2_state.local_flow_control_window(awaiting_flow_on) > 0:
+                return
 
             # This conditional is a bit icky. We don't want to block reading if we've
             # actually got an event to return for a given stream. We need to do that
@@ -465,7 +475,7 @@ class AsyncHTTP2Connection(AsyncConnectionInterface):
         max_frame_size: int = self._h2_state.max_outbound_frame_size
         flow = min(local_flow, max_frame_size)
         while flow <= 0:
-            await self._receive_events(request)
+            await self._receive_events(request, awaiting_flow_on=stream_id)
             local_flow = self._h2_state.local_flow_control_window(stream_id)
             max_frame_size = self._h2_state.max_outbound_frame_size
             flow = min(local_flow, max_frame_size)

--- a/src/httpcore2/httpcore2/_sync/http2.py
+++ b/src/httpcore2/httpcore2/_sync/http2.py
@@ -314,7 +314,12 @@ class HTTP2Connection(ConnectionInterface):
             raise RemoteProtocolError(event)
         return event
 
-    def _receive_events(self, request: Request, stream_id: int | None = None) -> None:
+    def _receive_events(
+        self,
+        request: Request,
+        stream_id: int | None = None,
+        awaiting_flow_on: int | None = None,
+    ) -> None:
         """
         Read some data from the network until we see one or more events
         for a given stream ID.
@@ -326,6 +331,11 @@ class HTTP2Connection(ConnectionInterface):
                     self._request_count -= 1
                     raise ConnectionNotAvailable()
                 raise RemoteProtocolError(self._connection_terminated)
+
+            # Another task may have received the WINDOW_UPDATE while this task
+            # was queued for the read lock. Avoid blocking on a redundant read.
+            if awaiting_flow_on is not None and self._h2_state.local_flow_control_window(awaiting_flow_on) > 0:
+                return
 
             # This conditional is a bit icky. We don't want to block reading if we've
             # actually got an event to return for a given stream. We need to do that
@@ -465,7 +475,7 @@ class HTTP2Connection(ConnectionInterface):
         max_frame_size: int = self._h2_state.max_outbound_frame_size
         flow = min(local_flow, max_frame_size)
         while flow <= 0:
-            self._receive_events(request)
+            self._receive_events(request, awaiting_flow_on=stream_id)
             local_flow = self._h2_state.local_flow_control_window(stream_id)
             max_frame_size = self._h2_state.max_outbound_frame_size
             flow = min(local_flow, max_frame_size)

--- a/tests/httpcore2/_async/test_http2.py
+++ b/tests/httpcore2/_async/test_http2.py
@@ -1,8 +1,28 @@
 import hpack
 import hyperframe.frame
 import pytest
+from h2.connection import H2Connection
 
 import httpcore2
+
+
+class AsyncFlowControlLock:
+    def __init__(self, h2_state: H2Connection, amount: int) -> None:
+        self._h2_state = h2_state
+        self._amount = amount
+
+    async def __aenter__(self) -> "AsyncFlowControlLock":
+        window_update = hyperframe.frame.WindowUpdateFrame(stream_id=0, window_increment=self._amount)
+        self._h2_state.receive_data(window_update.serialize())
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: object | None,
+    ) -> None:
+        pass
 
 
 @pytest.mark.anyio
@@ -312,6 +332,46 @@ async def test_http2_connection_with_flow_control() -> None:
         )
         assert response.status == 200
         assert response.content == b"100,000 bytes received"
+
+
+@pytest.mark.anyio
+async def test_http2_connection_rechecks_flow_after_acquiring_read_lock() -> None:
+    origin = httpcore2.Origin(b"https", b"example.com", 443)
+    stream = httpcore2.AsyncMockStream([])
+    request = httpcore2.Request("POST", "https://example.com/")
+    conn = httpcore2.AsyncHTTP2Connection(origin=origin, stream=stream)
+
+    conn._h2_state.initiate_connection()
+    conn._h2_state.send_headers(
+        stream_id=1,
+        headers=[
+            (b":method", b"POST"),
+            (b":scheme", b"https"),
+            (b":authority", b"example.com"),
+            (b":path", b"/"),
+        ],
+    )
+    conn._h2_state.send_headers(
+        stream_id=3,
+        headers=[
+            (b":method", b"POST"),
+            (b":scheme", b"https"),
+            (b":authority", b"example.com"),
+            (b":path", b"/"),
+        ],
+    )
+    while conn._h2_state.local_flow_control_window(stream_id=1) > 0:
+        amount = min(
+            conn._h2_state.local_flow_control_window(stream_id=1),
+            conn._h2_state.max_outbound_frame_size,
+        )
+        conn._h2_state.send_data(stream_id=1, data=b"x" * amount)
+
+    # Simulate another task replenishing the connection window while this task
+    # is queued for the read lock. There is no further network data to read.
+    conn._read_lock = AsyncFlowControlLock(conn._h2_state, amount=1)  # type: ignore[assignment]
+
+    assert await conn._wait_for_outgoing_flow(request, stream_id=3) == 1
 
 
 @pytest.mark.anyio

--- a/tests/httpcore2/_sync/test_http2.py
+++ b/tests/httpcore2/_sync/test_http2.py
@@ -1,8 +1,28 @@
 import hpack
 import hyperframe.frame
 import pytest
+from h2.connection import H2Connection
 
 import httpcore2
+
+
+class FlowControlLock:
+    def __init__(self, h2_state: H2Connection, amount: int) -> None:
+        self._h2_state = h2_state
+        self._amount = amount
+
+    def __enter__(self) -> "FlowControlLock":
+        window_update = hyperframe.frame.WindowUpdateFrame(stream_id=0, window_increment=self._amount)
+        self._h2_state.receive_data(window_update.serialize())
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: object | None,
+    ) -> None:
+        pass
 
 
 
@@ -312,6 +332,46 @@ def test_http2_connection_with_flow_control() -> None:
         )
         assert response.status == 200
         assert response.content == b"100,000 bytes received"
+
+
+
+def test_http2_connection_rechecks_flow_after_acquiring_read_lock() -> None:
+    origin = httpcore2.Origin(b"https", b"example.com", 443)
+    stream = httpcore2.MockStream([])
+    request = httpcore2.Request("POST", "https://example.com/")
+    conn = httpcore2.HTTP2Connection(origin=origin, stream=stream)
+
+    conn._h2_state.initiate_connection()
+    conn._h2_state.send_headers(
+        stream_id=1,
+        headers=[
+            (b":method", b"POST"),
+            (b":scheme", b"https"),
+            (b":authority", b"example.com"),
+            (b":path", b"/"),
+        ],
+    )
+    conn._h2_state.send_headers(
+        stream_id=3,
+        headers=[
+            (b":method", b"POST"),
+            (b":scheme", b"https"),
+            (b":authority", b"example.com"),
+            (b":path", b"/"),
+        ],
+    )
+    while conn._h2_state.local_flow_control_window(stream_id=1) > 0:
+        amount = min(
+            conn._h2_state.local_flow_control_window(stream_id=1),
+            conn._h2_state.max_outbound_frame_size,
+        )
+        conn._h2_state.send_data(stream_id=1, data=b"x" * amount)
+
+    # Simulate another task replenishing the connection window while this task
+    # is queued for the read lock. There is no further network data to read.
+    conn._read_lock = FlowControlLock(conn._h2_state, amount=1)  # type: ignore[assignment]
+
+    assert conn._wait_for_outgoing_flow(request, stream_id=3) == 1
 
 
 


### PR DESCRIPTION
Fixes #1133.

When multiple HTTP/2 uploads exhaust the connection window, a task waiting in `_wait_for_outgoing_flow()` may queue behind another task on the read lock. That earlier read can deliver the `WINDOW_UPDATE` the queued task needs, but the queued task currently performs another blocking read without rechecking its window.

This change:

- passes the flow-control stream ID into `_receive_events()`;
- rechecks the stream's effective outgoing window after acquiring the read lock and skips a redundant read when credit is already available;
- applies the change to both the async implementation and its generated sync counterpart;
- adds a deterministic regression test that restores connection credit during read-lock acquisition and verifies no further network read is attempted.

Tests:

- `scripts/check`
- `uv run pytest tests/httpcore2 -q` (238 passed)
- async and sync HTTP/2 tests (39 passed)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

