### PR TITLE
Track connection pool state incrementally instead of scanning on every request

### DIFF
--- a/scripts/unasync.py
+++ b/scripts/unasync.py
@@ -10,6 +10,7 @@ SUBS = [
         "from .._backends.sync import SyncBackend",
     ),
     ("import trio as concurrency", "from tests.httpcore2 import concurrency"),
+    ("anyio.sleep", "concurrency.sleep"),
     ("AsyncIterator", "Iterator"),
     ("Async([A-Z][A-Za-z0-9_]*)", r"\2"),
     ("async def", "def"),

--- a/src/httpcore2/httpcore2/_async/connection_pool.py
+++ b/src/httpcore2/httpcore2/_async/connection_pool.py
@@ -130,8 +130,8 @@ class AsyncConnectionPool(AsyncRequestInterface):
         # HTTP/1.1 connection with a holder is reserved by a request that has
         # not sent on it yet.
         self._holders: dict[AsyncConnectionInterface, int] = {}
-        # Idle HTTP/1.1 connections free for reuse, oldest first, mapped to the
-        # time they became idle, plus the same connections keyed by origin.
+        # Idle connections free for reuse, oldest first, mapped to the time
+        # they became idle, plus the same connections keyed by origin.
         self._idle: dict[AsyncConnectionInterface, float] = {}
         self._idle_by_origin: dict[Origin, dict[AsyncConnectionInterface, None]] = {}
         # Connections that may take a request while not idle: HTTP/2 connections,
@@ -343,15 +343,18 @@ class AsyncConnectionPool(AsyncRequestInterface):
         while idle:
             connection = next(iter(idle))
             self._remove_idle(connection)
-            # `has_expired()` also probes the socket, catching a connection
-            # the server closed while it sat idle.
-            if connection.has_expired():
+            # `has_expired()` also probes the socket, catching a connection the
+            # server closed while it sat idle. An idle HTTP/2 connection may
+            # have become unusable without closing, for example after an error.
+            if connection.has_expired() or not connection.is_available():
                 self._drop_connection(connection)
                 closing_connections.append(connection)
                 continue
             return connection
 
-        for connection in self._live_sharable_connections(origin, closing_connections):
+        # Idle sharable connections were handled above; the remaining ones are
+        # either serving requests or not yet connected.
+        for connection in self._sharable_by_origin.get(origin, ()):
             if connection.is_available():
                 return connection
 
@@ -360,7 +363,6 @@ class AsyncConnectionPool(AsyncRequestInterface):
 
         if self._idle:
             connection = next(iter(self._idle))
-            self._remove_idle(connection)
             self._drop_connection(connection)
             closing_connections.append(connection)
             return self._add_connection(origin)
@@ -388,69 +390,37 @@ class AsyncConnectionPool(AsyncRequestInterface):
             self._drop_connection(connection)
             return
 
+        sharable = self._sharable_by_origin.setdefault(origin, {})
         if connection.can_multiplex():
-            self._sharable_by_origin.setdefault(origin, {})[connection] = None
-            if connection.is_idle():
-                self._schedule_expiry(time.monotonic())
-            return
-
-        # An HTTP/1.1 connection: no longer a candidate for HTTP/2 multiplexing.
-        sharable = self._sharable_by_origin.get(origin)
-        if sharable is not None:
+            sharable[connection] = None
+        else:
+            # An HTTP/1.1 connection is no longer a candidate for multiplexing.
             sharable.pop(connection, None)
 
         if connection.is_idle():
             now = time.monotonic()
             self._idle[connection] = now
             self._idle_by_origin.setdefault(origin, {})[connection] = None
-            self._schedule_expiry(now)
+            if self._expiry_due is None and self._keepalive_expiry is not None:
+                self._expiry_due = now + self._keepalive_expiry
 
             # Enforce `max_keepalive_connections`, closing the longest idle first.
             while len(self._idle) > self._max_keepalive_connections:
                 surplus = next(iter(self._idle))
-                self._remove_idle(surplus)
                 self._drop_connection(surplus)
                 closing_connections.append(surplus)
 
     def _expire_idle_connections(self, closing_connections: list[AsyncConnectionInterface]) -> None:
         for connection in list(self._idle):
             if connection.has_expired():
-                self._remove_idle(connection)
                 self._drop_connection(connection)
                 closing_connections.append(connection)
 
-        sharable_idle = False
-        for origin in list(self._sharable_by_origin):
-            for connection in self._live_sharable_connections(origin, closing_connections):
-                if connection.is_idle():
-                    sharable_idle = True
-
-        self._expiry_due = None
         assert self._keepalive_expiry is not None
+        self._expiry_due = None
         if self._idle:
+            # The next sweep is due when the oldest remaining idle connection expires.
             self._expiry_due = next(iter(self._idle.values())) + self._keepalive_expiry
-        elif sharable_idle:
-            self._expiry_due = time.monotonic() + self._keepalive_expiry
-
-    def _live_sharable_connections(
-        self, origin: Origin, closing_connections: list[AsyncConnectionInterface]
-    ) -> list[AsyncConnectionInterface]:
-        # Drop sharable connections that were closed or expired while the pool
-        # was not looking at them, returning the ones still worth using.
-        live: list[AsyncConnectionInterface] = []
-        for connection in list(self._sharable_by_origin.get(origin, ())):
-            if connection.is_closed():
-                self._drop_connection(connection)
-            elif connection.has_expired():
-                self._drop_connection(connection)
-                closing_connections.append(connection)
-            else:
-                live.append(connection)
-        return live
-
-    def _schedule_expiry(self, now: float) -> None:
-        if self._expiry_due is None and self._keepalive_expiry is not None:
-            self._expiry_due = now + self._keepalive_expiry
 
     def _add_connection(self, origin: Origin) -> AsyncConnectionInterface:
         connection = self.create_connection(origin)
@@ -470,6 +440,8 @@ class AsyncConnectionPool(AsyncRequestInterface):
             del self._idle_by_origin[origin]
 
     def _drop_connection(self, connection: AsyncConnectionInterface) -> None:
+        if connection in self._idle:
+            self._remove_idle(connection)
         origin = self._connections.pop(connection)
         self._holders.pop(connection, None)
         sharable = self._sharable_by_origin.get(origin)

--- a/src/httpcore2/httpcore2/_async/connection_pool.py
+++ b/src/httpcore2/httpcore2/_async/connection_pool.py
@@ -22,6 +22,7 @@ class AsyncPoolRequest:
     def __init__(self, request: Request) -> None:
         self.request = request
         self.connection: AsyncConnectionInterface | None = None
+        self.entry: _ConnectionEntry | None = None
         # Created only by a request that actually has to wait: in the common
         # case a connection is assigned before `wait_for_connection` is called.
         self._connection_acquired: AsyncEvent | None = None
@@ -47,6 +48,24 @@ class AsyncPoolRequest:
 
     def is_queued(self) -> bool:
         return self.connection is None
+
+
+class _ConnectionEntry:
+    """
+    The pool's bookkeeping for one connection. Entries are hashed by identity,
+    so connections themselves need not be hashable.
+    """
+
+    __slots__ = ("connection", "origin", "holders", "idle_since")
+
+    def __init__(self, connection: AsyncConnectionInterface, origin: Origin) -> None:
+        self.connection = connection
+        self.origin = origin
+        # The number of in-flight requests holding the connection. An idle
+        # HTTP/1.1 connection with a holder is reserved by a request that has
+        # not sent on it yet.
+        self.holders = 0
+        self.idle_since = 0.0
 
 
 class AsyncConnectionPool(AsyncRequestInterface):
@@ -104,7 +123,7 @@ class AsyncConnectionPool(AsyncRequestInterface):
         self._max_keepalive_connections = (
             sys.maxsize if max_keepalive_connections is None else max_keepalive_connections
         )
-        self._max_keepalive_connections = min(self._max_connections, self._max_keepalive_connections)
+        self._max_keepalive_connections = max(0, min(self._max_connections, self._max_keepalive_connections))
 
         self._keepalive_expiry = keepalive_expiry
         self._http1 = http1
@@ -120,26 +139,22 @@ class AsyncConnectionPool(AsyncRequestInterface):
         # releasing a connection costs O(1) rather than a scan of every
         # connection and every in-flight request.
         #
-        # Every connection owned by the pool, in creation order, with its origin.
-        self._connections: dict[AsyncConnectionInterface, Origin] = {}
+        # Every connection owned by the pool, in creation order, keyed by identity.
+        self._entries: dict[int, _ConnectionEntry] = {}
         # Every in-flight request, in arrival order.
         self._requests: dict[AsyncPoolRequest, None] = {}
         # Requests still waiting for a connection, in arrival order.
         self._queued: deque[AsyncPoolRequest] = deque()
-        # The number of in-flight requests holding each connection. An idle
-        # HTTP/1.1 connection with a holder is reserved by a request that has
-        # not sent on it yet.
-        self._holders: dict[AsyncConnectionInterface, int] = {}
-        # Idle connections free for reuse, oldest first, mapped to the time
-        # they became idle, plus the same connections keyed by origin.
-        self._idle: dict[AsyncConnectionInterface, float] = {}
-        self._idle_by_origin: dict[Origin, dict[AsyncConnectionInterface, None]] = {}
+        # Idle connections free for reuse, oldest first, plus the same
+        # connections keyed by origin.
+        self._idle: dict[_ConnectionEntry, None] = {}
+        self._idle_by_origin: dict[Origin, dict[_ConnectionEntry, None]] = {}
         # Connections that may take a request while not idle: HTTP/2 connections,
         # and connections that may still negotiate HTTP/2.
-        self._sharable_by_origin: dict[Origin, dict[AsyncConnectionInterface, None]] = {}
+        self._sharable_by_origin: dict[Origin, dict[_ConnectionEntry, None]] = {}
         # Connections whose in-flight request has ended since the last pass,
         # to be re-examined by the next pass.
-        self._released: list[AsyncConnectionInterface] = []
+        self._released: list[_ConnectionEntry] = []
         # When the oldest idle connection may have expired, or `None` while
         # no idle connection is subject to expiry.
         self._expiry_due: float | None = None
@@ -218,7 +233,7 @@ class AsyncConnectionPool(AsyncRequestInterface):
         ]
         ```
         """
-        return list(self._connections)
+        return [entry.connection for entry in self._entries.values()]
 
     async def handle_async_request(self, request: Request) -> Response:
         """
@@ -308,8 +323,8 @@ class AsyncConnectionPool(AsyncRequestInterface):
         # dropped if their request left them closed.
         if self._released:
             released, self._released = self._released, []
-            for connection in released:
-                self._examine_released_connection(connection, closing_connections)
+            for entry in released:
+                self._examine_released_connection(entry, closing_connections)
 
         # Expire idle connections, but only once the oldest may have expired.
         if self._expiry_due is not None and time.monotonic() >= self._expiry_due:
@@ -332,7 +347,7 @@ class AsyncConnectionPool(AsyncRequestInterface):
 
     def _acquire_connection(
         self, origin: Origin, closing_connections: list[AsyncConnectionInterface]
-    ) -> AsyncConnectionInterface | None:
+    ) -> _ConnectionEntry | None:
         # There are three cases for how we may be able to handle the request:
         #
         # 1. There is an existing connection that can handle the request.
@@ -341,129 +356,126 @@ class AsyncConnectionPool(AsyncRequestInterface):
         #    to handle the request.
         idle = self._idle_by_origin.get(origin)
         while idle:
-            connection = next(iter(idle))
-            self._remove_idle(connection)
+            entry = next(iter(idle))
+            self._remove_idle(entry)
             # `has_expired()` also probes the socket, catching a connection the
             # server closed while it sat idle. An idle HTTP/2 connection may
             # have become unusable without closing, for example after an error.
-            if connection.has_expired() or not connection.is_available():
-                self._drop_connection(connection)
-                closing_connections.append(connection)
+            if entry.connection.has_expired() or not entry.connection.is_available():
+                self._drop_connection(entry)
+                closing_connections.append(entry.connection)
                 continue
-            return connection
+            return entry
 
         # Idle sharable connections were handled above; the remaining ones are
         # either serving requests or not yet connected.
-        for connection in self._sharable_by_origin.get(origin, ()):
-            if connection.is_available():
-                return connection
+        for entry in self._sharable_by_origin.get(origin, ()):
+            if entry.connection.is_available():
+                return entry
 
-        if len(self._connections) < self._max_connections:
+        if len(self._entries) < self._max_connections:
             return self._add_connection(origin)
 
         if self._idle:
-            connection = next(iter(self._idle))
-            self._drop_connection(connection)
-            closing_connections.append(connection)
+            entry = next(iter(self._idle))
+            self._drop_connection(entry)
+            closing_connections.append(entry.connection)
             return self._add_connection(origin)
 
         return None
 
     def _examine_released_connection(
-        self, connection: AsyncConnectionInterface, closing_connections: list[AsyncConnectionInterface]
+        self, entry: _ConnectionEntry, closing_connections: list[AsyncConnectionInterface]
     ) -> None:
-        origin = self._connections.get(connection)
-        if origin is None:
+        connection = entry.connection
+        if self._entries.get(id(connection)) is not entry:
             # Already dropped, for example by the pool closing.
             return
         if connection.is_closed():
             # The request left the connection closed; there is no socket to close.
-            self._drop_connection(connection)
+            self._drop_connection(entry)
             return
-        if self._holders.get(connection, 0):
+        if entry.holders:
             # Still serving another request, or reserved by a queued request.
             return
         if not connection.is_connected():
             # Garbage: a NEW-state connection whose request was cancelled
             # before the TCP handshake completed. Drop it without closing
             # (there is no socket to close yet).
-            self._drop_connection(connection)
+            self._drop_connection(entry)
             return
 
-        sharable = self._sharable_by_origin.setdefault(origin, {})
+        sharable = self._sharable_by_origin.setdefault(entry.origin, {})
         if connection.can_multiplex():
-            sharable[connection] = None
+            sharable[entry] = None
         else:
             # An HTTP/1.1 connection is no longer a candidate for multiplexing.
-            sharable.pop(connection, None)
+            sharable.pop(entry, None)
 
         if connection.is_idle():
-            now = time.monotonic()
-            self._idle[connection] = now
-            self._idle_by_origin.setdefault(origin, {})[connection] = None
+            entry.idle_since = time.monotonic()
+            self._idle[entry] = None
+            self._idle_by_origin.setdefault(entry.origin, {})[entry] = None
             if self._expiry_due is None and self._keepalive_expiry is not None:
-                self._expiry_due = now + self._keepalive_expiry
+                self._expiry_due = entry.idle_since + self._keepalive_expiry
 
             # Enforce `max_keepalive_connections`, closing the longest idle first.
             while len(self._idle) > self._max_keepalive_connections:
                 surplus = next(iter(self._idle))
                 self._drop_connection(surplus)
-                closing_connections.append(surplus)
+                closing_connections.append(surplus.connection)
 
     def _expire_idle_connections(self, closing_connections: list[AsyncConnectionInterface]) -> None:
-        for connection in list(self._idle):
-            if connection.has_expired():
-                self._drop_connection(connection)
-                closing_connections.append(connection)
+        for entry in list(self._idle):
+            if entry.connection.has_expired():
+                self._drop_connection(entry)
+                closing_connections.append(entry.connection)
 
         assert self._keepalive_expiry is not None
         self._expiry_due = None
         if self._idle:
             # The next sweep is due when the oldest remaining idle connection expires.
-            self._expiry_due = next(iter(self._idle.values())) + self._keepalive_expiry
+            self._expiry_due = next(iter(self._idle)).idle_since + self._keepalive_expiry
 
-    def _add_connection(self, origin: Origin) -> AsyncConnectionInterface:
+    def _add_connection(self, origin: Origin) -> _ConnectionEntry:
         connection = self.create_connection(origin)
-        self._connections[connection] = origin
+        entry = _ConnectionEntry(connection, origin)
+        self._entries[id(connection)] = entry
         if connection.is_available():
             # Not yet connected, but may negotiate HTTP/2 and then take
             # further requests concurrently.
-            self._sharable_by_origin.setdefault(origin, {})[connection] = None
-        return connection
+            self._sharable_by_origin.setdefault(origin, {})[entry] = None
+        return entry
 
-    def _remove_idle(self, connection: AsyncConnectionInterface) -> None:
-        del self._idle[connection]
-        origin = self._connections[connection]
-        by_origin = self._idle_by_origin[origin]
-        del by_origin[connection]
+    def _remove_idle(self, entry: _ConnectionEntry) -> None:
+        del self._idle[entry]
+        by_origin = self._idle_by_origin[entry.origin]
+        del by_origin[entry]
         if not by_origin:
-            del self._idle_by_origin[origin]
+            del self._idle_by_origin[entry.origin]
 
-    def _drop_connection(self, connection: AsyncConnectionInterface) -> None:
-        if connection in self._idle:
-            self._remove_idle(connection)
-        origin = self._connections.pop(connection)
-        self._holders.pop(connection, None)
-        sharable = self._sharable_by_origin.get(origin)
+    def _drop_connection(self, entry: _ConnectionEntry) -> None:
+        if entry in self._idle:
+            self._remove_idle(entry)
+        del self._entries[id(entry.connection)]
+        sharable = self._sharable_by_origin.get(entry.origin)
         if sharable is not None:
-            sharable.pop(connection, None)
+            sharable.pop(entry, None)
             if not sharable:
-                del self._sharable_by_origin[origin]
+                del self._sharable_by_origin[entry.origin]
 
-    def _reserve_connection(self, pool_request: AsyncPoolRequest, connection: AsyncConnectionInterface) -> None:
-        self._holders[connection] = self._holders.get(connection, 0) + 1
-        pool_request.assign_to_connection(connection)
+    def _reserve_connection(self, pool_request: AsyncPoolRequest, entry: _ConnectionEntry) -> None:
+        entry.holders += 1
+        pool_request.entry = entry
+        pool_request.assign_to_connection(entry.connection)
 
     def _release_connection(self, pool_request: AsyncPoolRequest) -> None:
-        connection = pool_request.connection
-        if connection is None:
+        entry = pool_request.entry
+        if entry is None:
             return
-        count = self._holders.get(connection, 0) - 1
-        if count > 0:
-            self._holders[connection] = count
-        else:
-            self._holders.pop(connection, None)
-        self._released.append(connection)
+        pool_request.entry = None
+        entry.holders -= 1
+        self._released.append(entry)
 
     async def _close_connections(self, closing: list[AsyncConnectionInterface]) -> None:
         # Close connections which have been removed from the pool.
@@ -477,9 +489,8 @@ class AsyncConnectionPool(AsyncRequestInterface):
         # Explicitly close the connection pool.
         # Clears all existing requests and connections.
         with self._optional_thread_lock:
-            closing_connections = list(self._connections)
-            self._connections = {}
-            self._holders = {}
+            closing_connections = [entry.connection for entry in self._entries.values()]
+            self._entries = {}
             self._idle = {}
             self._idle_by_origin = {}
             self._sharable_by_origin = {}
@@ -503,7 +514,7 @@ class AsyncConnectionPool(AsyncRequestInterface):
         with self._optional_thread_lock:
             num_queued_requests = len(self._queued)
             num_active_requests = len(self._requests) - num_queued_requests
-            connection_is_idle = [connection.is_idle() for connection in self._connections]
+            connection_is_idle = [entry.connection.is_idle() for entry in self._entries.values()]
 
             num_active_connections = connection_is_idle.count(False)
             num_idle_connections = connection_is_idle.count(True)

--- a/src/httpcore2/httpcore2/_async/connection_pool.py
+++ b/src/httpcore2/httpcore2/_async/connection_pool.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import ssl
 import sys
+import time
 import types
 import typing
+from collections import deque
 from collections.abc import AsyncGenerator
 
 from .._backends.auto import AutoBackend
@@ -20,19 +22,26 @@ class AsyncPoolRequest:
     def __init__(self, request: Request) -> None:
         self.request = request
         self.connection: AsyncConnectionInterface | None = None
-        self._connection_acquired = AsyncEvent()
+        # Created only by a request that actually has to wait: in the common
+        # case a connection is assigned before `wait_for_connection` is called.
+        self._connection_acquired: AsyncEvent | None = None
 
     def assign_to_connection(self, connection: AsyncConnectionInterface | None) -> None:
         self.connection = connection
-        self._connection_acquired.set()
+        if self._connection_acquired is not None:
+            self._connection_acquired.set()
 
     def clear_connection(self) -> None:
         self.connection = None
-        self._connection_acquired = AsyncEvent()
+        self._connection_acquired = None
 
     async def wait_for_connection(self, timeout: float | None = None) -> AsyncConnectionInterface:
         if self.connection is None:
-            await self._connection_acquired.wait(timeout=timeout)
+            self._connection_acquired = AsyncEvent()
+            # Re-check after publishing the event: in the threaded case an
+            # assignment may have landed between the first check and here.
+            if self.connection is None:
+                await self._connection_acquired.wait(timeout=timeout)
         assert self.connection is not None
         return self.connection
 
@@ -107,10 +116,33 @@ class AsyncConnectionPool(AsyncRequestInterface):
         self._network_backend = AutoBackend() if network_backend is None else network_backend
         self._socket_options = socket_options
 
-        # The mutable state on a connection pool is the queue of incoming requests,
-        # and the set of connections that are servicing those requests.
-        self._connections: list[AsyncConnectionInterface] = []
-        self._requests: list[AsyncPoolRequest] = []
+        # The pool's state is kept incrementally, so that handling a request or
+        # releasing a connection costs O(1) rather than a scan of every
+        # connection and every in-flight request.
+        #
+        # Every connection owned by the pool, in creation order, with its origin.
+        self._connections: dict[AsyncConnectionInterface, Origin] = {}
+        # Every in-flight request, in arrival order.
+        self._requests: dict[AsyncPoolRequest, None] = {}
+        # Requests still waiting for a connection, in arrival order.
+        self._queued: deque[AsyncPoolRequest] = deque()
+        # The number of in-flight requests holding each connection. An idle
+        # HTTP/1.1 connection with a holder is reserved by a request that has
+        # not sent on it yet.
+        self._holders: dict[AsyncConnectionInterface, int] = {}
+        # Idle HTTP/1.1 connections free for reuse, oldest first, mapped to the
+        # time they became idle, plus the same connections keyed by origin.
+        self._idle: dict[AsyncConnectionInterface, float] = {}
+        self._idle_by_origin: dict[Origin, dict[AsyncConnectionInterface, None]] = {}
+        # Connections that may take a request while not idle: HTTP/2 connections,
+        # and connections that may still negotiate HTTP/2.
+        self._sharable_by_origin: dict[Origin, dict[AsyncConnectionInterface, None]] = {}
+        # Connections whose in-flight request has ended since the last pass,
+        # to be re-examined by the next pass.
+        self._released: list[AsyncConnectionInterface] = []
+        # When the oldest idle connection may have expired, or `None` while
+        # no idle connection is subject to expiry.
+        self._expiry_due: float | None = None
 
         # We only mutate the state of the connection pool within an 'optional_thread_lock'
         # context. This holds a threading lock unless we're running in async mode,
@@ -206,7 +238,8 @@ class AsyncConnectionPool(AsyncRequestInterface):
         with self._optional_thread_lock:
             # Add the incoming request to our request queue.
             pool_request = AsyncPoolRequest(request)
-            self._requests.append(pool_request)
+            self._requests[pool_request] = None
+            self._queued.append(pool_request)
 
         try:
             while True:
@@ -226,8 +259,12 @@ class AsyncConnectionPool(AsyncRequestInterface):
                     # In some cases a connection may initially be available to
                     # handle a request, but then become unavailable.
                     #
-                    # In this case we clear the connection and try again.
-                    pool_request.clear_connection()
+                    # In this case we clear the connection and try again, keeping
+                    # the request at the front of the queue.
+                    with self._optional_thread_lock:
+                        self._release_connection(pool_request)
+                        pool_request.clear_connection()
+                        self._queued.appendleft(pool_request)
                 else:
                     break  # pragma: no cover
 
@@ -235,7 +272,10 @@ class AsyncConnectionPool(AsyncRequestInterface):
             with self._optional_thread_lock:
                 # For any exception or cancellation we remove the request from
                 # the queue, and then re-assign requests to connections.
-                self._requests.remove(pool_request)
+                self._release_connection(pool_request)
+                if pool_request.is_queued():
+                    self._queued.remove(pool_request)
+                del self._requests[pool_request]
                 closing = self._assign_requests_to_connections()
 
             await self._close_connections(closing)
@@ -253,122 +293,210 @@ class AsyncConnectionPool(AsyncRequestInterface):
 
     def _assign_requests_to_connections(self) -> list[AsyncConnectionInterface]:
         """
-        Manage the state of the connection pool, assigning incoming
+        Manage the state of the connection pool, assigning queued
         requests to connections as available.
 
-        Called whenever a new request is added or removed from the pool.
+        Called whenever a request is added to the pool, or a request
+        releases its connection.
 
         Any closing connections are returned, allowing the I/O for closing
         those connections to be handled separately.
         """
         closing_connections: list[AsyncConnectionInterface] = []
-        retained_connections: list[AsyncConnectionInterface] = []
 
-        # Connections currently referenced by an in-flight request, including
-        # connections that are in the process of being established and idle
-        # connections reserved by an assigned-but-not-yet-sent request.
-        request_connections = {r.connection for r in self._requests}
+        # Connections released since the last pass become reusable, or are
+        # dropped if their request left them closed.
+        if self._released:
+            released, self._released = self._released, []
+            for connection in released:
+                self._examine_released_connection(connection, closing_connections)
 
-        # First we handle cleaning up any connections that are closed
-        # or have expired their keep-alive, in a single pass. Reserved
-        # connections skip the expiry check: they were checked when assigned,
-        # and `has_expired()` on an idle connection probes the socket.
-        for connection in self._connections:
-            reserved = connection in request_connections
-            if connection.is_closed():
-                continue
-            elif not (connection.is_connected() or reserved):
-                # Garbage: a NEW-state connection whose request was cancelled
-                # before the TCP handshake completed.  Drop it without closing
-                # (there is no socket to close yet).
-                continue
-            elif not reserved and connection.has_expired():
-                closing_connections.append(connection)
-            else:
-                retained_connections.append(connection)
+        # Expire idle connections, but only once the oldest may have expired.
+        if self._expiry_due is not None and time.monotonic() >= self._expiry_due:
+            self._expire_idle_connections(closing_connections)
 
-        # Then we close any surplus idle connections, to enforce the
-        # max_keepalive_connections setting. Reserved connections are not
-        # surplus: a request is about to be sent on them.
-        idle_surplus = (
-            sum(connection.is_idle() and connection not in request_connections for connection in retained_connections)
-            - self._max_keepalive_connections
-        )
-        if idle_surplus > 0:
-            kept: list[AsyncConnectionInterface] = []
-            for connection in retained_connections:
-                if idle_surplus > 0 and connection.is_idle() and connection not in request_connections:
-                    closing_connections.append(connection)
-                    idle_surplus -= 1
+        # Assign queued requests to connections, in arrival order. A request
+        # that cannot be served yet stays queued without blocking later
+        # requests that can reuse an existing connection.
+        if self._queued:
+            still_queued: deque[AsyncPoolRequest] = deque()
+            for pool_request in self._queued:
+                acquired = self._acquire_connection(pool_request.request.url.origin, closing_connections)
+                if acquired is None:
+                    still_queued.append(pool_request)
                 else:
-                    kept.append(connection)
-            retained_connections = kept
-
-        self._connections = retained_connections
-
-        # Snapshot the set of reusable connections once, rather than rebuilding
-        # it per queued request — this is what brings the loop from O(N*M) to
-        # O(N+M) in the common case.
-        #
-        # An idle connection already assigned to an in-flight request is
-        # reserved: it stays IDLE until the winning task sends on it, so
-        # without this exclusion the next pass would assign it again and the
-        # loser would churn through `ConnectionNotAvailable`. Multiplexing
-        # connections are exempt: they can take further requests while idle.
-        available_connections = [
-            connection
-            for connection in self._connections
-            if connection.is_available()
-            and not (connection.is_idle() and connection in request_connections and not connection.can_multiplex())
-        ]
-        new_connection_budget = self._max_connections - len(self._connections)
-
-        # Assign queued requests to connections. Once no connection is
-        # available and no new connection may be created, no queued request
-        # can be assigned, so the scan stops early: this keeps a pass on a
-        # saturated pool O(connections) rather than O(in-flight requests).
-        for pool_request in self._requests:
-            if not available_connections and new_connection_budget <= 0:
-                break
-            if not pool_request.is_queued():
-                continue
-            origin = pool_request.request.url.origin
-
-            # There are three cases for how we may be able to handle the request:
-            #
-            # 1. There is an existing connection that can handle the request.
-            # 2. We can create a new connection to handle the request.
-            # 3. We can close an idle connection and then create a new connection
-            #    to handle the request.
-            for idx, connection in enumerate(available_connections):
-                if connection.can_handle_request(origin):
-                    pool_request.assign_to_connection(connection)
-                    if connection.is_idle() and not connection.can_multiplex():
-                        # An idle HTTP/1.1 connection can only take this
-                        # single request until it is released.
-                        del available_connections[idx]
-                    break
-            else:
-                if new_connection_budget > 0:
-                    connection = self.create_connection(origin)
-                    self._connections.append(connection)
-                    pool_request.assign_to_connection(connection)
-                    new_connection_budget -= 1
-                    continue
-                for idx, connection in enumerate(available_connections):
-                    if connection.is_idle():
-                        del available_connections[idx]
-                        self._connections.remove(connection)
-                        closing_connections.append(connection)
-                        connection = self.create_connection(origin)
-                        self._connections.append(connection)
-                        pool_request.assign_to_connection(connection)
-                        break
+                    self._reserve_connection(pool_request, acquired)
+            self._queued = still_queued
 
         return closing_connections
 
+    def _acquire_connection(
+        self, origin: Origin, closing_connections: list[AsyncConnectionInterface]
+    ) -> AsyncConnectionInterface | None:
+        # There are three cases for how we may be able to handle the request:
+        #
+        # 1. There is an existing connection that can handle the request.
+        # 2. We can create a new connection to handle the request.
+        # 3. We can close an idle connection and then create a new connection
+        #    to handle the request.
+        idle = self._idle_by_origin.get(origin)
+        while idle:
+            connection = next(iter(idle))
+            self._remove_idle(connection)
+            # `has_expired()` also probes the socket, catching a connection
+            # the server closed while it sat idle.
+            if connection.has_expired():
+                self._drop_connection(connection)
+                closing_connections.append(connection)
+                continue
+            return connection
+
+        for connection in self._live_sharable_connections(origin, closing_connections):
+            if connection.is_available():
+                return connection
+
+        if len(self._connections) < self._max_connections:
+            return self._add_connection(origin)
+
+        if self._idle:
+            connection = next(iter(self._idle))
+            self._remove_idle(connection)
+            self._drop_connection(connection)
+            closing_connections.append(connection)
+            return self._add_connection(origin)
+
+        return None
+
+    def _examine_released_connection(
+        self, connection: AsyncConnectionInterface, closing_connections: list[AsyncConnectionInterface]
+    ) -> None:
+        origin = self._connections.get(connection)
+        if origin is None:
+            # Already dropped, for example by the pool closing.
+            return
+        if connection.is_closed():
+            # The request left the connection closed; there is no socket to close.
+            self._drop_connection(connection)
+            return
+        if self._holders.get(connection, 0):
+            # Still serving another request, or reserved by a queued request.
+            return
+        if not connection.is_connected():
+            # Garbage: a NEW-state connection whose request was cancelled
+            # before the TCP handshake completed. Drop it without closing
+            # (there is no socket to close yet).
+            self._drop_connection(connection)
+            return
+
+        if connection.can_multiplex():
+            self._sharable_by_origin.setdefault(origin, {})[connection] = None
+            if connection.is_idle():
+                self._schedule_expiry(time.monotonic())
+            return
+
+        # An HTTP/1.1 connection: no longer a candidate for HTTP/2 multiplexing.
+        sharable = self._sharable_by_origin.get(origin)
+        if sharable is not None:
+            sharable.pop(connection, None)
+
+        if connection.is_idle():
+            now = time.monotonic()
+            self._idle[connection] = now
+            self._idle_by_origin.setdefault(origin, {})[connection] = None
+            self._schedule_expiry(now)
+
+            # Enforce `max_keepalive_connections`, closing the longest idle first.
+            while len(self._idle) > self._max_keepalive_connections:
+                surplus = next(iter(self._idle))
+                self._remove_idle(surplus)
+                self._drop_connection(surplus)
+                closing_connections.append(surplus)
+
+    def _expire_idle_connections(self, closing_connections: list[AsyncConnectionInterface]) -> None:
+        for connection in list(self._idle):
+            if connection.has_expired():
+                self._remove_idle(connection)
+                self._drop_connection(connection)
+                closing_connections.append(connection)
+
+        sharable_idle = False
+        for origin in list(self._sharable_by_origin):
+            for connection in self._live_sharable_connections(origin, closing_connections):
+                if connection.is_idle():
+                    sharable_idle = True
+
+        self._expiry_due = None
+        assert self._keepalive_expiry is not None
+        if self._idle:
+            self._expiry_due = next(iter(self._idle.values())) + self._keepalive_expiry
+        elif sharable_idle:
+            self._expiry_due = time.monotonic() + self._keepalive_expiry
+
+    def _live_sharable_connections(
+        self, origin: Origin, closing_connections: list[AsyncConnectionInterface]
+    ) -> list[AsyncConnectionInterface]:
+        # Drop sharable connections that were closed or expired while the pool
+        # was not looking at them, returning the ones still worth using.
+        live: list[AsyncConnectionInterface] = []
+        for connection in list(self._sharable_by_origin.get(origin, ())):
+            if connection.is_closed():
+                self._drop_connection(connection)
+            elif connection.has_expired():
+                self._drop_connection(connection)
+                closing_connections.append(connection)
+            else:
+                live.append(connection)
+        return live
+
+    def _schedule_expiry(self, now: float) -> None:
+        if self._expiry_due is None and self._keepalive_expiry is not None:
+            self._expiry_due = now + self._keepalive_expiry
+
+    def _add_connection(self, origin: Origin) -> AsyncConnectionInterface:
+        connection = self.create_connection(origin)
+        self._connections[connection] = origin
+        if connection.is_available():
+            # Not yet connected, but may negotiate HTTP/2 and then take
+            # further requests concurrently.
+            self._sharable_by_origin.setdefault(origin, {})[connection] = None
+        return connection
+
+    def _remove_idle(self, connection: AsyncConnectionInterface) -> None:
+        del self._idle[connection]
+        origin = self._connections[connection]
+        by_origin = self._idle_by_origin[origin]
+        del by_origin[connection]
+        if not by_origin:
+            del self._idle_by_origin[origin]
+
+    def _drop_connection(self, connection: AsyncConnectionInterface) -> None:
+        origin = self._connections.pop(connection)
+        self._holders.pop(connection, None)
+        sharable = self._sharable_by_origin.get(origin)
+        if sharable is not None:
+            sharable.pop(connection, None)
+            if not sharable:
+                del self._sharable_by_origin[origin]
+
+    def _reserve_connection(self, pool_request: AsyncPoolRequest, connection: AsyncConnectionInterface) -> None:
+        self._holders[connection] = self._holders.get(connection, 0) + 1
+        pool_request.assign_to_connection(connection)
+
+    def _release_connection(self, pool_request: AsyncPoolRequest) -> None:
+        connection = pool_request.connection
+        if connection is None:
+            return
+        count = self._holders.get(connection, 0) - 1
+        if count > 0:
+            self._holders[connection] = count
+        else:
+            self._holders.pop(connection, None)
+        self._released.append(connection)
+
     async def _close_connections(self, closing: list[AsyncConnectionInterface]) -> None:
         # Close connections which have been removed from the pool.
+        if not closing:
+            return
         with AsyncShieldCancellation():
             for connection in closing:
                 await connection.aclose()
@@ -378,7 +506,13 @@ class AsyncConnectionPool(AsyncRequestInterface):
         # Clears all existing requests and connections.
         with self._optional_thread_lock:
             closing_connections = list(self._connections)
-            self._connections = []
+            self._connections = {}
+            self._holders = {}
+            self._idle = {}
+            self._idle_by_origin = {}
+            self._sharable_by_origin = {}
+            self._released = []
+            self._expiry_due = None
         await self._close_connections(closing_connections)
 
     async def __aenter__(self) -> AsyncConnectionPool:
@@ -395,11 +529,10 @@ class AsyncConnectionPool(AsyncRequestInterface):
     def __repr__(self) -> str:
         class_name = self.__class__.__name__
         with self._optional_thread_lock:
-            request_is_queued = [request.is_queued() for request in self._requests]
+            num_queued_requests = len(self._queued)
+            num_active_requests = len(self._requests) - num_queued_requests
             connection_is_idle = [connection.is_idle() for connection in self._connections]
 
-            num_active_requests = request_is_queued.count(False)
-            num_queued_requests = request_is_queued.count(True)
             num_active_connections = connection_is_idle.count(False)
             num_idle_connections = connection_is_idle.count(True)
 
@@ -434,7 +567,8 @@ class PoolByteStream:
                     await self._stream.aclose()
 
             with self._pool._optional_thread_lock:
-                self._pool._requests.remove(self._pool_request)
+                self._pool._release_connection(self._pool_request)
+                del self._pool._requests[self._pool_request]
                 closing = self._pool._assign_requests_to_connections()
 
             await self._pool._close_connections(closing)

--- a/src/httpcore2/httpcore2/_async/connection_pool.py
+++ b/src/httpcore2/httpcore2/_async/connection_pool.py
@@ -368,9 +368,13 @@ class AsyncConnectionPool(AsyncRequestInterface):
             return entry
 
         # Idle sharable connections were handled above; the remaining ones are
-        # either serving requests or not yet connected.
-        for entry in self._sharable_by_origin.get(origin, ()):
-            if entry.connection.is_available():
+        # either serving requests or not yet connected. One that closed while
+        # a response still holds it is dropped now rather than at that release,
+        # so it does not count against `max_connections` in the meantime.
+        for entry in list(self._sharable_by_origin.get(origin, ())):
+            if entry.connection.is_closed():
+                self._drop_connection(entry)
+            elif entry.connection.is_available():
                 return entry
 
         if len(self._entries) < self._max_connections:
@@ -396,7 +400,11 @@ class AsyncConnectionPool(AsyncRequestInterface):
             self._drop_connection(entry)
             return
         if entry.holders:
-            # Still serving another request, or reserved by a queued request.
+            # Still serving another request, or reserved by a request that has
+            # not sent on it yet. Once known to be HTTP/1.1, it must not be
+            # handed to further requests while it is held.
+            if not connection.can_multiplex():
+                self._remove_sharable(entry)
             return
         if not connection.is_connected():
             # Garbage: a NEW-state connection whose request was cancelled
@@ -405,12 +413,11 @@ class AsyncConnectionPool(AsyncRequestInterface):
             self._drop_connection(entry)
             return
 
-        sharable = self._sharable_by_origin.setdefault(entry.origin, {})
         if connection.can_multiplex():
-            sharable[entry] = None
+            self._sharable_by_origin.setdefault(entry.origin, {})[entry] = None
         else:
             # An HTTP/1.1 connection is no longer a candidate for multiplexing.
-            sharable.pop(entry, None)
+            self._remove_sharable(entry)
 
         if connection.is_idle():
             entry.idle_since = time.monotonic()
@@ -454,15 +461,18 @@ class AsyncConnectionPool(AsyncRequestInterface):
         if not by_origin:
             del self._idle_by_origin[entry.origin]
 
-    def _drop_connection(self, entry: _ConnectionEntry) -> None:
-        if entry in self._idle:
-            self._remove_idle(entry)
-        del self._entries[id(entry.connection)]
+    def _remove_sharable(self, entry: _ConnectionEntry) -> None:
         sharable = self._sharable_by_origin.get(entry.origin)
         if sharable is not None:
             sharable.pop(entry, None)
             if not sharable:
                 del self._sharable_by_origin[entry.origin]
+
+    def _drop_connection(self, entry: _ConnectionEntry) -> None:
+        if entry in self._idle:
+            self._remove_idle(entry)
+        del self._entries[id(entry.connection)]
+        self._remove_sharable(entry)
 
     def _reserve_connection(self, pool_request: AsyncPoolRequest, entry: _ConnectionEntry) -> None:
         entry.holders += 1

--- a/src/httpcore2/httpcore2/_async/http_proxy.py
+++ b/src/httpcore2/httpcore2/_async/http_proxy.py
@@ -216,6 +216,9 @@ class AsyncForwardHTTPConnection(AsyncConnectionInterface):
     def is_idle(self) -> bool:
         return self._connection.is_idle()
 
+    def can_multiplex(self) -> bool:
+        return self._connection.can_multiplex()
+
     def is_closed(self) -> bool:
         return self._connection.is_closed()
 
@@ -344,6 +347,9 @@ class AsyncTunnelHTTPConnection(AsyncConnectionInterface):
 
     def is_idle(self) -> bool:
         return self._connection.is_idle()
+
+    def can_multiplex(self) -> bool:
+        return self._connection.can_multiplex()
 
     def is_closed(self) -> bool:
         return self._connection.is_closed()

--- a/src/httpcore2/httpcore2/_async/socks_proxy.py
+++ b/src/httpcore2/httpcore2/_async/socks_proxy.py
@@ -311,6 +311,11 @@ class AsyncSocks5Connection(AsyncConnectionInterface):
             return self._connect_failed
         return self._connection.is_idle()
 
+    def can_multiplex(self) -> bool:
+        if self._connection is None:  # pragma: no cover
+            return False
+        return self._connection.can_multiplex()
+
     def is_closed(self) -> bool:
         if self._connection is None:  # pragma: no cover
             return self._connect_failed

--- a/src/httpcore2/httpcore2/_models.py
+++ b/src/httpcore2/httpcore2/_models.py
@@ -169,6 +169,9 @@ class Origin:
             and self.port == other.port
         )
 
+    def __hash__(self) -> int:
+        return hash((self.scheme, self.host, self.port))
+
     def __str__(self) -> str:
         scheme = self.scheme.decode("ascii")
         host = self.host.decode("ascii")

--- a/src/httpcore2/httpcore2/_sync/connection_pool.py
+++ b/src/httpcore2/httpcore2/_sync/connection_pool.py
@@ -22,6 +22,7 @@ class PoolRequest:
     def __init__(self, request: Request) -> None:
         self.request = request
         self.connection: ConnectionInterface | None = None
+        self.entry: _ConnectionEntry | None = None
         # Created only by a request that actually has to wait: in the common
         # case a connection is assigned before `wait_for_connection` is called.
         self._connection_acquired: Event | None = None
@@ -47,6 +48,24 @@ class PoolRequest:
 
     def is_queued(self) -> bool:
         return self.connection is None
+
+
+class _ConnectionEntry:
+    """
+    The pool's bookkeeping for one connection. Entries are hashed by identity,
+    so connections themselves need not be hashable.
+    """
+
+    __slots__ = ("connection", "origin", "holders", "idle_since")
+
+    def __init__(self, connection: ConnectionInterface, origin: Origin) -> None:
+        self.connection = connection
+        self.origin = origin
+        # The number of in-flight requests holding the connection. An idle
+        # HTTP/1.1 connection with a holder is reserved by a request that has
+        # not sent on it yet.
+        self.holders = 0
+        self.idle_since = 0.0
 
 
 class ConnectionPool(RequestInterface):
@@ -104,7 +123,7 @@ class ConnectionPool(RequestInterface):
         self._max_keepalive_connections = (
             sys.maxsize if max_keepalive_connections is None else max_keepalive_connections
         )
-        self._max_keepalive_connections = min(self._max_connections, self._max_keepalive_connections)
+        self._max_keepalive_connections = max(0, min(self._max_connections, self._max_keepalive_connections))
 
         self._keepalive_expiry = keepalive_expiry
         self._http1 = http1
@@ -120,26 +139,22 @@ class ConnectionPool(RequestInterface):
         # releasing a connection costs O(1) rather than a scan of every
         # connection and every in-flight request.
         #
-        # Every connection owned by the pool, in creation order, with its origin.
-        self._connections: dict[ConnectionInterface, Origin] = {}
+        # Every connection owned by the pool, in creation order, keyed by identity.
+        self._entries: dict[int, _ConnectionEntry] = {}
         # Every in-flight request, in arrival order.
         self._requests: dict[PoolRequest, None] = {}
         # Requests still waiting for a connection, in arrival order.
         self._queued: deque[PoolRequest] = deque()
-        # The number of in-flight requests holding each connection. An idle
-        # HTTP/1.1 connection with a holder is reserved by a request that has
-        # not sent on it yet.
-        self._holders: dict[ConnectionInterface, int] = {}
-        # Idle connections free for reuse, oldest first, mapped to the time
-        # they became idle, plus the same connections keyed by origin.
-        self._idle: dict[ConnectionInterface, float] = {}
-        self._idle_by_origin: dict[Origin, dict[ConnectionInterface, None]] = {}
+        # Idle connections free for reuse, oldest first, plus the same
+        # connections keyed by origin.
+        self._idle: dict[_ConnectionEntry, None] = {}
+        self._idle_by_origin: dict[Origin, dict[_ConnectionEntry, None]] = {}
         # Connections that may take a request while not idle: HTTP/2 connections,
         # and connections that may still negotiate HTTP/2.
-        self._sharable_by_origin: dict[Origin, dict[ConnectionInterface, None]] = {}
+        self._sharable_by_origin: dict[Origin, dict[_ConnectionEntry, None]] = {}
         # Connections whose in-flight request has ended since the last pass,
         # to be re-examined by the next pass.
-        self._released: list[ConnectionInterface] = []
+        self._released: list[_ConnectionEntry] = []
         # When the oldest idle connection may have expired, or `None` while
         # no idle connection is subject to expiry.
         self._expiry_due: float | None = None
@@ -218,7 +233,7 @@ class ConnectionPool(RequestInterface):
         ]
         ```
         """
-        return list(self._connections)
+        return [entry.connection for entry in self._entries.values()]
 
     def handle_request(self, request: Request) -> Response:
         """
@@ -308,8 +323,8 @@ class ConnectionPool(RequestInterface):
         # dropped if their request left them closed.
         if self._released:
             released, self._released = self._released, []
-            for connection in released:
-                self._examine_released_connection(connection, closing_connections)
+            for entry in released:
+                self._examine_released_connection(entry, closing_connections)
 
         # Expire idle connections, but only once the oldest may have expired.
         if self._expiry_due is not None and time.monotonic() >= self._expiry_due:
@@ -332,7 +347,7 @@ class ConnectionPool(RequestInterface):
 
     def _acquire_connection(
         self, origin: Origin, closing_connections: list[ConnectionInterface]
-    ) -> ConnectionInterface | None:
+    ) -> _ConnectionEntry | None:
         # There are three cases for how we may be able to handle the request:
         #
         # 1. There is an existing connection that can handle the request.
@@ -341,129 +356,126 @@ class ConnectionPool(RequestInterface):
         #    to handle the request.
         idle = self._idle_by_origin.get(origin)
         while idle:
-            connection = next(iter(idle))
-            self._remove_idle(connection)
+            entry = next(iter(idle))
+            self._remove_idle(entry)
             # `has_expired()` also probes the socket, catching a connection the
             # server closed while it sat idle. An idle HTTP/2 connection may
             # have become unusable without closing, for example after an error.
-            if connection.has_expired() or not connection.is_available():
-                self._drop_connection(connection)
-                closing_connections.append(connection)
+            if entry.connection.has_expired() or not entry.connection.is_available():
+                self._drop_connection(entry)
+                closing_connections.append(entry.connection)
                 continue
-            return connection
+            return entry
 
         # Idle sharable connections were handled above; the remaining ones are
         # either serving requests or not yet connected.
-        for connection in self._sharable_by_origin.get(origin, ()):
-            if connection.is_available():
-                return connection
+        for entry in self._sharable_by_origin.get(origin, ()):
+            if entry.connection.is_available():
+                return entry
 
-        if len(self._connections) < self._max_connections:
+        if len(self._entries) < self._max_connections:
             return self._add_connection(origin)
 
         if self._idle:
-            connection = next(iter(self._idle))
-            self._drop_connection(connection)
-            closing_connections.append(connection)
+            entry = next(iter(self._idle))
+            self._drop_connection(entry)
+            closing_connections.append(entry.connection)
             return self._add_connection(origin)
 
         return None
 
     def _examine_released_connection(
-        self, connection: ConnectionInterface, closing_connections: list[ConnectionInterface]
+        self, entry: _ConnectionEntry, closing_connections: list[ConnectionInterface]
     ) -> None:
-        origin = self._connections.get(connection)
-        if origin is None:
+        connection = entry.connection
+        if self._entries.get(id(connection)) is not entry:
             # Already dropped, for example by the pool closing.
             return
         if connection.is_closed():
             # The request left the connection closed; there is no socket to close.
-            self._drop_connection(connection)
+            self._drop_connection(entry)
             return
-        if self._holders.get(connection, 0):
+        if entry.holders:
             # Still serving another request, or reserved by a queued request.
             return
         if not connection.is_connected():
             # Garbage: a NEW-state connection whose request was cancelled
             # before the TCP handshake completed. Drop it without closing
             # (there is no socket to close yet).
-            self._drop_connection(connection)
+            self._drop_connection(entry)
             return
 
-        sharable = self._sharable_by_origin.setdefault(origin, {})
+        sharable = self._sharable_by_origin.setdefault(entry.origin, {})
         if connection.can_multiplex():
-            sharable[connection] = None
+            sharable[entry] = None
         else:
             # An HTTP/1.1 connection is no longer a candidate for multiplexing.
-            sharable.pop(connection, None)
+            sharable.pop(entry, None)
 
         if connection.is_idle():
-            now = time.monotonic()
-            self._idle[connection] = now
-            self._idle_by_origin.setdefault(origin, {})[connection] = None
+            entry.idle_since = time.monotonic()
+            self._idle[entry] = None
+            self._idle_by_origin.setdefault(entry.origin, {})[entry] = None
             if self._expiry_due is None and self._keepalive_expiry is not None:
-                self._expiry_due = now + self._keepalive_expiry
+                self._expiry_due = entry.idle_since + self._keepalive_expiry
 
             # Enforce `max_keepalive_connections`, closing the longest idle first.
             while len(self._idle) > self._max_keepalive_connections:
                 surplus = next(iter(self._idle))
                 self._drop_connection(surplus)
-                closing_connections.append(surplus)
+                closing_connections.append(surplus.connection)
 
     def _expire_idle_connections(self, closing_connections: list[ConnectionInterface]) -> None:
-        for connection in list(self._idle):
-            if connection.has_expired():
-                self._drop_connection(connection)
-                closing_connections.append(connection)
+        for entry in list(self._idle):
+            if entry.connection.has_expired():
+                self._drop_connection(entry)
+                closing_connections.append(entry.connection)
 
         assert self._keepalive_expiry is not None
         self._expiry_due = None
         if self._idle:
             # The next sweep is due when the oldest remaining idle connection expires.
-            self._expiry_due = next(iter(self._idle.values())) + self._keepalive_expiry
+            self._expiry_due = next(iter(self._idle)).idle_since + self._keepalive_expiry
 
-    def _add_connection(self, origin: Origin) -> ConnectionInterface:
+    def _add_connection(self, origin: Origin) -> _ConnectionEntry:
         connection = self.create_connection(origin)
-        self._connections[connection] = origin
+        entry = _ConnectionEntry(connection, origin)
+        self._entries[id(connection)] = entry
         if connection.is_available():
             # Not yet connected, but may negotiate HTTP/2 and then take
             # further requests concurrently.
-            self._sharable_by_origin.setdefault(origin, {})[connection] = None
-        return connection
+            self._sharable_by_origin.setdefault(origin, {})[entry] = None
+        return entry
 
-    def _remove_idle(self, connection: ConnectionInterface) -> None:
-        del self._idle[connection]
-        origin = self._connections[connection]
-        by_origin = self._idle_by_origin[origin]
-        del by_origin[connection]
+    def _remove_idle(self, entry: _ConnectionEntry) -> None:
+        del self._idle[entry]
+        by_origin = self._idle_by_origin[entry.origin]
+        del by_origin[entry]
         if not by_origin:
-            del self._idle_by_origin[origin]
+            del self._idle_by_origin[entry.origin]
 
-    def _drop_connection(self, connection: ConnectionInterface) -> None:
-        if connection in self._idle:
-            self._remove_idle(connection)
-        origin = self._connections.pop(connection)
-        self._holders.pop(connection, None)
-        sharable = self._sharable_by_origin.get(origin)
+    def _drop_connection(self, entry: _ConnectionEntry) -> None:
+        if entry in self._idle:
+            self._remove_idle(entry)
+        del self._entries[id(entry.connection)]
+        sharable = self._sharable_by_origin.get(entry.origin)
         if sharable is not None:
-            sharable.pop(connection, None)
+            sharable.pop(entry, None)
             if not sharable:
-                del self._sharable_by_origin[origin]
+                del self._sharable_by_origin[entry.origin]
 
-    def _reserve_connection(self, pool_request: PoolRequest, connection: ConnectionInterface) -> None:
-        self._holders[connection] = self._holders.get(connection, 0) + 1
-        pool_request.assign_to_connection(connection)
+    def _reserve_connection(self, pool_request: PoolRequest, entry: _ConnectionEntry) -> None:
+        entry.holders += 1
+        pool_request.entry = entry
+        pool_request.assign_to_connection(entry.connection)
 
     def _release_connection(self, pool_request: PoolRequest) -> None:
-        connection = pool_request.connection
-        if connection is None:
+        entry = pool_request.entry
+        if entry is None:
             return
-        count = self._holders.get(connection, 0) - 1
-        if count > 0:
-            self._holders[connection] = count
-        else:
-            self._holders.pop(connection, None)
-        self._released.append(connection)
+        pool_request.entry = None
+        entry.holders -= 1
+        self._released.append(entry)
 
     def _close_connections(self, closing: list[ConnectionInterface]) -> None:
         # Close connections which have been removed from the pool.
@@ -477,9 +489,8 @@ class ConnectionPool(RequestInterface):
         # Explicitly close the connection pool.
         # Clears all existing requests and connections.
         with self._optional_thread_lock:
-            closing_connections = list(self._connections)
-            self._connections = {}
-            self._holders = {}
+            closing_connections = [entry.connection for entry in self._entries.values()]
+            self._entries = {}
             self._idle = {}
             self._idle_by_origin = {}
             self._sharable_by_origin = {}
@@ -503,7 +514,7 @@ class ConnectionPool(RequestInterface):
         with self._optional_thread_lock:
             num_queued_requests = len(self._queued)
             num_active_requests = len(self._requests) - num_queued_requests
-            connection_is_idle = [connection.is_idle() for connection in self._connections]
+            connection_is_idle = [entry.connection.is_idle() for entry in self._entries.values()]
 
             num_active_connections = connection_is_idle.count(False)
             num_idle_connections = connection_is_idle.count(True)

--- a/src/httpcore2/httpcore2/_sync/connection_pool.py
+++ b/src/httpcore2/httpcore2/_sync/connection_pool.py
@@ -130,8 +130,8 @@ class ConnectionPool(RequestInterface):
         # HTTP/1.1 connection with a holder is reserved by a request that has
         # not sent on it yet.
         self._holders: dict[ConnectionInterface, int] = {}
-        # Idle HTTP/1.1 connections free for reuse, oldest first, mapped to the
-        # time they became idle, plus the same connections keyed by origin.
+        # Idle connections free for reuse, oldest first, mapped to the time
+        # they became idle, plus the same connections keyed by origin.
         self._idle: dict[ConnectionInterface, float] = {}
         self._idle_by_origin: dict[Origin, dict[ConnectionInterface, None]] = {}
         # Connections that may take a request while not idle: HTTP/2 connections,
@@ -343,15 +343,18 @@ class ConnectionPool(RequestInterface):
         while idle:
             connection = next(iter(idle))
             self._remove_idle(connection)
-            # `has_expired()` also probes the socket, catching a connection
-            # the server closed while it sat idle.
-            if connection.has_expired():
+            # `has_expired()` also probes the socket, catching a connection the
+            # server closed while it sat idle. An idle HTTP/2 connection may
+            # have become unusable without closing, for example after an error.
+            if connection.has_expired() or not connection.is_available():
                 self._drop_connection(connection)
                 closing_connections.append(connection)
                 continue
             return connection
 
-        for connection in self._live_sharable_connections(origin, closing_connections):
+        # Idle sharable connections were handled above; the remaining ones are
+        # either serving requests or not yet connected.
+        for connection in self._sharable_by_origin.get(origin, ()):
             if connection.is_available():
                 return connection
 
@@ -360,7 +363,6 @@ class ConnectionPool(RequestInterface):
 
         if self._idle:
             connection = next(iter(self._idle))
-            self._remove_idle(connection)
             self._drop_connection(connection)
             closing_connections.append(connection)
             return self._add_connection(origin)
@@ -388,69 +390,37 @@ class ConnectionPool(RequestInterface):
             self._drop_connection(connection)
             return
 
+        sharable = self._sharable_by_origin.setdefault(origin, {})
         if connection.can_multiplex():
-            self._sharable_by_origin.setdefault(origin, {})[connection] = None
-            if connection.is_idle():
-                self._schedule_expiry(time.monotonic())
-            return
-
-        # An HTTP/1.1 connection: no longer a candidate for HTTP/2 multiplexing.
-        sharable = self._sharable_by_origin.get(origin)
-        if sharable is not None:
+            sharable[connection] = None
+        else:
+            # An HTTP/1.1 connection is no longer a candidate for multiplexing.
             sharable.pop(connection, None)
 
         if connection.is_idle():
             now = time.monotonic()
             self._idle[connection] = now
             self._idle_by_origin.setdefault(origin, {})[connection] = None
-            self._schedule_expiry(now)
+            if self._expiry_due is None and self._keepalive_expiry is not None:
+                self._expiry_due = now + self._keepalive_expiry
 
             # Enforce `max_keepalive_connections`, closing the longest idle first.
             while len(self._idle) > self._max_keepalive_connections:
                 surplus = next(iter(self._idle))
-                self._remove_idle(surplus)
                 self._drop_connection(surplus)
                 closing_connections.append(surplus)
 
     def _expire_idle_connections(self, closing_connections: list[ConnectionInterface]) -> None:
         for connection in list(self._idle):
             if connection.has_expired():
-                self._remove_idle(connection)
                 self._drop_connection(connection)
                 closing_connections.append(connection)
 
-        sharable_idle = False
-        for origin in list(self._sharable_by_origin):
-            for connection in self._live_sharable_connections(origin, closing_connections):
-                if connection.is_idle():
-                    sharable_idle = True
-
-        self._expiry_due = None
         assert self._keepalive_expiry is not None
+        self._expiry_due = None
         if self._idle:
+            # The next sweep is due when the oldest remaining idle connection expires.
             self._expiry_due = next(iter(self._idle.values())) + self._keepalive_expiry
-        elif sharable_idle:
-            self._expiry_due = time.monotonic() + self._keepalive_expiry
-
-    def _live_sharable_connections(
-        self, origin: Origin, closing_connections: list[ConnectionInterface]
-    ) -> list[ConnectionInterface]:
-        # Drop sharable connections that were closed or expired while the pool
-        # was not looking at them, returning the ones still worth using.
-        live: list[ConnectionInterface] = []
-        for connection in list(self._sharable_by_origin.get(origin, ())):
-            if connection.is_closed():
-                self._drop_connection(connection)
-            elif connection.has_expired():
-                self._drop_connection(connection)
-                closing_connections.append(connection)
-            else:
-                live.append(connection)
-        return live
-
-    def _schedule_expiry(self, now: float) -> None:
-        if self._expiry_due is None and self._keepalive_expiry is not None:
-            self._expiry_due = now + self._keepalive_expiry
 
     def _add_connection(self, origin: Origin) -> ConnectionInterface:
         connection = self.create_connection(origin)
@@ -470,6 +440,8 @@ class ConnectionPool(RequestInterface):
             del self._idle_by_origin[origin]
 
     def _drop_connection(self, connection: ConnectionInterface) -> None:
+        if connection in self._idle:
+            self._remove_idle(connection)
         origin = self._connections.pop(connection)
         self._holders.pop(connection, None)
         sharable = self._sharable_by_origin.get(origin)

--- a/src/httpcore2/httpcore2/_sync/connection_pool.py
+++ b/src/httpcore2/httpcore2/_sync/connection_pool.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import ssl
 import sys
+import time
 import types
 import typing
+from collections import deque
 from collections.abc import Generator
 
 from .._backends.sync import SyncBackend
@@ -20,19 +22,26 @@ class PoolRequest:
     def __init__(self, request: Request) -> None:
         self.request = request
         self.connection: ConnectionInterface | None = None
-        self._connection_acquired = Event()
+        # Created only by a request that actually has to wait: in the common
+        # case a connection is assigned before `wait_for_connection` is called.
+        self._connection_acquired: Event | None = None
 
     def assign_to_connection(self, connection: ConnectionInterface | None) -> None:
         self.connection = connection
-        self._connection_acquired.set()
+        if self._connection_acquired is not None:
+            self._connection_acquired.set()
 
     def clear_connection(self) -> None:
         self.connection = None
-        self._connection_acquired = Event()
+        self._connection_acquired = None
 
     def wait_for_connection(self, timeout: float | None = None) -> ConnectionInterface:
         if self.connection is None:
-            self._connection_acquired.wait(timeout=timeout)
+            self._connection_acquired = Event()
+            # Re-check after publishing the event: in the threaded case an
+            # assignment may have landed between the first check and here.
+            if self.connection is None:
+                self._connection_acquired.wait(timeout=timeout)
         assert self.connection is not None
         return self.connection
 
@@ -107,10 +116,33 @@ class ConnectionPool(RequestInterface):
         self._network_backend = SyncBackend() if network_backend is None else network_backend
         self._socket_options = socket_options
 
-        # The mutable state on a connection pool is the queue of incoming requests,
-        # and the set of connections that are servicing those requests.
-        self._connections: list[ConnectionInterface] = []
-        self._requests: list[PoolRequest] = []
+        # The pool's state is kept incrementally, so that handling a request or
+        # releasing a connection costs O(1) rather than a scan of every
+        # connection and every in-flight request.
+        #
+        # Every connection owned by the pool, in creation order, with its origin.
+        self._connections: dict[ConnectionInterface, Origin] = {}
+        # Every in-flight request, in arrival order.
+        self._requests: dict[PoolRequest, None] = {}
+        # Requests still waiting for a connection, in arrival order.
+        self._queued: deque[PoolRequest] = deque()
+        # The number of in-flight requests holding each connection. An idle
+        # HTTP/1.1 connection with a holder is reserved by a request that has
+        # not sent on it yet.
+        self._holders: dict[ConnectionInterface, int] = {}
+        # Idle HTTP/1.1 connections free for reuse, oldest first, mapped to the
+        # time they became idle, plus the same connections keyed by origin.
+        self._idle: dict[ConnectionInterface, float] = {}
+        self._idle_by_origin: dict[Origin, dict[ConnectionInterface, None]] = {}
+        # Connections that may take a request while not idle: HTTP/2 connections,
+        # and connections that may still negotiate HTTP/2.
+        self._sharable_by_origin: dict[Origin, dict[ConnectionInterface, None]] = {}
+        # Connections whose in-flight request has ended since the last pass,
+        # to be re-examined by the next pass.
+        self._released: list[ConnectionInterface] = []
+        # When the oldest idle connection may have expired, or `None` while
+        # no idle connection is subject to expiry.
+        self._expiry_due: float | None = None
 
         # We only mutate the state of the connection pool within an 'optional_thread_lock'
         # context. This holds a threading lock unless we're running in async mode,
@@ -206,7 +238,8 @@ class ConnectionPool(RequestInterface):
         with self._optional_thread_lock:
             # Add the incoming request to our request queue.
             pool_request = PoolRequest(request)
-            self._requests.append(pool_request)
+            self._requests[pool_request] = None
+            self._queued.append(pool_request)
 
         try:
             while True:
@@ -226,8 +259,12 @@ class ConnectionPool(RequestInterface):
                     # In some cases a connection may initially be available to
                     # handle a request, but then become unavailable.
                     #
-                    # In this case we clear the connection and try again.
-                    pool_request.clear_connection()
+                    # In this case we clear the connection and try again, keeping
+                    # the request at the front of the queue.
+                    with self._optional_thread_lock:
+                        self._release_connection(pool_request)
+                        pool_request.clear_connection()
+                        self._queued.appendleft(pool_request)
                 else:
                     break  # pragma: no cover
 
@@ -235,7 +272,10 @@ class ConnectionPool(RequestInterface):
             with self._optional_thread_lock:
                 # For any exception or cancellation we remove the request from
                 # the queue, and then re-assign requests to connections.
-                self._requests.remove(pool_request)
+                self._release_connection(pool_request)
+                if pool_request.is_queued():
+                    self._queued.remove(pool_request)
+                del self._requests[pool_request]
                 closing = self._assign_requests_to_connections()
 
             self._close_connections(closing)
@@ -253,122 +293,210 @@ class ConnectionPool(RequestInterface):
 
     def _assign_requests_to_connections(self) -> list[ConnectionInterface]:
         """
-        Manage the state of the connection pool, assigning incoming
+        Manage the state of the connection pool, assigning queued
         requests to connections as available.
 
-        Called whenever a new request is added or removed from the pool.
+        Called whenever a request is added to the pool, or a request
+        releases its connection.
 
         Any closing connections are returned, allowing the I/O for closing
         those connections to be handled separately.
         """
         closing_connections: list[ConnectionInterface] = []
-        retained_connections: list[ConnectionInterface] = []
 
-        # Connections currently referenced by an in-flight request, including
-        # connections that are in the process of being established and idle
-        # connections reserved by an assigned-but-not-yet-sent request.
-        request_connections = {r.connection for r in self._requests}
+        # Connections released since the last pass become reusable, or are
+        # dropped if their request left them closed.
+        if self._released:
+            released, self._released = self._released, []
+            for connection in released:
+                self._examine_released_connection(connection, closing_connections)
 
-        # First we handle cleaning up any connections that are closed
-        # or have expired their keep-alive, in a single pass. Reserved
-        # connections skip the expiry check: they were checked when assigned,
-        # and `has_expired()` on an idle connection probes the socket.
-        for connection in self._connections:
-            reserved = connection in request_connections
-            if connection.is_closed():
-                continue
-            elif not (connection.is_connected() or reserved):
-                # Garbage: a NEW-state connection whose request was cancelled
-                # before the TCP handshake completed.  Drop it without closing
-                # (there is no socket to close yet).
-                continue
-            elif not reserved and connection.has_expired():
-                closing_connections.append(connection)
-            else:
-                retained_connections.append(connection)
+        # Expire idle connections, but only once the oldest may have expired.
+        if self._expiry_due is not None and time.monotonic() >= self._expiry_due:
+            self._expire_idle_connections(closing_connections)
 
-        # Then we close any surplus idle connections, to enforce the
-        # max_keepalive_connections setting. Reserved connections are not
-        # surplus: a request is about to be sent on them.
-        idle_surplus = (
-            sum(connection.is_idle() and connection not in request_connections for connection in retained_connections)
-            - self._max_keepalive_connections
-        )
-        if idle_surplus > 0:
-            kept: list[ConnectionInterface] = []
-            for connection in retained_connections:
-                if idle_surplus > 0 and connection.is_idle() and connection not in request_connections:
-                    closing_connections.append(connection)
-                    idle_surplus -= 1
+        # Assign queued requests to connections, in arrival order. A request
+        # that cannot be served yet stays queued without blocking later
+        # requests that can reuse an existing connection.
+        if self._queued:
+            still_queued: deque[PoolRequest] = deque()
+            for pool_request in self._queued:
+                acquired = self._acquire_connection(pool_request.request.url.origin, closing_connections)
+                if acquired is None:
+                    still_queued.append(pool_request)
                 else:
-                    kept.append(connection)
-            retained_connections = kept
-
-        self._connections = retained_connections
-
-        # Snapshot the set of reusable connections once, rather than rebuilding
-        # it per queued request — this is what brings the loop from O(N*M) to
-        # O(N+M) in the common case.
-        #
-        # An idle connection already assigned to an in-flight request is
-        # reserved: it stays IDLE until the winning task sends on it, so
-        # without this exclusion the next pass would assign it again and the
-        # loser would churn through `ConnectionNotAvailable`. Multiplexing
-        # connections are exempt: they can take further requests while idle.
-        available_connections = [
-            connection
-            for connection in self._connections
-            if connection.is_available()
-            and not (connection.is_idle() and connection in request_connections and not connection.can_multiplex())
-        ]
-        new_connection_budget = self._max_connections - len(self._connections)
-
-        # Assign queued requests to connections. Once no connection is
-        # available and no new connection may be created, no queued request
-        # can be assigned, so the scan stops early: this keeps a pass on a
-        # saturated pool O(connections) rather than O(in-flight requests).
-        for pool_request in self._requests:
-            if not available_connections and new_connection_budget <= 0:
-                break
-            if not pool_request.is_queued():
-                continue
-            origin = pool_request.request.url.origin
-
-            # There are three cases for how we may be able to handle the request:
-            #
-            # 1. There is an existing connection that can handle the request.
-            # 2. We can create a new connection to handle the request.
-            # 3. We can close an idle connection and then create a new connection
-            #    to handle the request.
-            for idx, connection in enumerate(available_connections):
-                if connection.can_handle_request(origin):
-                    pool_request.assign_to_connection(connection)
-                    if connection.is_idle() and not connection.can_multiplex():
-                        # An idle HTTP/1.1 connection can only take this
-                        # single request until it is released.
-                        del available_connections[idx]
-                    break
-            else:
-                if new_connection_budget > 0:
-                    connection = self.create_connection(origin)
-                    self._connections.append(connection)
-                    pool_request.assign_to_connection(connection)
-                    new_connection_budget -= 1
-                    continue
-                for idx, connection in enumerate(available_connections):
-                    if connection.is_idle():
-                        del available_connections[idx]
-                        self._connections.remove(connection)
-                        closing_connections.append(connection)
-                        connection = self.create_connection(origin)
-                        self._connections.append(connection)
-                        pool_request.assign_to_connection(connection)
-                        break
+                    self._reserve_connection(pool_request, acquired)
+            self._queued = still_queued
 
         return closing_connections
 
+    def _acquire_connection(
+        self, origin: Origin, closing_connections: list[ConnectionInterface]
+    ) -> ConnectionInterface | None:
+        # There are three cases for how we may be able to handle the request:
+        #
+        # 1. There is an existing connection that can handle the request.
+        # 2. We can create a new connection to handle the request.
+        # 3. We can close an idle connection and then create a new connection
+        #    to handle the request.
+        idle = self._idle_by_origin.get(origin)
+        while idle:
+            connection = next(iter(idle))
+            self._remove_idle(connection)
+            # `has_expired()` also probes the socket, catching a connection
+            # the server closed while it sat idle.
+            if connection.has_expired():
+                self._drop_connection(connection)
+                closing_connections.append(connection)
+                continue
+            return connection
+
+        for connection in self._live_sharable_connections(origin, closing_connections):
+            if connection.is_available():
+                return connection
+
+        if len(self._connections) < self._max_connections:
+            return self._add_connection(origin)
+
+        if self._idle:
+            connection = next(iter(self._idle))
+            self._remove_idle(connection)
+            self._drop_connection(connection)
+            closing_connections.append(connection)
+            return self._add_connection(origin)
+
+        return None
+
+    def _examine_released_connection(
+        self, connection: ConnectionInterface, closing_connections: list[ConnectionInterface]
+    ) -> None:
+        origin = self._connections.get(connection)
+        if origin is None:
+            # Already dropped, for example by the pool closing.
+            return
+        if connection.is_closed():
+            # The request left the connection closed; there is no socket to close.
+            self._drop_connection(connection)
+            return
+        if self._holders.get(connection, 0):
+            # Still serving another request, or reserved by a queued request.
+            return
+        if not connection.is_connected():
+            # Garbage: a NEW-state connection whose request was cancelled
+            # before the TCP handshake completed. Drop it without closing
+            # (there is no socket to close yet).
+            self._drop_connection(connection)
+            return
+
+        if connection.can_multiplex():
+            self._sharable_by_origin.setdefault(origin, {})[connection] = None
+            if connection.is_idle():
+                self._schedule_expiry(time.monotonic())
+            return
+
+        # An HTTP/1.1 connection: no longer a candidate for HTTP/2 multiplexing.
+        sharable = self._sharable_by_origin.get(origin)
+        if sharable is not None:
+            sharable.pop(connection, None)
+
+        if connection.is_idle():
+            now = time.monotonic()
+            self._idle[connection] = now
+            self._idle_by_origin.setdefault(origin, {})[connection] = None
+            self._schedule_expiry(now)
+
+            # Enforce `max_keepalive_connections`, closing the longest idle first.
+            while len(self._idle) > self._max_keepalive_connections:
+                surplus = next(iter(self._idle))
+                self._remove_idle(surplus)
+                self._drop_connection(surplus)
+                closing_connections.append(surplus)
+
+    def _expire_idle_connections(self, closing_connections: list[ConnectionInterface]) -> None:
+        for connection in list(self._idle):
+            if connection.has_expired():
+                self._remove_idle(connection)
+                self._drop_connection(connection)
+                closing_connections.append(connection)
+
+        sharable_idle = False
+        for origin in list(self._sharable_by_origin):
+            for connection in self._live_sharable_connections(origin, closing_connections):
+                if connection.is_idle():
+                    sharable_idle = True
+
+        self._expiry_due = None
+        assert self._keepalive_expiry is not None
+        if self._idle:
+            self._expiry_due = next(iter(self._idle.values())) + self._keepalive_expiry
+        elif sharable_idle:
+            self._expiry_due = time.monotonic() + self._keepalive_expiry
+
+    def _live_sharable_connections(
+        self, origin: Origin, closing_connections: list[ConnectionInterface]
+    ) -> list[ConnectionInterface]:
+        # Drop sharable connections that were closed or expired while the pool
+        # was not looking at them, returning the ones still worth using.
+        live: list[ConnectionInterface] = []
+        for connection in list(self._sharable_by_origin.get(origin, ())):
+            if connection.is_closed():
+                self._drop_connection(connection)
+            elif connection.has_expired():
+                self._drop_connection(connection)
+                closing_connections.append(connection)
+            else:
+                live.append(connection)
+        return live
+
+    def _schedule_expiry(self, now: float) -> None:
+        if self._expiry_due is None and self._keepalive_expiry is not None:
+            self._expiry_due = now + self._keepalive_expiry
+
+    def _add_connection(self, origin: Origin) -> ConnectionInterface:
+        connection = self.create_connection(origin)
+        self._connections[connection] = origin
+        if connection.is_available():
+            # Not yet connected, but may negotiate HTTP/2 and then take
+            # further requests concurrently.
+            self._sharable_by_origin.setdefault(origin, {})[connection] = None
+        return connection
+
+    def _remove_idle(self, connection: ConnectionInterface) -> None:
+        del self._idle[connection]
+        origin = self._connections[connection]
+        by_origin = self._idle_by_origin[origin]
+        del by_origin[connection]
+        if not by_origin:
+            del self._idle_by_origin[origin]
+
+    def _drop_connection(self, connection: ConnectionInterface) -> None:
+        origin = self._connections.pop(connection)
+        self._holders.pop(connection, None)
+        sharable = self._sharable_by_origin.get(origin)
+        if sharable is not None:
+            sharable.pop(connection, None)
+            if not sharable:
+                del self._sharable_by_origin[origin]
+
+    def _reserve_connection(self, pool_request: PoolRequest, connection: ConnectionInterface) -> None:
+        self._holders[connection] = self._holders.get(connection, 0) + 1
+        pool_request.assign_to_connection(connection)
+
+    def _release_connection(self, pool_request: PoolRequest) -> None:
+        connection = pool_request.connection
+        if connection is None:
+            return
+        count = self._holders.get(connection, 0) - 1
+        if count > 0:
+            self._holders[connection] = count
+        else:
+            self._holders.pop(connection, None)
+        self._released.append(connection)
+
     def _close_connections(self, closing: list[ConnectionInterface]) -> None:
         # Close connections which have been removed from the pool.
+        if not closing:
+            return
         with ShieldCancellation():
             for connection in closing:
                 connection.close()
@@ -378,7 +506,13 @@ class ConnectionPool(RequestInterface):
         # Clears all existing requests and connections.
         with self._optional_thread_lock:
             closing_connections = list(self._connections)
-            self._connections = []
+            self._connections = {}
+            self._holders = {}
+            self._idle = {}
+            self._idle_by_origin = {}
+            self._sharable_by_origin = {}
+            self._released = []
+            self._expiry_due = None
         self._close_connections(closing_connections)
 
     def __enter__(self) -> ConnectionPool:
@@ -395,11 +529,10 @@ class ConnectionPool(RequestInterface):
     def __repr__(self) -> str:
         class_name = self.__class__.__name__
         with self._optional_thread_lock:
-            request_is_queued = [request.is_queued() for request in self._requests]
+            num_queued_requests = len(self._queued)
+            num_active_requests = len(self._requests) - num_queued_requests
             connection_is_idle = [connection.is_idle() for connection in self._connections]
 
-            num_active_requests = request_is_queued.count(False)
-            num_queued_requests = request_is_queued.count(True)
             num_active_connections = connection_is_idle.count(False)
             num_idle_connections = connection_is_idle.count(True)
 
@@ -434,7 +567,8 @@ class PoolByteStream:
                     self._stream.close()
 
             with self._pool._optional_thread_lock:
-                self._pool._requests.remove(self._pool_request)
+                self._pool._release_connection(self._pool_request)
+                del self._pool._requests[self._pool_request]
                 closing = self._pool._assign_requests_to_connections()
 
             self._pool._close_connections(closing)

--- a/src/httpcore2/httpcore2/_sync/connection_pool.py
+++ b/src/httpcore2/httpcore2/_sync/connection_pool.py
@@ -368,9 +368,13 @@ class ConnectionPool(RequestInterface):
             return entry
 
         # Idle sharable connections were handled above; the remaining ones are
-        # either serving requests or not yet connected.
-        for entry in self._sharable_by_origin.get(origin, ()):
-            if entry.connection.is_available():
+        # either serving requests or not yet connected. One that closed while
+        # a response still holds it is dropped now rather than at that release,
+        # so it does not count against `max_connections` in the meantime.
+        for entry in list(self._sharable_by_origin.get(origin, ())):
+            if entry.connection.is_closed():
+                self._drop_connection(entry)
+            elif entry.connection.is_available():
                 return entry
 
         if len(self._entries) < self._max_connections:
@@ -396,7 +400,11 @@ class ConnectionPool(RequestInterface):
             self._drop_connection(entry)
             return
         if entry.holders:
-            # Still serving another request, or reserved by a queued request.
+            # Still serving another request, or reserved by a request that has
+            # not sent on it yet. Once known to be HTTP/1.1, it must not be
+            # handed to further requests while it is held.
+            if not connection.can_multiplex():
+                self._remove_sharable(entry)
             return
         if not connection.is_connected():
             # Garbage: a NEW-state connection whose request was cancelled
@@ -405,12 +413,11 @@ class ConnectionPool(RequestInterface):
             self._drop_connection(entry)
             return
 
-        sharable = self._sharable_by_origin.setdefault(entry.origin, {})
         if connection.can_multiplex():
-            sharable[entry] = None
+            self._sharable_by_origin.setdefault(entry.origin, {})[entry] = None
         else:
             # An HTTP/1.1 connection is no longer a candidate for multiplexing.
-            sharable.pop(entry, None)
+            self._remove_sharable(entry)
 
         if connection.is_idle():
             entry.idle_since = time.monotonic()
@@ -454,15 +461,18 @@ class ConnectionPool(RequestInterface):
         if not by_origin:
             del self._idle_by_origin[entry.origin]
 
-    def _drop_connection(self, entry: _ConnectionEntry) -> None:
-        if entry in self._idle:
-            self._remove_idle(entry)
-        del self._entries[id(entry.connection)]
+    def _remove_sharable(self, entry: _ConnectionEntry) -> None:
         sharable = self._sharable_by_origin.get(entry.origin)
         if sharable is not None:
             sharable.pop(entry, None)
             if not sharable:
                 del self._sharable_by_origin[entry.origin]
+
+    def _drop_connection(self, entry: _ConnectionEntry) -> None:
+        if entry in self._idle:
+            self._remove_idle(entry)
+        del self._entries[id(entry.connection)]
+        self._remove_sharable(entry)
 
     def _reserve_connection(self, pool_request: PoolRequest, entry: _ConnectionEntry) -> None:
         entry.holders += 1

--- a/src/httpcore2/httpcore2/_sync/http_proxy.py
+++ b/src/httpcore2/httpcore2/_sync/http_proxy.py
@@ -216,6 +216,9 @@ class ForwardHTTPConnection(ConnectionInterface):
     def is_idle(self) -> bool:
         return self._connection.is_idle()
 
+    def can_multiplex(self) -> bool:
+        return self._connection.can_multiplex()
+
     def is_closed(self) -> bool:
         return self._connection.is_closed()
 
@@ -344,6 +347,9 @@ class TunnelHTTPConnection(ConnectionInterface):
 
     def is_idle(self) -> bool:
         return self._connection.is_idle()
+
+    def can_multiplex(self) -> bool:
+        return self._connection.can_multiplex()
 
     def is_closed(self) -> bool:
         return self._connection.is_closed()

--- a/src/httpcore2/httpcore2/_sync/socks_proxy.py
+++ b/src/httpcore2/httpcore2/_sync/socks_proxy.py
@@ -311,6 +311,11 @@ class Socks5Connection(ConnectionInterface):
             return self._connect_failed
         return self._connection.is_idle()
 
+    def can_multiplex(self) -> bool:
+        if self._connection is None:  # pragma: no cover
+            return False
+        return self._connection.can_multiplex()
+
     def is_closed(self) -> bool:
         if self._connection is None:  # pragma: no cover
             return self._connect_failed

--- a/tests/httpcore2/_async/test_connection_pool.py
+++ b/tests/httpcore2/_async/test_connection_pool.py
@@ -1064,3 +1064,56 @@ async def test_connection_pool_closes_idle_http2_connection_for_different_origin
         assert response.status == 200
         info = [repr(c) for c in pool.connections]
         assert info == ["<AsyncHTTPConnection ['https://b.com:443', HTTP/2, IDLE, Request Count: 1]>"]
+
+
+@pytest.mark.anyio
+async def test_connection_pool_with_negative_keepalive_limit() -> None:
+    """
+    A negative `max_keepalive_connections` behaves like zero.
+    """
+    network_backend = httpcore2.AsyncMockBackend(
+        [
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Type: plain/text\r\n",
+            b"Content-Length: 13\r\n",
+            b"\r\n",
+            b"Hello, world!",
+        ]
+    )
+
+    async with httpcore2.AsyncConnectionPool(max_keepalive_connections=-1, network_backend=network_backend) as pool:
+        response = await pool.request("GET", "https://example.com/")
+        assert response.status == 200
+        assert pool.connections == []
+
+
+@pytest.mark.anyio
+async def test_connection_pool_with_unhashable_connections() -> None:
+    """
+    Connections returned by an overridden `create_connection` need not be hashable.
+    """
+
+    class UnhashableConnection(httpcore2.AsyncHTTPConnection):
+        __hash__ = None  # type: ignore[assignment]
+
+    class CustomPool(httpcore2.AsyncConnectionPool):
+        def create_connection(self, origin: httpcore2.Origin) -> httpcore2.AsyncConnectionInterface:
+            return UnhashableConnection(origin=origin, network_backend=self._network_backend)
+
+    network_backend = httpcore2.AsyncMockBackend(
+        [
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Type: plain/text\r\n",
+            b"Content-Length: 13\r\n",
+            b"\r\n",
+            b"Hello, world!",
+        ]
+        * 2
+    )
+
+    async with CustomPool(network_backend=network_backend) as pool:
+        for _ in range(2):
+            response = await pool.request("GET", "https://example.com/")
+            assert response.status == 200
+        info = [repr(c) for c in pool.connections]
+        assert info == ["<UnhashableConnection ['https://example.com:443', HTTP/1.1, IDLE, Request Count: 2]>"]

--- a/tests/httpcore2/_async/test_connection_pool.py
+++ b/tests/httpcore2/_async/test_connection_pool.py
@@ -1032,3 +1032,35 @@ async def test_connection_pool_discards_externally_closed_http2_connection() -> 
         assert response.status == 200
         info = [repr(c) for c in pool.connections]
         assert info == ["<AsyncHTTPConnection ['https://example.com:443', HTTP/2, IDLE, Request Count: 1]>"]
+
+
+@pytest.mark.anyio
+async def test_connection_pool_keepalive_limit_applies_to_http2_connections() -> None:
+    """
+    Idle HTTP/2 connections count towards `max_keepalive_connections`.
+    """
+    network_backend = httpcore2.AsyncMockBackend(buffer=http2_response_buffer(), http2=True)
+
+    async with httpcore2.AsyncConnectionPool(network_backend=network_backend, max_keepalive_connections=0) as pool:
+        response = await pool.request("GET", "https://example.com/")
+        assert response.status == 200
+        assert pool.connections == []
+
+
+@pytest.mark.anyio
+async def test_connection_pool_closes_idle_http2_connection_for_different_origin() -> None:
+    """
+    When the pool is full, an idle HTTP/2 connection to another origin is
+    closed to make room, just like an idle HTTP/1.1 connection.
+    """
+    network_backend = httpcore2.AsyncMockBackend(buffer=http2_response_buffer(), http2=True)
+
+    async with httpcore2.AsyncConnectionPool(network_backend=network_backend, max_connections=1) as pool:
+        await pool.request("GET", "https://a.com/")
+        info = [repr(c) for c in pool.connections]
+        assert info == ["<AsyncHTTPConnection ['https://a.com:443', HTTP/2, IDLE, Request Count: 1]>"]
+
+        response = await pool.request("GET", "https://b.com/")
+        assert response.status == 200
+        info = [repr(c) for c in pool.connections]
+        assert info == ["<AsyncHTTPConnection ['https://b.com:443', HTTP/2, IDLE, Request Count: 1]>"]

--- a/tests/httpcore2/_async/test_connection_pool.py
+++ b/tests/httpcore2/_async/test_connection_pool.py
@@ -1,4 +1,5 @@
 import logging
+import time
 import typing
 
 import anyio
@@ -939,12 +940,33 @@ async def test_connection_pool_discards_idle_connection_closed_by_server() -> No
         assert info == ["<AsyncHTTPConnection ['https://example.com:443', HTTP/1.1, IDLE, Request Count: 1]>"]
 
 
+class FakeClock:
+    """
+    A monotonic clock the test can advance, so keepalive expiry
+    does not depend on real time.
+    """
+
+    def __init__(self) -> None:
+        self._real = time.monotonic
+        self._offset = 0.0
+
+    def __call__(self) -> float:
+        return self._real() + self._offset
+
+    def advance(self, seconds: float) -> None:
+        self._offset += seconds
+
+
 @pytest.mark.anyio
-async def test_connection_pool_expires_only_the_idle_connections_past_keepalive() -> None:
+async def test_connection_pool_expires_only_the_idle_connections_past_keepalive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """
     Once the oldest idle connection passes its keepalive expiry, it is closed
     while younger idle connections are kept.
     """
+    clock = FakeClock()
+    monkeypatch.setattr(time, "monotonic", clock)
     network_backend = httpcore2.AsyncMockBackend(
         [
             b"HTTP/1.1 200 OK\r\n",
@@ -955,11 +977,11 @@ async def test_connection_pool_expires_only_the_idle_connections_past_keepalive(
         ]
     )
 
-    async with httpcore2.AsyncConnectionPool(network_backend=network_backend, keepalive_expiry=0.4) as pool:
+    async with httpcore2.AsyncConnectionPool(network_backend=network_backend, keepalive_expiry=10.0) as pool:
         await pool.request("GET", "https://a.com/")
-        await anyio.sleep(0.25)
+        clock.advance(6.0)
         await pool.request("GET", "https://b.com/")
-        await anyio.sleep(0.25)
+        clock.advance(6.0)
 
         # The a.com connection has expired, the b.com connection has not.
         await pool.request("GET", "https://c.com/")
@@ -983,23 +1005,27 @@ def http2_response_buffer(stream_id: int = 1) -> list[bytes]:
 
 
 @pytest.mark.anyio
-async def test_connection_pool_expires_idle_http2_connections_past_keepalive() -> None:
+async def test_connection_pool_expires_idle_http2_connections_past_keepalive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """
     Idle HTTP/2 connections are subject to the keepalive expiry too, with
     younger idle connections kept.
     """
+    clock = FakeClock()
+    monkeypatch.setattr(time, "monotonic", clock)
     network_backend = httpcore2.AsyncMockBackend(buffer=http2_response_buffer(), http2=True)
 
-    async with httpcore2.AsyncConnectionPool(network_backend=network_backend, keepalive_expiry=0.4) as pool:
+    async with httpcore2.AsyncConnectionPool(network_backend=network_backend, keepalive_expiry=10.0) as pool:
         await pool.request("GET", "https://a.com/")
-        await anyio.sleep(0.25)
+        clock.advance(6.0)
         await pool.request("GET", "https://b.com/")
         info = [repr(c) for c in pool.connections]
         assert info == [
             "<AsyncHTTPConnection ['https://a.com:443', HTTP/2, IDLE, Request Count: 1]>",
             "<AsyncHTTPConnection ['https://b.com:443', HTTP/2, IDLE, Request Count: 1]>",
         ]
-        await anyio.sleep(0.25)
+        clock.advance(6.0)
 
         # The a.com connection has expired, the b.com connection has not.
         await pool.request("GET", "https://c.com/")
@@ -1010,7 +1036,7 @@ async def test_connection_pool_expires_idle_http2_connections_past_keepalive() -
         ]
 
         # Left long enough, the remaining connections expire as well.
-        await anyio.sleep(0.5)
+        clock.advance(11.0)
         await pool.request("GET", "https://a.com/")
         info = [repr(c) for c in pool.connections]
         assert info == ["<AsyncHTTPConnection ['https://a.com:443', HTTP/2, IDLE, Request Count: 1]>"]

--- a/tests/httpcore2/_async/test_connection_pool.py
+++ b/tests/httpcore2/_async/test_connection_pool.py
@@ -1,6 +1,7 @@
 import logging
 import typing
 
+import anyio
 import hpack
 import hyperframe.frame
 import pytest
@@ -884,3 +885,150 @@ async def test_connection_pool_multiplexes_idle_http2_connection_within_a_pass()
                 nursery.start_soon(fetch, pool)
 
     assert QueueObservingPool.max_queued_after_pass == 0
+
+
+@pytest.mark.anyio
+async def test_connection_pool_discards_idle_connection_closed_by_server() -> None:
+    """
+    An idle connection that the server has closed is discarded when a request
+    would otherwise reuse it, and a new connection is opened instead.
+    """
+
+    class ServerClosingBackend(httpcore2.AsyncMockBackend):
+        server_closed = False
+
+        async def connect_tcp(
+            self,
+            host: str,
+            port: int,
+            timeout: float | None = None,
+            local_address: str | None = None,
+            socket_options: typing.Iterable[httpcore2.SOCKET_OPTION] | None = None,
+        ) -> httpcore2.AsyncNetworkStream:
+            backend = self
+
+            class ServerClosingStream(httpcore2.AsyncMockStream):
+                def get_extra_info(self, info: str) -> typing.Any:
+                    # A readable idle socket means the server sent a FIN.
+                    if info == "is_readable":
+                        return backend.server_closed
+                    return super().get_extra_info(info)
+
+            return ServerClosingStream(list(self._buffer))
+
+    network_backend = ServerClosingBackend(
+        [
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Type: plain/text\r\n",
+            b"Content-Length: 13\r\n",
+            b"\r\n",
+            b"Hello, world!",
+        ]
+    )
+
+    async with httpcore2.AsyncConnectionPool(network_backend=network_backend) as pool:
+        response = await pool.request("GET", "https://example.com/")
+        assert response.status == 200
+        info = [repr(c) for c in pool.connections]
+        assert info == ["<AsyncHTTPConnection ['https://example.com:443', HTTP/1.1, IDLE, Request Count: 1]>"]
+
+        network_backend.server_closed = True
+        response = await pool.request("GET", "https://example.com/")
+        assert response.status == 200
+        info = [repr(c) for c in pool.connections]
+        assert info == ["<AsyncHTTPConnection ['https://example.com:443', HTTP/1.1, IDLE, Request Count: 1]>"]
+
+
+@pytest.mark.anyio
+async def test_connection_pool_expires_only_the_idle_connections_past_keepalive() -> None:
+    """
+    Once the oldest idle connection passes its keepalive expiry, it is closed
+    while younger idle connections are kept.
+    """
+    network_backend = httpcore2.AsyncMockBackend(
+        [
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Type: plain/text\r\n",
+            b"Content-Length: 13\r\n",
+            b"\r\n",
+            b"Hello, world!",
+        ]
+    )
+
+    async with httpcore2.AsyncConnectionPool(network_backend=network_backend, keepalive_expiry=0.4) as pool:
+        await pool.request("GET", "https://a.com/")
+        await anyio.sleep(0.25)
+        await pool.request("GET", "https://b.com/")
+        await anyio.sleep(0.25)
+
+        # The a.com connection has expired, the b.com connection has not.
+        await pool.request("GET", "https://c.com/")
+        info = [repr(c) for c in pool.connections]
+        assert info == [
+            "<AsyncHTTPConnection ['https://b.com:443', HTTP/1.1, IDLE, Request Count: 1]>",
+            "<AsyncHTTPConnection ['https://c.com:443', HTTP/1.1, IDLE, Request Count: 1]>",
+        ]
+
+
+def http2_response_buffer(stream_id: int = 1) -> list[bytes]:
+    return [
+        hyperframe.frame.SettingsFrame().serialize(),
+        hyperframe.frame.HeadersFrame(
+            stream_id=stream_id,
+            data=hpack.Encoder().encode([(b":status", b"200")]),
+            flags=["END_HEADERS"],
+        ).serialize(),
+        hyperframe.frame.DataFrame(stream_id=stream_id, data=b"Hello, world!", flags=["END_STREAM"]).serialize(),
+    ]
+
+
+@pytest.mark.anyio
+async def test_connection_pool_expires_idle_http2_connections_past_keepalive() -> None:
+    """
+    Idle HTTP/2 connections are subject to the keepalive expiry too, with
+    younger idle connections kept.
+    """
+    network_backend = httpcore2.AsyncMockBackend(buffer=http2_response_buffer(), http2=True)
+
+    async with httpcore2.AsyncConnectionPool(network_backend=network_backend, keepalive_expiry=0.4) as pool:
+        await pool.request("GET", "https://a.com/")
+        await anyio.sleep(0.25)
+        await pool.request("GET", "https://b.com/")
+        info = [repr(c) for c in pool.connections]
+        assert info == [
+            "<AsyncHTTPConnection ['https://a.com:443', HTTP/2, IDLE, Request Count: 1]>",
+            "<AsyncHTTPConnection ['https://b.com:443', HTTP/2, IDLE, Request Count: 1]>",
+        ]
+        await anyio.sleep(0.25)
+
+        # The a.com connection has expired, the b.com connection has not.
+        await pool.request("GET", "https://c.com/")
+        info = [repr(c) for c in pool.connections]
+        assert info == [
+            "<AsyncHTTPConnection ['https://b.com:443', HTTP/2, IDLE, Request Count: 1]>",
+            "<AsyncHTTPConnection ['https://c.com:443', HTTP/2, IDLE, Request Count: 1]>",
+        ]
+
+        # Left long enough, the remaining connections expire as well.
+        await anyio.sleep(0.5)
+        await pool.request("GET", "https://a.com/")
+        info = [repr(c) for c in pool.connections]
+        assert info == ["<AsyncHTTPConnection ['https://a.com:443', HTTP/2, IDLE, Request Count: 1]>"]
+
+
+@pytest.mark.anyio
+async def test_connection_pool_discards_externally_closed_http2_connection() -> None:
+    """
+    An HTTP/2 connection closed outside of a request is discarded rather than
+    handed to the next request for that origin.
+    """
+    network_backend = httpcore2.AsyncMockBackend(buffer=http2_response_buffer(), http2=True)
+
+    async with httpcore2.AsyncConnectionPool(network_backend=network_backend) as pool:
+        await pool.request("GET", "https://example.com/")
+        await pool.connections[0].aclose()
+
+        response = await pool.request("GET", "https://example.com/")
+        assert response.status == 200
+        info = [repr(c) for c in pool.connections]
+        assert info == ["<AsyncHTTPConnection ['https://example.com:443', HTTP/2, IDLE, Request Count: 1]>"]

--- a/tests/httpcore2/_async/test_connection_pool.py
+++ b/tests/httpcore2/_async/test_connection_pool.py
@@ -1117,3 +1117,71 @@ async def test_connection_pool_with_unhashable_connections() -> None:
             assert response.status == 200
         info = [repr(c) for c in pool.connections]
         assert info == ["<UnhashableConnection ['https://example.com:443', HTTP/1.1, IDLE, Request Count: 2]>"]
+
+
+@pytest.mark.anyio
+async def test_connection_pool_replaces_http2_connection_closed_while_held() -> None:
+    """
+    An HTTP/2 connection that closes while a response still holds it is
+    replaced immediately, rather than counting against `max_connections`
+    until that response is closed.
+    """
+    network_backend = httpcore2.AsyncMockBackend(buffer=http2_response_buffer(), http2=True)
+
+    async with httpcore2.AsyncConnectionPool(network_backend=network_backend, max_connections=1, http2=True) as pool:
+        async with pool.stream("GET", "https://example.com/") as response:
+            await pool.connections[0].aclose()
+
+            timeout = {"timeout": {"pool": 1.0}}
+            second = await pool.request("GET", "https://example.com/", extensions=timeout)
+            assert second.status == 200
+            info = [repr(c) for c in pool.connections]
+            assert info == ["<AsyncHTTPConnection ['https://example.com:443', HTTP/2, IDLE, Request Count: 1]>"]
+
+        assert response.status == 200
+
+
+@pytest.mark.trio
+async def test_connection_pool_stops_sharing_http11_connection_still_held_speculatively() -> None:
+    """
+    With HTTP/2 enabled, requests may be assigned to a connection before it
+    has negotiated a protocol. Once it turns out to be HTTP/1.1 and its first
+    request completes while another is still waiting to send on it, it must
+    not be handed to any further request.
+    """
+
+    class YieldingBackend(httpcore2.AsyncMockBackend):
+        async def connect_tcp(
+            self,
+            host: str,
+            port: int,
+            timeout: float | None = None,
+            local_address: str | None = None,
+            socket_options: typing.Iterable[httpcore2.SOCKET_OPTION] | None = None,
+        ) -> httpcore2.AsyncNetworkStream:
+            # Let other requests be queued while this connection is being established.
+            await anyio.sleep(0)
+            return await super().connect_tcp(host, port, timeout, local_address, socket_options)
+
+    network_backend = YieldingBackend(
+        [
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Type: plain/text\r\n",
+            b"Content-Length: 13\r\n",
+            b"\r\n",
+            b"Hello, world!",
+        ]
+        * 3
+    )
+
+    async def fetch(pool: httpcore2.AsyncConnectionPool) -> None:
+        response = await pool.request("GET", "https://example.com/")
+        assert response.status == 200
+
+    async with httpcore2.AsyncConnectionPool(network_backend=network_backend, max_connections=1, http2=True) as pool:
+        async with concurrency.open_nursery() as nursery:
+            for _ in range(3):
+                nursery.start_soon(fetch, pool)
+
+        info = [repr(c) for c in pool.connections]
+        assert info == ["<AsyncHTTPConnection ['https://example.com:443', HTTP/1.1, IDLE, Request Count: 3]>"]

--- a/tests/httpcore2/_async/test_http_proxy.py
+++ b/tests/httpcore2/_async/test_http_proxy.py
@@ -52,6 +52,7 @@ async def test_proxy_forwarding() -> None:
         assert proxy.connections[0].is_idle()
         assert proxy.connections[0].is_available()
         assert not proxy.connections[0].is_closed()
+        assert not proxy.connections[0].has_expired()
 
         # A connection on a forwarding proxy can only handle HTTP requests to the same origin.
         assert proxy.connections[0].can_handle_request(Origin(b"http", b"example.com", 80))
@@ -97,6 +98,7 @@ async def test_proxy_tunneling() -> None:
         assert proxy.connections[0].is_idle()
         assert proxy.connections[0].is_available()
         assert not proxy.connections[0].is_closed()
+        assert not proxy.connections[0].has_expired()
 
         # A connection on a tunneled proxy can only handle HTTPS requests to the same origin.
         assert not proxy.connections[0].can_handle_request(Origin(b"http", b"example.com", 80))
@@ -175,6 +177,7 @@ async def test_proxy_tunneling_http2() -> None:
         assert proxy.connections[0].is_idle()
         assert proxy.connections[0].is_available()
         assert not proxy.connections[0].is_closed()
+        assert not proxy.connections[0].has_expired()
 
         # A connection on a tunneled proxy can only handle HTTPS requests to the same origin.
         assert not proxy.connections[0].can_handle_request(Origin(b"http", b"example.com", 80))

--- a/tests/httpcore2/_async/test_http_proxy.py
+++ b/tests/httpcore2/_async/test_http_proxy.py
@@ -53,6 +53,7 @@ async def test_proxy_forwarding() -> None:
         assert proxy.connections[0].is_available()
         assert not proxy.connections[0].is_closed()
         assert not proxy.connections[0].has_expired()
+        assert not proxy.connections[0].can_multiplex()
 
         # A connection on a forwarding proxy can only handle HTTP requests to the same origin.
         assert proxy.connections[0].can_handle_request(Origin(b"http", b"example.com", 80))
@@ -99,6 +100,7 @@ async def test_proxy_tunneling() -> None:
         assert proxy.connections[0].is_available()
         assert not proxy.connections[0].is_closed()
         assert not proxy.connections[0].has_expired()
+        assert not proxy.connections[0].can_multiplex()
 
         # A connection on a tunneled proxy can only handle HTTPS requests to the same origin.
         assert not proxy.connections[0].can_handle_request(Origin(b"http", b"example.com", 80))
@@ -178,6 +180,7 @@ async def test_proxy_tunneling_http2() -> None:
         assert proxy.connections[0].is_available()
         assert not proxy.connections[0].is_closed()
         assert not proxy.connections[0].has_expired()
+        assert proxy.connections[0].can_multiplex()
 
         # A connection on a tunneled proxy can only handle HTTPS requests to the same origin.
         assert not proxy.connections[0].can_handle_request(Origin(b"http", b"example.com", 80))

--- a/tests/httpcore2/_async/test_socks_proxy.py
+++ b/tests/httpcore2/_async/test_socks_proxy.py
@@ -41,6 +41,7 @@ async def test_socks5_request() -> None:
         assert proxy.connections[0].is_idle()
         assert proxy.connections[0].is_available()
         assert not proxy.connections[0].is_closed()
+        assert not proxy.connections[0].has_expired()
 
         # A connection on a tunneled proxy can only handle HTTPS requests to the same origin.
         assert not proxy.connections[0].can_handle_request(httpcore2.Origin(b"http", b"example.com", 80))
@@ -92,6 +93,7 @@ async def test_authenticated_socks5_request() -> None:
         assert proxy.connections[0].is_idle()
         assert proxy.connections[0].is_available()
         assert not proxy.connections[0].is_closed()
+        assert not proxy.connections[0].has_expired()
 
 
 @pytest.mark.anyio

--- a/tests/httpcore2/_async/test_socks_proxy.py
+++ b/tests/httpcore2/_async/test_socks_proxy.py
@@ -42,6 +42,7 @@ async def test_socks5_request() -> None:
         assert proxy.connections[0].is_available()
         assert not proxy.connections[0].is_closed()
         assert not proxy.connections[0].has_expired()
+        assert not proxy.connections[0].can_multiplex()
 
         # A connection on a tunneled proxy can only handle HTTPS requests to the same origin.
         assert not proxy.connections[0].can_handle_request(httpcore2.Origin(b"http", b"example.com", 80))
@@ -94,6 +95,7 @@ async def test_authenticated_socks5_request() -> None:
         assert proxy.connections[0].is_available()
         assert not proxy.connections[0].is_closed()
         assert not proxy.connections[0].has_expired()
+        assert not proxy.connections[0].can_multiplex()
 
 
 @pytest.mark.anyio

--- a/tests/httpcore2/_sync/test_connection_pool.py
+++ b/tests/httpcore2/_sync/test_connection_pool.py
@@ -1117,3 +1117,71 @@ def test_connection_pool_with_unhashable_connections() -> None:
             assert response.status == 200
         info = [repr(c) for c in pool.connections]
         assert info == ["<UnhashableConnection ['https://example.com:443', HTTP/1.1, IDLE, Request Count: 2]>"]
+
+
+
+def test_connection_pool_replaces_http2_connection_closed_while_held() -> None:
+    """
+    An HTTP/2 connection that closes while a response still holds it is
+    replaced immediately, rather than counting against `max_connections`
+    until that response is closed.
+    """
+    network_backend = httpcore2.MockBackend(buffer=http2_response_buffer(), http2=True)
+
+    with httpcore2.ConnectionPool(network_backend=network_backend, max_connections=1, http2=True) as pool:
+        with pool.stream("GET", "https://example.com/") as response:
+            pool.connections[0].close()
+
+            timeout = {"timeout": {"pool": 1.0}}
+            second = pool.request("GET", "https://example.com/", extensions=timeout)
+            assert second.status == 200
+            info = [repr(c) for c in pool.connections]
+            assert info == ["<HTTPConnection ['https://example.com:443', HTTP/2, IDLE, Request Count: 1]>"]
+
+        assert response.status == 200
+
+
+
+def test_connection_pool_stops_sharing_http11_connection_still_held_speculatively() -> None:
+    """
+    With HTTP/2 enabled, requests may be assigned to a connection before it
+    has negotiated a protocol. Once it turns out to be HTTP/1.1 and its first
+    request completes while another is still waiting to send on it, it must
+    not be handed to any further request.
+    """
+
+    class YieldingBackend(httpcore2.MockBackend):
+        def connect_tcp(
+            self,
+            host: str,
+            port: int,
+            timeout: float | None = None,
+            local_address: str | None = None,
+            socket_options: typing.Iterable[httpcore2.SOCKET_OPTION] | None = None,
+        ) -> httpcore2.NetworkStream:
+            # Let other requests be queued while this connection is being established.
+            concurrency.sleep(0)
+            return super().connect_tcp(host, port, timeout, local_address, socket_options)
+
+    network_backend = YieldingBackend(
+        [
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Type: plain/text\r\n",
+            b"Content-Length: 13\r\n",
+            b"\r\n",
+            b"Hello, world!",
+        ]
+        * 3
+    )
+
+    def fetch(pool: httpcore2.ConnectionPool) -> None:
+        response = pool.request("GET", "https://example.com/")
+        assert response.status == 200
+
+    with httpcore2.ConnectionPool(network_backend=network_backend, max_connections=1, http2=True) as pool:
+        with concurrency.open_nursery() as nursery:
+            for _ in range(3):
+                nursery.start_soon(fetch, pool)
+
+        info = [repr(c) for c in pool.connections]
+        assert info == ["<HTTPConnection ['https://example.com:443', HTTP/1.1, IDLE, Request Count: 3]>"]

--- a/tests/httpcore2/_sync/test_connection_pool.py
+++ b/tests/httpcore2/_sync/test_connection_pool.py
@@ -1064,3 +1064,56 @@ def test_connection_pool_closes_idle_http2_connection_for_different_origin() -> 
         assert response.status == 200
         info = [repr(c) for c in pool.connections]
         assert info == ["<HTTPConnection ['https://b.com:443', HTTP/2, IDLE, Request Count: 1]>"]
+
+
+
+def test_connection_pool_with_negative_keepalive_limit() -> None:
+    """
+    A negative `max_keepalive_connections` behaves like zero.
+    """
+    network_backend = httpcore2.MockBackend(
+        [
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Type: plain/text\r\n",
+            b"Content-Length: 13\r\n",
+            b"\r\n",
+            b"Hello, world!",
+        ]
+    )
+
+    with httpcore2.ConnectionPool(max_keepalive_connections=-1, network_backend=network_backend) as pool:
+        response = pool.request("GET", "https://example.com/")
+        assert response.status == 200
+        assert pool.connections == []
+
+
+
+def test_connection_pool_with_unhashable_connections() -> None:
+    """
+    Connections returned by an overridden `create_connection` need not be hashable.
+    """
+
+    class UnhashableConnection(httpcore2.HTTPConnection):
+        __hash__ = None  # type: ignore[assignment]
+
+    class CustomPool(httpcore2.ConnectionPool):
+        def create_connection(self, origin: httpcore2.Origin) -> httpcore2.ConnectionInterface:
+            return UnhashableConnection(origin=origin, network_backend=self._network_backend)
+
+    network_backend = httpcore2.MockBackend(
+        [
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Type: plain/text\r\n",
+            b"Content-Length: 13\r\n",
+            b"\r\n",
+            b"Hello, world!",
+        ]
+        * 2
+    )
+
+    with CustomPool(network_backend=network_backend) as pool:
+        for _ in range(2):
+            response = pool.request("GET", "https://example.com/")
+            assert response.status == 200
+        info = [repr(c) for c in pool.connections]
+        assert info == ["<UnhashableConnection ['https://example.com:443', HTTP/1.1, IDLE, Request Count: 2]>"]

--- a/tests/httpcore2/_sync/test_connection_pool.py
+++ b/tests/httpcore2/_sync/test_connection_pool.py
@@ -1032,3 +1032,35 @@ def test_connection_pool_discards_externally_closed_http2_connection() -> None:
         assert response.status == 200
         info = [repr(c) for c in pool.connections]
         assert info == ["<HTTPConnection ['https://example.com:443', HTTP/2, IDLE, Request Count: 1]>"]
+
+
+
+def test_connection_pool_keepalive_limit_applies_to_http2_connections() -> None:
+    """
+    Idle HTTP/2 connections count towards `max_keepalive_connections`.
+    """
+    network_backend = httpcore2.MockBackend(buffer=http2_response_buffer(), http2=True)
+
+    with httpcore2.ConnectionPool(network_backend=network_backend, max_keepalive_connections=0) as pool:
+        response = pool.request("GET", "https://example.com/")
+        assert response.status == 200
+        assert pool.connections == []
+
+
+
+def test_connection_pool_closes_idle_http2_connection_for_different_origin() -> None:
+    """
+    When the pool is full, an idle HTTP/2 connection to another origin is
+    closed to make room, just like an idle HTTP/1.1 connection.
+    """
+    network_backend = httpcore2.MockBackend(buffer=http2_response_buffer(), http2=True)
+
+    with httpcore2.ConnectionPool(network_backend=network_backend, max_connections=1) as pool:
+        pool.request("GET", "https://a.com/")
+        info = [repr(c) for c in pool.connections]
+        assert info == ["<HTTPConnection ['https://a.com:443', HTTP/2, IDLE, Request Count: 1]>"]
+
+        response = pool.request("GET", "https://b.com/")
+        assert response.status == 200
+        info = [repr(c) for c in pool.connections]
+        assert info == ["<HTTPConnection ['https://b.com:443', HTTP/2, IDLE, Request Count: 1]>"]

--- a/tests/httpcore2/_sync/test_connection_pool.py
+++ b/tests/httpcore2/_sync/test_connection_pool.py
@@ -1,6 +1,7 @@
 import logging
 import typing
 
+import anyio
 import hpack
 import hyperframe.frame
 import pytest
@@ -884,3 +885,150 @@ def test_connection_pool_multiplexes_idle_http2_connection_within_a_pass() -> No
                 nursery.start_soon(fetch, pool)
 
     assert QueueObservingPool.max_queued_after_pass == 0
+
+
+
+def test_connection_pool_discards_idle_connection_closed_by_server() -> None:
+    """
+    An idle connection that the server has closed is discarded when a request
+    would otherwise reuse it, and a new connection is opened instead.
+    """
+
+    class ServerClosingBackend(httpcore2.MockBackend):
+        server_closed = False
+
+        def connect_tcp(
+            self,
+            host: str,
+            port: int,
+            timeout: float | None = None,
+            local_address: str | None = None,
+            socket_options: typing.Iterable[httpcore2.SOCKET_OPTION] | None = None,
+        ) -> httpcore2.NetworkStream:
+            backend = self
+
+            class ServerClosingStream(httpcore2.MockStream):
+                def get_extra_info(self, info: str) -> typing.Any:
+                    # A readable idle socket means the server sent a FIN.
+                    if info == "is_readable":
+                        return backend.server_closed
+                    return super().get_extra_info(info)
+
+            return ServerClosingStream(list(self._buffer))
+
+    network_backend = ServerClosingBackend(
+        [
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Type: plain/text\r\n",
+            b"Content-Length: 13\r\n",
+            b"\r\n",
+            b"Hello, world!",
+        ]
+    )
+
+    with httpcore2.ConnectionPool(network_backend=network_backend) as pool:
+        response = pool.request("GET", "https://example.com/")
+        assert response.status == 200
+        info = [repr(c) for c in pool.connections]
+        assert info == ["<HTTPConnection ['https://example.com:443', HTTP/1.1, IDLE, Request Count: 1]>"]
+
+        network_backend.server_closed = True
+        response = pool.request("GET", "https://example.com/")
+        assert response.status == 200
+        info = [repr(c) for c in pool.connections]
+        assert info == ["<HTTPConnection ['https://example.com:443', HTTP/1.1, IDLE, Request Count: 1]>"]
+
+
+
+def test_connection_pool_expires_only_the_idle_connections_past_keepalive() -> None:
+    """
+    Once the oldest idle connection passes its keepalive expiry, it is closed
+    while younger idle connections are kept.
+    """
+    network_backend = httpcore2.MockBackend(
+        [
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Type: plain/text\r\n",
+            b"Content-Length: 13\r\n",
+            b"\r\n",
+            b"Hello, world!",
+        ]
+    )
+
+    with httpcore2.ConnectionPool(network_backend=network_backend, keepalive_expiry=0.4) as pool:
+        pool.request("GET", "https://a.com/")
+        concurrency.sleep(0.25)
+        pool.request("GET", "https://b.com/")
+        concurrency.sleep(0.25)
+
+        # The a.com connection has expired, the b.com connection has not.
+        pool.request("GET", "https://c.com/")
+        info = [repr(c) for c in pool.connections]
+        assert info == [
+            "<HTTPConnection ['https://b.com:443', HTTP/1.1, IDLE, Request Count: 1]>",
+            "<HTTPConnection ['https://c.com:443', HTTP/1.1, IDLE, Request Count: 1]>",
+        ]
+
+
+def http2_response_buffer(stream_id: int = 1) -> list[bytes]:
+    return [
+        hyperframe.frame.SettingsFrame().serialize(),
+        hyperframe.frame.HeadersFrame(
+            stream_id=stream_id,
+            data=hpack.Encoder().encode([(b":status", b"200")]),
+            flags=["END_HEADERS"],
+        ).serialize(),
+        hyperframe.frame.DataFrame(stream_id=stream_id, data=b"Hello, world!", flags=["END_STREAM"]).serialize(),
+    ]
+
+
+
+def test_connection_pool_expires_idle_http2_connections_past_keepalive() -> None:
+    """
+    Idle HTTP/2 connections are subject to the keepalive expiry too, with
+    younger idle connections kept.
+    """
+    network_backend = httpcore2.MockBackend(buffer=http2_response_buffer(), http2=True)
+
+    with httpcore2.ConnectionPool(network_backend=network_backend, keepalive_expiry=0.4) as pool:
+        pool.request("GET", "https://a.com/")
+        concurrency.sleep(0.25)
+        pool.request("GET", "https://b.com/")
+        info = [repr(c) for c in pool.connections]
+        assert info == [
+            "<HTTPConnection ['https://a.com:443', HTTP/2, IDLE, Request Count: 1]>",
+            "<HTTPConnection ['https://b.com:443', HTTP/2, IDLE, Request Count: 1]>",
+        ]
+        concurrency.sleep(0.25)
+
+        # The a.com connection has expired, the b.com connection has not.
+        pool.request("GET", "https://c.com/")
+        info = [repr(c) for c in pool.connections]
+        assert info == [
+            "<HTTPConnection ['https://b.com:443', HTTP/2, IDLE, Request Count: 1]>",
+            "<HTTPConnection ['https://c.com:443', HTTP/2, IDLE, Request Count: 1]>",
+        ]
+
+        # Left long enough, the remaining connections expire as well.
+        concurrency.sleep(0.5)
+        pool.request("GET", "https://a.com/")
+        info = [repr(c) for c in pool.connections]
+        assert info == ["<HTTPConnection ['https://a.com:443', HTTP/2, IDLE, Request Count: 1]>"]
+
+
+
+def test_connection_pool_discards_externally_closed_http2_connection() -> None:
+    """
+    An HTTP/2 connection closed outside of a request is discarded rather than
+    handed to the next request for that origin.
+    """
+    network_backend = httpcore2.MockBackend(buffer=http2_response_buffer(), http2=True)
+
+    with httpcore2.ConnectionPool(network_backend=network_backend) as pool:
+        pool.request("GET", "https://example.com/")
+        pool.connections[0].close()
+
+        response = pool.request("GET", "https://example.com/")
+        assert response.status == 200
+        info = [repr(c) for c in pool.connections]
+        assert info == ["<HTTPConnection ['https://example.com:443', HTTP/2, IDLE, Request Count: 1]>"]

--- a/tests/httpcore2/_sync/test_connection_pool.py
+++ b/tests/httpcore2/_sync/test_connection_pool.py
@@ -1,4 +1,5 @@
 import logging
+import time
 import typing
 
 import anyio
@@ -939,12 +940,33 @@ def test_connection_pool_discards_idle_connection_closed_by_server() -> None:
         assert info == ["<HTTPConnection ['https://example.com:443', HTTP/1.1, IDLE, Request Count: 1]>"]
 
 
+class FakeClock:
+    """
+    A monotonic clock the test can advance, so keepalive expiry
+    does not depend on real time.
+    """
 
-def test_connection_pool_expires_only_the_idle_connections_past_keepalive() -> None:
+    def __init__(self) -> None:
+        self._real = time.monotonic
+        self._offset = 0.0
+
+    def __call__(self) -> float:
+        return self._real() + self._offset
+
+    def advance(self, seconds: float) -> None:
+        self._offset += seconds
+
+
+
+def test_connection_pool_expires_only_the_idle_connections_past_keepalive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """
     Once the oldest idle connection passes its keepalive expiry, it is closed
     while younger idle connections are kept.
     """
+    clock = FakeClock()
+    monkeypatch.setattr(time, "monotonic", clock)
     network_backend = httpcore2.MockBackend(
         [
             b"HTTP/1.1 200 OK\r\n",
@@ -955,11 +977,11 @@ def test_connection_pool_expires_only_the_idle_connections_past_keepalive() -> N
         ]
     )
 
-    with httpcore2.ConnectionPool(network_backend=network_backend, keepalive_expiry=0.4) as pool:
+    with httpcore2.ConnectionPool(network_backend=network_backend, keepalive_expiry=10.0) as pool:
         pool.request("GET", "https://a.com/")
-        concurrency.sleep(0.25)
+        clock.advance(6.0)
         pool.request("GET", "https://b.com/")
-        concurrency.sleep(0.25)
+        clock.advance(6.0)
 
         # The a.com connection has expired, the b.com connection has not.
         pool.request("GET", "https://c.com/")
@@ -983,23 +1005,27 @@ def http2_response_buffer(stream_id: int = 1) -> list[bytes]:
 
 
 
-def test_connection_pool_expires_idle_http2_connections_past_keepalive() -> None:
+def test_connection_pool_expires_idle_http2_connections_past_keepalive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """
     Idle HTTP/2 connections are subject to the keepalive expiry too, with
     younger idle connections kept.
     """
+    clock = FakeClock()
+    monkeypatch.setattr(time, "monotonic", clock)
     network_backend = httpcore2.MockBackend(buffer=http2_response_buffer(), http2=True)
 
-    with httpcore2.ConnectionPool(network_backend=network_backend, keepalive_expiry=0.4) as pool:
+    with httpcore2.ConnectionPool(network_backend=network_backend, keepalive_expiry=10.0) as pool:
         pool.request("GET", "https://a.com/")
-        concurrency.sleep(0.25)
+        clock.advance(6.0)
         pool.request("GET", "https://b.com/")
         info = [repr(c) for c in pool.connections]
         assert info == [
             "<HTTPConnection ['https://a.com:443', HTTP/2, IDLE, Request Count: 1]>",
             "<HTTPConnection ['https://b.com:443', HTTP/2, IDLE, Request Count: 1]>",
         ]
-        concurrency.sleep(0.25)
+        clock.advance(6.0)
 
         # The a.com connection has expired, the b.com connection has not.
         pool.request("GET", "https://c.com/")
@@ -1010,7 +1036,7 @@ def test_connection_pool_expires_idle_http2_connections_past_keepalive() -> None
         ]
 
         # Left long enough, the remaining connections expire as well.
-        concurrency.sleep(0.5)
+        clock.advance(11.0)
         pool.request("GET", "https://a.com/")
         info = [repr(c) for c in pool.connections]
         assert info == ["<HTTPConnection ['https://a.com:443', HTTP/2, IDLE, Request Count: 1]>"]

--- a/tests/httpcore2/_sync/test_http_proxy.py
+++ b/tests/httpcore2/_sync/test_http_proxy.py
@@ -52,6 +52,7 @@ def test_proxy_forwarding() -> None:
         assert proxy.connections[0].is_idle()
         assert proxy.connections[0].is_available()
         assert not proxy.connections[0].is_closed()
+        assert not proxy.connections[0].has_expired()
 
         # A connection on a forwarding proxy can only handle HTTP requests to the same origin.
         assert proxy.connections[0].can_handle_request(Origin(b"http", b"example.com", 80))
@@ -97,6 +98,7 @@ def test_proxy_tunneling() -> None:
         assert proxy.connections[0].is_idle()
         assert proxy.connections[0].is_available()
         assert not proxy.connections[0].is_closed()
+        assert not proxy.connections[0].has_expired()
 
         # A connection on a tunneled proxy can only handle HTTPS requests to the same origin.
         assert not proxy.connections[0].can_handle_request(Origin(b"http", b"example.com", 80))
@@ -175,6 +177,7 @@ def test_proxy_tunneling_http2() -> None:
         assert proxy.connections[0].is_idle()
         assert proxy.connections[0].is_available()
         assert not proxy.connections[0].is_closed()
+        assert not proxy.connections[0].has_expired()
 
         # A connection on a tunneled proxy can only handle HTTPS requests to the same origin.
         assert not proxy.connections[0].can_handle_request(Origin(b"http", b"example.com", 80))

--- a/tests/httpcore2/_sync/test_http_proxy.py
+++ b/tests/httpcore2/_sync/test_http_proxy.py
@@ -53,6 +53,7 @@ def test_proxy_forwarding() -> None:
         assert proxy.connections[0].is_available()
         assert not proxy.connections[0].is_closed()
         assert not proxy.connections[0].has_expired()
+        assert not proxy.connections[0].can_multiplex()
 
         # A connection on a forwarding proxy can only handle HTTP requests to the same origin.
         assert proxy.connections[0].can_handle_request(Origin(b"http", b"example.com", 80))
@@ -99,6 +100,7 @@ def test_proxy_tunneling() -> None:
         assert proxy.connections[0].is_available()
         assert not proxy.connections[0].is_closed()
         assert not proxy.connections[0].has_expired()
+        assert not proxy.connections[0].can_multiplex()
 
         # A connection on a tunneled proxy can only handle HTTPS requests to the same origin.
         assert not proxy.connections[0].can_handle_request(Origin(b"http", b"example.com", 80))
@@ -178,6 +180,7 @@ def test_proxy_tunneling_http2() -> None:
         assert proxy.connections[0].is_available()
         assert not proxy.connections[0].is_closed()
         assert not proxy.connections[0].has_expired()
+        assert proxy.connections[0].can_multiplex()
 
         # A connection on a tunneled proxy can only handle HTTPS requests to the same origin.
         assert not proxy.connections[0].can_handle_request(Origin(b"http", b"example.com", 80))

--- a/tests/httpcore2/_sync/test_socks_proxy.py
+++ b/tests/httpcore2/_sync/test_socks_proxy.py
@@ -42,6 +42,7 @@ def test_socks5_request() -> None:
         assert proxy.connections[0].is_available()
         assert not proxy.connections[0].is_closed()
         assert not proxy.connections[0].has_expired()
+        assert not proxy.connections[0].can_multiplex()
 
         # A connection on a tunneled proxy can only handle HTTPS requests to the same origin.
         assert not proxy.connections[0].can_handle_request(httpcore2.Origin(b"http", b"example.com", 80))
@@ -94,6 +95,7 @@ def test_authenticated_socks5_request() -> None:
         assert proxy.connections[0].is_available()
         assert not proxy.connections[0].is_closed()
         assert not proxy.connections[0].has_expired()
+        assert not proxy.connections[0].can_multiplex()
 
 
 

--- a/tests/httpcore2/_sync/test_socks_proxy.py
+++ b/tests/httpcore2/_sync/test_socks_proxy.py
@@ -41,6 +41,7 @@ def test_socks5_request() -> None:
         assert proxy.connections[0].is_idle()
         assert proxy.connections[0].is_available()
         assert not proxy.connections[0].is_closed()
+        assert not proxy.connections[0].has_expired()
 
         # A connection on a tunneled proxy can only handle HTTPS requests to the same origin.
         assert not proxy.connections[0].can_handle_request(httpcore2.Origin(b"http", b"example.com", 80))
@@ -92,6 +93,7 @@ def test_authenticated_socks5_request() -> None:
         assert proxy.connections[0].is_idle()
         assert proxy.connections[0].is_available()
         assert not proxy.connections[0].is_closed()
+        assert not proxy.connections[0].has_expired()
 
 
 

--- a/tests/httpcore2/concurrency.py
+++ b/tests/httpcore2/concurrency.py
@@ -10,6 +10,7 @@ children, because we don't need that for our use-case.
 """
 
 import threading
+import time
 from collections.abc import Callable
 from types import TracebackType
 from typing import Any
@@ -40,3 +41,7 @@ class Nursery:
 
 def open_nursery() -> Nursery:
     return Nursery()
+
+
+def sleep(seconds: float) -> None:
+    time.sleep(seconds)

--- a/tests/httpcore2/test_synchronization.py
+++ b/tests/httpcore2/test_synchronization.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import threading
+
+import anyio
+import pytest
+
+from httpcore2 import PoolTimeout
+from httpcore2._synchronization import AsyncEvent, Event
+
+
+@pytest.mark.anyio
+async def test_async_event_set_before_wait() -> None:
+    event = AsyncEvent()
+    event.set()
+    await event.wait()
+
+
+@pytest.mark.anyio
+async def test_async_event_wait_then_set() -> None:
+    event = AsyncEvent()
+    waited = False
+
+    async def waiter() -> None:
+        nonlocal waited
+        await event.wait(timeout=5.0)
+        waited = True
+
+    async with anyio.create_task_group() as task_group:
+        task_group.start_soon(waiter)
+        await anyio.sleep(0)
+        event.set()
+
+    assert waited
+
+
+@pytest.mark.anyio
+async def test_async_event_wait_timeout() -> None:
+    event = AsyncEvent()
+    with pytest.raises(PoolTimeout):
+        await event.wait(timeout=0.01)
+
+
+def test_event_set_before_wait() -> None:
+    event = Event()
+    event.set()
+    event.wait()
+
+
+def test_event_wait_then_set() -> None:
+    event = Event()
+    thread = threading.Thread(target=event.set)
+    thread.start()
+    event.wait(timeout=5.0)
+    thread.join()
+
+
+def test_event_wait_timeout() -> None:
+    event = Event()
+    with pytest.raises(PoolTimeout):
+        event.wait(timeout=0.01)


### PR DESCRIPTION
# Summary

`AsyncConnectionPool._assign_requests_to_connections` ran on every enqueue and every release and walked every pooled connection each time (several delegated state queries per connection, plus a `poll()` on every idle socket via `has_expired()`), so per-request cost grew with the number of connections. With an unbounded pool at 512 concurrent requests, ~85% of client CPU was pool bookkeeping and throughput fell to a third of the c16 figure.

The pool now keeps its state incrementally and a pass is O(1) in the common case:

* Connections and in-flight requests live in insertion-ordered dicts; requests waiting for a connection are a FIFO `deque`.
* Idle HTTP/1.1 connections are indexed by origin, oldest first, which serves reuse, `max_keepalive_connections` eviction (longest idle first, as before) and the "close an idle connection to another origin when the pool is full" case.
* Sharable connections (HTTP/2, or not yet negotiated with `http2=True`) are kept per origin and checked with `is_available()` on lookup, so a burst against a warm HTTP/2 connection is still multiplexed within one pass.
* Reservations are refcounted per connection (the idea from #1076), and a pass re-examines only the connections released since the previous pass.
* A server-closed idle socket is detected when the connection is about to be reused (one probe per reuse) instead of probing every idle socket on every pass; keepalive expiry is swept only once the oldest idle connection may have expired.
* `Origin` gets a `__hash__` consistent with its `__eq__`, and `AsyncPoolRequest` creates its wakeup event only when it actually has to wait (the common path assigns before waiting, so no `anyio.Event` and no `sniffio` call per request).

`_assign_requests_to_connections` keeps its name and cadence (once per enqueue, once per release), so the existing pass-counting tests hold. #1076 becomes redundant with this change.

# Benchmarks

`scripts/benchmark --lib httpx2 --python main=... --python pool=...`, CPython 3.14 + zuvloop, 2 vCPU, interleaved rounds (medians):

| scenario | main | this PR |
|---|---|---|
| c1/1k | 798 rps · 391 us/req | 817 rps · 371 us/req |
| c16/1k | 2,619 rps · 299 us/req | 3,104 rps · 251 us/req |
| c128/1k | 2,037 rps · p99 90 ms · 426 us/req | 3,494 rps · p99 59 ms · 248 us/req |
| c512/1k | 787 rps · p99 1152 ms · 1058 us/req | 3,267 rps · p99 218 ms · 263 us/req |
| c64/100k | 2,023 rps · 412 us/req | 2,695 rps · 317 us/req |
| c64/1k POST | 2,266 rps · 379 us/req | 2,974 rps · 287 us/req |
| c8/5m, c8/1m POST | unchanged (body-bound) | unchanged |

Retention (rps at c512 over rps at c16) goes from 30% to 105%; per-request CPU is now flat across concurrency. Measured on the final state of the branch, after the review changes.

# Tests

New tests cover: an idle connection closed by the server is discarded on reuse; staggered keepalive expiry keeps younger idle connections (HTTP/1.1 and HTTP/2); an externally closed HTTP/2 connection is discarded; and the `AsyncEvent`/`Event` primitives directly, since the pool no longer exercises every branch on each request. The async tests use `anyio.sleep`, mapped to a threaded `concurrency.sleep` by unasync.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


