### PR TITLE
Support streaming in ASGITransport

### DIFF
--- a/src/httpx2/httpx2/_transports/asgi.py
+++ b/src/httpx2/httpx2/_transports/asgi.py
@@ -1,18 +1,14 @@
 from __future__ import annotations
 
 import typing
+from types import TracebackType
+
+import anyio
+import anyio.streams.memory
 
 from .._models import Request, Response
 from .._types import AsyncByteStream
 from .base import AsyncBaseTransport
-
-if typing.TYPE_CHECKING:
-    import asyncio
-
-    import trio
-
-    Event = asyncio.Event | trio.Event
-
 
 _Message = typing.MutableMapping[str, typing.Any]
 _Receive = typing.Callable[[], typing.Awaitable[_Message]]
@@ -22,38 +18,25 @@ _ASGIApp = typing.Callable[[typing.MutableMapping[str, typing.Any], _Receive, _S
 __all__ = ["ASGITransport"]
 
 
-def is_running_trio() -> bool:
-    try:
-        # sniffio is a dependency of trio.
-
-        # See https://github.com/python-trio/trio/issues/2802
-        import sniffio
-
-        if sniffio.current_async_library() == "trio":
-            return True
-    except ImportError:  # pragma: no cover
-        pass
-
-    return False
-
-
-def create_event() -> Event:
-    if is_running_trio():
-        import trio
-
-        return trio.Event()
-
-    import asyncio
-
-    return asyncio.Event()
-
-
 class ASGIResponseStream(AsyncByteStream):
-    def __init__(self, body: list[bytes]) -> None:
-        self._body = body
+    def __init__(self, body_parts_stream: anyio.streams.memory.MemoryObjectReceiveStream) -> None:
+        self._body_parts = body_parts_stream
 
     async def __aiter__(self) -> typing.AsyncIterator[bytes]:
-        yield b"".join(self._body)
+        async for part in self._body_parts:
+            if isinstance(part, bytes):
+                yield part
+            elif isinstance(part, Exception):
+                raise part
+            else:
+                raise TypeError(part)
+        self._body_parts.close()
+
+    async def aclose(self):
+        self._body_parts.close()
+
+    def __del__(self):
+        self._body_parts.close()
 
 
 class ASGITransport(AsyncBaseTransport):
@@ -89,6 +72,30 @@ class ASGITransport(AsyncBaseTransport):
         self.raise_app_exceptions = raise_app_exceptions
         self.root_path = root_path
         self.client = client
+        self.__task_group = None
+
+    async def __aenter__(self):
+        self.__task_group = anyio.create_task_group()
+        await self.__task_group.__aenter__()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None = None,
+        exc_value: BaseException | None = None,
+        traceback: TracebackType | None = None,
+    ) -> None:
+        if self.__task_group is not None:
+            self.__task_group.cancel_scope.cancel()
+            await self.__task_group.__aexit__(exc_type, exc_value, traceback)
+            self.__task_group = None
+        return await super().__aexit__(exc_type, exc_value, traceback)
+
+    async def aclose(self):
+        if self.__task_group is not None:
+            self.__task_group.cancel_scope.cancel()
+            await self.__task_group.__aexit__(None, None, None)
+            self.__task_group = None
 
     async def handle_async_request(self, request: Request) -> Response:
         assert isinstance(request.stream, AsyncByteStream)
@@ -116,9 +123,10 @@ class ASGITransport(AsyncBaseTransport):
         # Response.
         status_code = None
         response_headers = None
-        body_parts: list[bytes] = []
-        response_started = False
-        response_complete = create_event()
+        body_send, body_receive = anyio.create_memory_object_stream[bytes|Exception](16)
+        response_started = anyio.Event()
+        response_complete = anyio.Event()
+        app_exception = None
 
         # ASGI callables.
 
@@ -137,14 +145,14 @@ class ASGITransport(AsyncBaseTransport):
             return {"type": "http.request", "body": body, "more_body": True}
 
         async def send(message: typing.MutableMapping[str, typing.Any]) -> None:
-            nonlocal status_code, response_headers, response_started
+            nonlocal status_code, response_headers
 
             if message["type"] == "http.response.start":
-                assert not response_started
+                assert not response_started.is_set()
 
                 status_code = message["status"]
                 response_headers = message.get("headers", [])
-                response_started = True
+                response_started.set()
 
             elif message["type"] == "http.response.body":
                 assert not response_complete.is_set()
@@ -152,27 +160,40 @@ class ASGITransport(AsyncBaseTransport):
                 more_body = message.get("more_body", False)
 
                 if body and request.method != "HEAD":
-                    body_parts.append(body)
+                    await body_send.send(body)
 
                 if not more_body:
                     response_complete.set()
 
-        try:
-            await self.app(scope, receive, send)
-        except Exception:
-            if self.raise_app_exceptions:
-                raise
+        async def app_wrapper():
+            nonlocal app_exception, status_code, response_headers
+            try:
+                await self.app(scope, receive, send)
+            except Exception as exc:
+                if status_code is None:
+                    status_code = 500
+                if response_headers is None:
+                    response_headers = {}
+                if self.raise_app_exceptions:
+                    await body_send.send(exc)
+                    app_exception = exc
+                response_started.set()
+                response_complete.set()
+            finally:
+                body_send.close()
 
-            response_complete.set()
-            if status_code is None:
-                status_code = 500
-            if response_headers is None:
-                response_headers = {}
+        if self.__task_group is None:
+            raise RuntimeError("ASGITransport.__aenter__ not called")
+        self.__task_group.start_soon(app_wrapper)
+        await response_started.wait()
 
-        assert response_complete.is_set()
         assert status_code is not None
         assert response_headers is not None
 
-        stream = ASGIResponseStream(body_parts)
+        if app_exception is not None:
+            body_receive.close()
+            raise app_exception
+
+        stream = ASGIResponseStream(body_receive)
 
         return Response(status_code, headers=response_headers, stream=stream)

--- a/src/httpx2/httpx2/_transports/asgi.py
+++ b/src/httpx2/httpx2/_transports/asgi.py
@@ -126,7 +126,7 @@ class ASGITransport(AsyncBaseTransport):
         # Response.
         status_code = None
         response_headers = None
-        body_send, body_receive = anyio.create_memory_object_stream[bytes|Exception](16)
+        body_send, body_receive = anyio.create_memory_object_stream[bytes | Exception](16)
         response_started = anyio.Event()
         response_complete = anyio.Event()
         app_exception = None

--- a/src/httpx2/httpx2/_transports/asgi.py
+++ b/src/httpx2/httpx2/_transports/asgi.py
@@ -5,6 +5,7 @@ import typing
 from types import TracebackType
 
 import anyio
+import anyio.abc
 import anyio.streams.memory
 
 from .._models import Request, Response
@@ -20,7 +21,7 @@ __all__ = ["ASGITransport"]
 
 
 class ASGIResponseStream(AsyncByteStream):
-    def __init__(self, body_parts_stream: anyio.streams.memory.MemoryObjectReceiveStream) -> None:
+    def __init__(self, body_parts_stream: anyio.streams.memory.MemoryObjectReceiveStream[bytes | Exception]) -> None:
         self._body_parts = body_parts_stream
 
     async def __aiter__(self) -> typing.AsyncIterator[bytes]:
@@ -33,10 +34,10 @@ class ASGIResponseStream(AsyncByteStream):
                 raise TypeError(part)
         self._body_parts.close()
 
-    async def aclose(self):
+    async def aclose(self) -> None:
         self._body_parts.close()
 
-    def __del__(self):
+    def __del__(self) -> None:
         self._body_parts.close()
 
 
@@ -73,10 +74,10 @@ class ASGITransport(AsyncBaseTransport):
         self.raise_app_exceptions = raise_app_exceptions
         self.root_path = root_path
         self.client = client
-        self._task_group = None
-        self._exit_stack = None
+        self._task_group: anyio.abc.TaskGroup | None = None
+        self._exit_stack: contextlib.AsyncExitStack | None = None
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> ASGITransport:
         await super().__aenter__()
 
         async with contextlib.AsyncExitStack() as stack:
@@ -168,7 +169,7 @@ class ASGITransport(AsyncBaseTransport):
                 if not more_body:
                     response_complete.set()
 
-        async def app_wrapper():
+        async def app_wrapper() -> None:
             nonlocal app_exception, status_code, response_headers
             try:
                 await self.app(scope, receive, send)

--- a/src/httpx2/httpx2/_transports/asgi.py
+++ b/src/httpx2/httpx2/_transports/asgi.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import typing
 from types import TracebackType
 
@@ -72,30 +73,32 @@ class ASGITransport(AsyncBaseTransport):
         self.raise_app_exceptions = raise_app_exceptions
         self.root_path = root_path
         self.client = client
-        self.__task_group = None
+        self._task_group = None
+        self._exit_stack = None
 
     async def __aenter__(self):
-        self.__task_group = anyio.create_task_group()
-        await self.__task_group.__aenter__()
+        await super().__aenter__()
+
+        async with contextlib.AsyncExitStack() as stack:
+            self._task_group = await stack.enter_async_context(anyio.create_task_group())
+            # Make sure all remaining tasks are cancelled after normal cleanup
+            stack.callback(self._task_group.cancel_scope.cancel)
+            self._exit_stack = stack.pop_all()
+
         return self
 
     async def __aexit__(
         self,
         exc_type: type[BaseException] | None = None,
-        exc_value: BaseException | None = None,
-        traceback: TracebackType | None = None,
+        exc_val: BaseException | None = None,
+        exc_tb: TracebackType | None = None,
     ) -> None:
-        if self.__task_group is not None:
-            self.__task_group.cancel_scope.cancel()
-            await self.__task_group.__aexit__(exc_type, exc_value, traceback)
-            self.__task_group = None
-        return await super().__aexit__(exc_type, exc_value, traceback)
+        if self._exit_stack is not None:
+            await self._exit_stack.__aexit__(exc_type, exc_val, exc_tb)
+            self._task_group = None
+            self._exit_stack = None
 
-    async def aclose(self):
-        if self.__task_group is not None:
-            self.__task_group.cancel_scope.cancel()
-            await self.__task_group.__aexit__(None, None, None)
-            self.__task_group = None
+        await super().__aexit__(exc_type, exc_val, exc_tb)
 
     async def handle_async_request(self, request: Request) -> Response:
         assert isinstance(request.stream, AsyncByteStream)
@@ -182,9 +185,9 @@ class ASGITransport(AsyncBaseTransport):
             finally:
                 body_send.close()
 
-        if self.__task_group is None:
+        if self._task_group is None:
             raise RuntimeError("ASGITransport.__aenter__ not called")
-        self.__task_group.start_soon(app_wrapper)
+        self._task_group.start_soon(app_wrapper)
         await response_started.wait()
 
         assert status_code is not None

--- a/src/httpx2/httpx2/_transports/asgi.py
+++ b/src/httpx2/httpx2/_transports/asgi.py
@@ -30,8 +30,6 @@ class ASGIResponseStream(AsyncByteStream):
                 yield part
             elif isinstance(part, Exception):
                 raise part
-            else:
-                raise TypeError(part)
         self._body_parts.close()
 
     async def aclose(self) -> None:
@@ -186,8 +184,7 @@ class ASGITransport(AsyncBaseTransport):
             finally:
                 body_send.close()
 
-        if self._task_group is None:
-            raise RuntimeError("ASGITransport.__aenter__ not called")
+        assert self._task_group is not None
         self._task_group.start_soon(app_wrapper)
         await response_started.wait()
 

--- a/src/httpx2/httpx2/websockets/_transport.py
+++ b/src/httpx2/httpx2/websockets/_transport.py
@@ -207,7 +207,7 @@ class ASGIWebSocketTransport(ASGITransport):
             self._task_group = await stack.enter_async_context(anyio.create_task_group())
             self._exit_stack = stack.pop_all()
 
-        return self
+        return await super().__aenter__()
 
     async def __aexit__(
         self,

--- a/src/httpx2/httpx2/websockets/_transport.py
+++ b/src/httpx2/httpx2/websockets/_transport.py
@@ -199,25 +199,7 @@ class ASGIWebSocketTransport(ASGITransport):
         initial_receive_timeout: float = 1.0,
     ) -> None:
         super().__init__(app, raise_app_exceptions, root_path, client)
-        self._exit_stack: contextlib.AsyncExitStack | None = None
         self._initial_receive_timeout = initial_receive_timeout
-
-    async def __aenter__(self) -> ASGIWebSocketTransport:
-        async with contextlib.AsyncExitStack() as stack:
-            self._task_group = await stack.enter_async_context(anyio.create_task_group())
-            self._exit_stack = stack.pop_all()
-
-        return await super().__aenter__()
-
-    async def __aexit__(
-        self,
-        exc_type: type[BaseException] | None = None,
-        exc_val: BaseException | None = None,
-        exc_tb: TracebackType | None = None,
-    ) -> None:
-        await super().__aexit__(exc_type, exc_val, exc_tb)
-        assert self._exit_stack is not None
-        await self._exit_stack.__aexit__(exc_type, exc_val, exc_tb)
 
     async def handle_async_request(self, request: Request) -> Response:
         scheme = request.url.scheme

--- a/src/httpx2/httpx2/websockets/_transport.py
+++ b/src/httpx2/httpx2/websockets/_transport.py
@@ -231,6 +231,7 @@ class ASGIWebSocketTransport(ASGITransport):
         *,
         task_status: anyio.abc.TaskStatus[tuple[ASGIWebSocketAsyncNetworkStream, bytes]],
     ) -> None:
+        assert self._task_group is not None
         stream = ASGIWebSocketAsyncNetworkStream(
             self.app,  # type: ignore[arg-type]
             self.scope,
@@ -249,6 +250,7 @@ class ASGIWebSocketTransport(ASGITransport):
         assert isinstance(request.stream, AsyncByteStream)
 
         self.scope = scope
+        assert self._task_group is not None
         stream, accept_response = await self._task_group.start(self._create_asgi_websocket_async_network_stream)
         accept_response_lines = accept_response.decode("utf-8").splitlines()
         headers = [

--- a/tests/httpx2/test_asgi.py
+++ b/tests/httpx2/test_asgi.py
@@ -72,7 +72,6 @@ async def streaming_hello_world(scope: Scope, receive: Receive, send: Send) -> N
         await anyio.sleep(1.0)
 
 
-
 async def raise_exc(scope: Scope, receive: Receive, send: Send) -> None:
     raise RuntimeError()
 
@@ -240,7 +239,7 @@ async def test_asgi_exc_no_raise() -> None:
 
 
 @pytest.mark.anyio
-@pytest.mark.filterwarnings('ignore::ResourceWarning')
+@pytest.mark.filterwarnings("ignore::ResourceWarning")
 async def test_asgi_streaming() -> None:
     async with httpx2.ASGITransport(app=streaming_hello_world) as transport:
         request = httpx2.Request("GET", "http://www.example.com/")

--- a/tests/httpx2/test_asgi.py
+++ b/tests/httpx2/test_asgi.py
@@ -1,6 +1,7 @@
 import json
 import typing
 
+import anyio
 import pytest
 
 import httpx2
@@ -58,6 +59,18 @@ async def echo_headers(scope: Scope, receive: Receive, send: Send) -> None:
 
     await send({"type": "http.response.start", "status": status, "headers": headers})
     await send({"type": "http.response.body", "body": output})
+
+
+async def streaming_hello_world(scope: Scope, receive: Receive, send: Send) -> None:
+    status = 200
+    output = b"Hello, World!\r\n"
+    headers = [(b"content-type", "text/plain"), (b"content-length", str(len(output)))]
+
+    await send({"type": "http.response.start", "status": status, "headers": headers})
+    while True:
+        await send({"type": "http.response.body", "body": output, "more_body": True})
+        await anyio.sleep(1.0)
+
 
 
 async def raise_exc(scope: Scope, receive: Receive, send: Send) -> None:
@@ -224,3 +237,17 @@ async def test_asgi_exc_no_raise() -> None:
         response = await client.get("http://www.example.org/")
 
         assert response.status_code == 500
+
+
+@pytest.mark.anyio
+@pytest.mark.filterwarnings('ignore::ResourceWarning')
+async def test_asgi_streaming() -> None:
+    async with httpx2.ASGITransport(app=streaming_hello_world) as transport:
+        request = httpx2.Request("GET", "http://www.example.com/")
+
+        with anyio.fail_after(0.5):
+            response = await transport.handle_async_request(request)
+            lines = response.aiter_lines()
+            assert response.status_code == 200
+            first_line = await anext(lines)
+            assert first_line == "Hello, World!"


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX2! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

This changes ASGITransport to support streaming responses, so you can use ASGITransport to test things like SSE. 

I wrote this without realizing that PR #1032 by @Kludex, which aims to achieve the same thing, exists. The basic idea is the same: run the app in a separate task.

The reason I'm opening this PR in competition with #1032 is that currently, #1032 breaks some websocket tests (after merging main)

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.

→ IMHO this doesn't need to be mentioned explicitly anywhere as it just implements the intuitive and expected behaviour for an ASGITransport. It doesn't contradict anything in the current docs that I can see. I could of course add a note to the docs like #1032 if this is deemed necessary.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

