### PR TITLE
Support IP CIDR ranges in NO_PROXY

### DIFF
--- a/src/httpx2/httpx2/_utils.py
+++ b/src/httpx2/httpx2/_utils.py
@@ -168,12 +168,23 @@ class URLPattern:
             )
 
         url = URL(pattern)
+        self.network = None
+        prefix = url.path.lstrip("/")
+        if prefix:
+            # A CIDR-style host, e.g. "all://192.168.0.0/16" or "all://[::1]/64".
+            try:
+                self.network = ipaddress.ip_network(f"{url.host}/{prefix}", strict=False)
+            except ValueError:
+                self.network = None
+
         self.pattern = pattern
         self.scheme = "" if url.scheme == "all" else url.scheme
         self.host = "" if url.host == "*" else url.host
         self.port = url.port
-        if not url.host or url.host == "*":
+        if self.network is not None:
             self.host_regex: typing.Pattern[str] | None = None
+        elif not url.host or url.host == "*":
+            self.host_regex = None
         elif url.host.startswith("*."):
             # *.example.com should match "www.example.com", but not "example.com"
             domain = re.escape(url.host[2:])
@@ -190,25 +201,44 @@ class URLPattern:
     def matches(self, other: URL) -> bool:
         if self.scheme and self.scheme != other.scheme:
             return False
-        if self.host and self.host_regex is not None and not self.host_regex.match(other.host):
+        if self.network is not None:
+            try:
+                other_address = ipaddress.ip_address(other.host)
+            except ValueError:
+                return False
+            if other_address not in self.network:
+                return False
+        elif self.host and self.host_regex is not None and not self.host_regex.match(other.host):
             return False
         if self.port is not None and self.port != other.port:
             return False
         return True
 
     @property
-    def priority(self) -> tuple[int, int, int]:
+    def priority(self) -> tuple[int, int, int, int, int]:
         """
         The priority allows URLPattern instances to be sortable, so that
         we can match from most specific to least specific.
         """
+        # Patterns without a network sort after any CIDR network. Smaller
+        # (more specific) networks should match first, compared by address
+        # count rather than prefix length, since an IPv4 /8 and an IPv6 /8
+        # cover wildly different numbers of addresses.
+        has_no_network = 0 if self.network is not None else 1
+        network_priority = self.network.num_addresses if self.network is not None else 0
         # URLs with a port should take priority over URLs without a port.
         port_priority = 0 if self.port is not None else 1
         # Longer hostnames should match first.
         host_priority = -len(self.host)
         # Longer schemes should match first.
         scheme_priority = -len(self.scheme)
-        return (port_priority, host_priority, scheme_priority)
+        return (
+            has_no_network,
+            network_priority,
+            port_priority,
+            host_priority,
+            scheme_priority,
+        )
 
     def __hash__(self) -> int:
         return hash(self.pattern)

--- a/tests/httpx2/test_utils.py
+++ b/tests/httpx2/test_utils.py
@@ -144,6 +144,8 @@ def test_get_environment_proxies(environment: dict[str, str], proxies: dict[str,
         ("all://[::1]/128", "http://[::1]:8080", True),
         ("all://[::1]/128", "http://[::2]", False),
         ("all://192.168.0.0.0/16", "http://192.168.4.5", False),  # Invalid CIDR
+        ("all://[fe11::]/16", "http://[fe11:1234::5]", True),
+        ("all://192.168.0.10/16", "http://192.168.5.10", True),  # host bits set
     ],
 )
 def test_url_matches(pattern: str, url: str, expected: bool) -> None:

--- a/tests/httpx2/test_utils.py
+++ b/tests/httpx2/test_utils.py
@@ -136,6 +136,14 @@ def test_get_environment_proxies(environment: dict[str, str], proxies: dict[str,
         ("http://", "https://example.com", False),
         ("all://", "https://example.com:123", True),
         ("", "https://example.com:123", True),
+        ("all://192.168.0.0/16", "http://192.168.5.10", True),
+        ("all://192.168.0.0/16", "http://192.168.5.10:8080", True),
+        ("all://192.168.0.0/16", "http://10.0.0.1", False),
+        ("all://192.168.0.0/16", "http://example.com", False),
+        ("all://[::1]/128", "http://[::1]", True),
+        ("all://[::1]/128", "http://[::1]:8080", True),
+        ("all://[::1]/128", "http://[::2]", False),
+        ("all://192.168.0.0.0/16", "http://192.168.4.5", False),  # Invalid CIDR
     ],
 )
 def test_url_matches(pattern: str, url: str, expected: bool) -> None:
@@ -149,9 +157,17 @@ def test_pattern_priority() -> None:
         URLPattern("http://"),
         URLPattern("http://example.com"),
         URLPattern("http://example.com:123"),
+        URLPattern("all://[::]/8"),  # 2**120 addresses
+        URLPattern("all://192.168.1.0/24"),  # 256 addresses
+        URLPattern("all://192.168.1.0/23"),  # 512 addresses
+        URLPattern("all://[::]/126"),  # 4 addresses
     ]
     random.shuffle(matchers)
     assert sorted(matchers) == [
+        URLPattern("all://[::]/126"),
+        URLPattern("all://192.168.1.0/24"),
+        URLPattern("all://192.168.1.0/23"),
+        URLPattern("all://[::]/8"),
         URLPattern("http://example.com:123"),
         URLPattern("http://example.com"),
         URLPattern("http://"),


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX2! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

From #1164:

> The comments for get_environment_proxies implies that CIDRs are supported in the NO_PROXY environment variable:

            # NO_PROXY=.google.com is marked as "all://*.google.com,
            #   which disables "www.google.com" but not "google.com"
            # NO_PROXY=google.com is marked as "all://*google.com,
            #   which disables "www.google.com" and "google.com".
            #   (But not "wwwgoogle.com")
            # NO_PROXY can include domains, IPv6, IPv4 addresses and "localhost"
            #   NO_PROXY=example.com,::1,localhost,192.168.0.0/16
> Unfortunately, they aren't actually respected. If you use the NO_PROXY string from the comment, and connect to http://192.168.0.10, it will still attempt to go through the proxy.

The `NO_PROXY` string is currently being properly translated to a URLPattern (e.g. `192.168.0.0/16` => `all://192.168.0.0/16`), but the URLPattern matcher doesn't handle the CIDR.

This PR is an attempt to fix the matching logic.

Unit tests provide full code coverage.  `scripts/test` passes.  As an additional sanity check, this used to fail with "connection refused" since the proxy doesn't exist, but now works on my branch:

```
HTTPS_PROXY=http://localhost:12345 NO_PROXY=10.128.0.0/16 python -c "import httpx2; httpx2.get('https://10.128.11.39/')"
```

The most questionable part of this PR is how URLPattern ordering should work.  "Check smaller ranges before larger ranges" seems reasonable.  "IP addresses & ranges before hosts" seemed like basically a coin flip, so I just picked one.

This is my first PR to httpx2, so if I violated any conventions or you'd like any changes, just let me know.  Thanks!

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.

> Since this brings the behavior in line with the documentation (or at least the comments), and I don't see any references to `NO_PROXY` in the docs, I skipped this step.  If you'd like a change added, just let me know.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

