### PR TITLE
Convert `Timeout` and `Limits` to dataclasses

### DIFF
--- a/src/httpx2/httpx2/_config.py
+++ b/src/httpx2/httpx2/_config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import os
 import typing
 
@@ -75,6 +76,7 @@ def create_ssl_context(
     return ctx
 
 
+@dataclasses.dataclass(init=False, repr=False)
 class Timeout:
     """
     Timeout configuration.
@@ -145,15 +147,6 @@ class Timeout:
             "pool": self.pool,
         }
 
-    def __eq__(self, other: typing.Any) -> bool:
-        return (
-            isinstance(other, self.__class__)
-            and self.connect == other.connect
-            and self.read == other.read
-            and self.write == other.write
-            and self.pool == other.pool
-        )
-
     def __repr__(self) -> str:
         class_name = self.__class__.__name__
         if len({self.connect, self.read, self.write, self.pool}) == 1:
@@ -161,6 +154,7 @@ class Timeout:
         return f"{class_name}(connect={self.connect}, read={self.read}, write={self.write}, pool={self.pool})"
 
 
+@dataclasses.dataclass(kw_only=True)
 class Limits:
     """
     Configuration for limits to various client behaviors.
@@ -175,32 +169,9 @@ class Limits:
     * **keepalive_expiry** - Time limit on idle keep-alive connections in seconds.
     """
 
-    def __init__(
-        self,
-        *,
-        max_connections: int | None = None,
-        max_keepalive_connections: int | None = None,
-        keepalive_expiry: float | None = 5.0,
-    ) -> None:
-        self.max_connections = max_connections
-        self.max_keepalive_connections = max_keepalive_connections
-        self.keepalive_expiry = keepalive_expiry
-
-    def __eq__(self, other: typing.Any) -> bool:
-        return (
-            isinstance(other, self.__class__)
-            and self.max_connections == other.max_connections
-            and self.max_keepalive_connections == other.max_keepalive_connections
-            and self.keepalive_expiry == other.keepalive_expiry
-        )
-
-    def __repr__(self) -> str:
-        class_name = self.__class__.__name__
-        return (
-            f"{class_name}(max_connections={self.max_connections}, "
-            f"max_keepalive_connections={self.max_keepalive_connections}, "
-            f"keepalive_expiry={self.keepalive_expiry})"
-        )
+    max_connections: int | None = None
+    max_keepalive_connections: int | None = None
+    keepalive_expiry: float | None = 5.0
 
 
 class Proxy:


### PR DESCRIPTION
## Summary

`Timeout` and `Limits` in `_config.py` both hand-roll `__init__`, `__eq__` and `__repr__`. Most of that is what `dataclasses` generates for free.

- `Limits` becomes a plain `@dataclass(kw_only=True)`. Its `__init__` was already keyword-only with plain defaults, so all three methods go. The generated `__repr__` is identical to the one it replaces.
- `Timeout` becomes `@dataclass(init=False, repr=False)`. It keeps its custom `__init__`, which accepts a polymorphic positional (`float`, `None`, 4-tuple, or another `Timeout`) layered over four `UNSET` keywords, and it keeps its `__repr__`, which collapses to `Timeout(timeout=5.0)` when all four values match. It drops the hand-written `__eq__`.

Net: 6 insertions, 35 deletions.

The useful side effect is that both classes now support `dataclasses.replace()`:

```python
>>> dataclasses.replace(DEFAULT_LIMITS, max_connections=200)
Limits(max_connections=200, max_keepalive_connections=20, keepalive_expiry=5.0)
```

That is the operation behind #1057 - override one field, keep the library defaults for the rest - without exporting `DEFAULT_LIMITS` or `DEFAULT_TIMEOUT_CONFIG`. This PR does not add public `default()` or `copy_with()` helpers; happy to follow up if that direction looks right.

## Behaviour

No changes. Verified:

| | before | after |
|---|---|---|
| `repr(Timeout(5.0))` | `Timeout(timeout=5.0)` | same |
| `repr(Timeout(None, read=5.0))` | `Timeout(connect=None, read=5.0, write=None, pool=None)` | same |
| `repr(Limits(max_connections=100))` | `Limits(max_connections=100, max_keepalive_connections=None, keepalive_expiry=5.0)` | same |
| `Timeout()`, `Timeout(connect=10.0)` | `ValueError` | same |
| `hash(Timeout(5.0))` | unhashable | same |

Both classes were already unhashable, since each defined `__eq__` without `__hash__`, so `eq=True` changes nothing there.

One difference worth naming: the generated `__eq__` compares `other.__class__ is self.__class__` where the hand-written one used `isinstance(other, self.__class__)`. A subclass instance would stop comparing equal to its base. Nothing in the codebase subclasses either class, but it is technically observable.

No changelog entry, as there is no user-visible change.

## Test plan

- [x] `ruff format --check`, `ruff check`, `mypy` (128 source files), `scripts/unasync.py --check` all pass
- [x] `_config.py` at 100% coverage
- [x] 1561 passed with `tests/httpx2/websockets` excluded

The `tests/httpx2/websockets` suite has 86 failures in my environment, all `RuntimeError: Already running asyncio in this thread`. They reproduce identically on clean `main` with this branch stashed, so they are unrelated to this change - my venv is free-threaded CPython 3.14t.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

