### PR TITLE
Forward `uds`, `local_address` and `retries` to proxied connections

### DIFF
--- a/docs/advanced/transports.md
+++ b/docs/advanced/transports.md
@@ -35,6 +35,11 @@ connecting via a Unix Domain Socket that is only available via this low-level AP
 {"ID": "...", "Containers": 4, "Images": 74, ...}
 ```
 
+These options also apply when the transport is configured with a `proxy`, in
+which case they affect how the connection to the proxy server is established.
+For SOCKS proxies only `retries` is supported; `uds`, `local_address` and
+`socket_options` are not available.
+
 ## WSGI Transport
 
 You can configure an `httpx2` client to call directly into a Python web application using the WSGI protocol.

--- a/src/httpcore2/CHANGELOG.md
+++ b/src/httpcore2/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Fixed
+
+* Honor `retries`, `local_address` and `uds` when connecting via an HTTP proxy, and `retries` when connecting via a SOCKS proxy. Previously these options were accepted but silently ignored for proxied connections, both on `ConnectionPool(proxy=...)` and on the `HTTPProxy` and `SOCKSProxy` pools.
+  ([#1160](https://github.com/pydantic/httpx2/discussions/1160))
+
 ## 2.12.0 (August 18th, 2026)
 
 No changes since `2.11.0`. Version bumped to stay in lockstep with `httpx2`.

--- a/src/httpcore2/httpcore2/_async/connection_pool.py
+++ b/src/httpcore2/httpcore2/_async/connection_pool.py
@@ -130,6 +130,7 @@ class AsyncConnectionPool(AsyncRequestInterface):
                     keepalive_expiry=self._keepalive_expiry,
                     http1=self._http1,
                     http2=self._http2,
+                    retries=self._retries,
                     network_backend=self._network_backend,
                 )
             elif origin.scheme == b"http":
@@ -141,7 +142,11 @@ class AsyncConnectionPool(AsyncRequestInterface):
                     proxy_ssl_context=self._proxy.ssl_context,
                     remote_origin=origin,
                     keepalive_expiry=self._keepalive_expiry,
+                    retries=self._retries,
+                    local_address=self._local_address,
+                    uds=self._uds,
                     network_backend=self._network_backend,
+                    socket_options=self._socket_options,
                 )
             from .http_proxy import AsyncTunnelHTTPConnection
 
@@ -154,7 +159,11 @@ class AsyncConnectionPool(AsyncRequestInterface):
                 keepalive_expiry=self._keepalive_expiry,
                 http1=self._http1,
                 http2=self._http2,
+                retries=self._retries,
+                local_address=self._local_address,
+                uds=self._uds,
                 network_backend=self._network_backend,
+                socket_options=self._socket_options,
             )
 
         return AsyncHTTPConnection(

--- a/src/httpcore2/httpcore2/_async/http_proxy.py
+++ b/src/httpcore2/httpcore2/_async/http_proxy.py
@@ -140,7 +140,11 @@ class AsyncHTTPProxy(AsyncConnectionPool):  # pragma: no cover
                 proxy_headers=self._proxy_headers,
                 remote_origin=origin,
                 keepalive_expiry=self._keepalive_expiry,
+                retries=self._retries,
+                local_address=self._local_address,
+                uds=self._uds,
                 network_backend=self._network_backend,
+                socket_options=self._socket_options,
                 proxy_ssl_context=self._proxy_ssl_context,
             )
         return AsyncTunnelHTTPConnection(
@@ -152,7 +156,11 @@ class AsyncHTTPProxy(AsyncConnectionPool):  # pragma: no cover
             keepalive_expiry=self._keepalive_expiry,
             http1=self._http1,
             http2=self._http2,
+            retries=self._retries,
+            local_address=self._local_address,
+            uds=self._uds,
             network_backend=self._network_backend,
+            socket_options=self._socket_options,
         )
 
 
@@ -163,6 +171,9 @@ class AsyncForwardHTTPConnection(AsyncConnectionInterface):
         remote_origin: Origin,
         proxy_headers: HeadersAsMapping | HeadersAsSequence | None = None,
         keepalive_expiry: float | None = None,
+        retries: int = 0,
+        local_address: str | None = None,
+        uds: str | None = None,
         network_backend: AsyncNetworkBackend | None = None,
         socket_options: typing.Iterable[SOCKET_OPTION] | None = None,
         proxy_ssl_context: ssl.SSLContext | None = None,
@@ -170,6 +181,9 @@ class AsyncForwardHTTPConnection(AsyncConnectionInterface):
         self._connection = AsyncHTTPConnection(
             origin=proxy_origin,
             keepalive_expiry=keepalive_expiry,
+            retries=retries,
+            local_address=local_address,
+            uds=uds,
             network_backend=network_backend,
             socket_options=socket_options,
             ssl_context=proxy_ssl_context,
@@ -234,12 +248,18 @@ class AsyncTunnelHTTPConnection(AsyncConnectionInterface):
         keepalive_expiry: float | None = None,
         http1: bool = True,
         http2: bool = False,
+        retries: int = 0,
+        local_address: str | None = None,
+        uds: str | None = None,
         network_backend: AsyncNetworkBackend | None = None,
         socket_options: typing.Iterable[SOCKET_OPTION] | None = None,
     ) -> None:
         self._connection: AsyncConnectionInterface = AsyncHTTPConnection(
             origin=proxy_origin,
             keepalive_expiry=keepalive_expiry,
+            retries=retries,
+            local_address=local_address,
+            uds=uds,
             network_backend=network_backend,
             socket_options=socket_options,
             ssl_context=proxy_ssl_context,

--- a/src/httpcore2/httpcore2/_async/socks_proxy.py
+++ b/src/httpcore2/httpcore2/_async/socks_proxy.py
@@ -2,16 +2,18 @@ from __future__ import annotations
 
 import logging
 import ssl
+import typing
 
 import socksio
 
 from .._backends.auto import AutoBackend
 from .._backends.base import AsyncNetworkBackend, AsyncNetworkStream
-from .._exceptions import ConnectionNotAvailable, ProxyError
+from .._exceptions import ConnectError, ConnectionNotAvailable, ConnectTimeout, ProxyError
 from .._models import URL, Origin, Request, Response, enforce_bytes, enforce_url
 from .._ssl import default_ssl_context
 from .._synchronization import AsyncLock
 from .._trace import Trace
+from .connection import RETRIES_BACKOFF_FACTOR, exponential_backoff
 from .connection_pool import AsyncConnectionPool
 from .http11 import AsyncHTTP11Connection
 from .interfaces import AsyncConnectionInterface
@@ -139,13 +141,7 @@ class AsyncSOCKSProxy(AsyncConnectionPool):  # pragma: no cover
             http2: A boolean indicating if HTTP/2 requests should be supported by
                 the connection pool. Defaults to False.
             retries: The maximum number of retries when trying to establish
-                a connection.
-            local_address: Local address to connect from. Can also be used to
-                connect using a particular address family. Using
-                `local_address="0.0.0.0"` will connect using an `AF_INET` address
-                (IPv4), while using `local_address="::"` will connect using an
-                `AF_INET6` address (IPv6).
-            uds: Path to a Unix Domain Socket to use instead of TCP sockets.
+                a connection to the proxy server.
             network_backend: A backend instance to use for handling network I/O.
         """
         super().__init__(
@@ -180,6 +176,7 @@ class AsyncSOCKSProxy(AsyncConnectionPool):  # pragma: no cover
             keepalive_expiry=self._keepalive_expiry,
             http1=self._http1,
             http2=self._http2,
+            retries=self._retries,
             network_backend=self._network_backend,
         )
 
@@ -194,6 +191,7 @@ class AsyncSocks5Connection(AsyncConnectionInterface):
         keepalive_expiry: float | None = None,
         http1: bool = True,
         http2: bool = False,
+        retries: int = 0,
         network_backend: AsyncNetworkBackend | None = None,
     ) -> None:
         self._proxy_origin = proxy_origin
@@ -203,6 +201,7 @@ class AsyncSocks5Connection(AsyncConnectionInterface):
         self._keepalive_expiry = keepalive_expiry
         self._http1 = http1
         self._http2 = http2
+        self._retries = retries
 
         self._network_backend: AsyncNetworkBackend = AutoBackend() if network_backend is None else network_backend
         self._connect_lock = AsyncLock()
@@ -218,14 +217,7 @@ class AsyncSocks5Connection(AsyncConnectionInterface):
             if self._connection is None:
                 try:
                     # Connect to the proxy
-                    kwargs = {
-                        "host": self._proxy_origin.host.decode("ascii"),
-                        "port": self._proxy_origin.port,
-                        "timeout": timeout,
-                    }
-                    async with Trace("connect_tcp", logger, request, kwargs) as trace:
-                        stream = await self._network_backend.connect_tcp(**kwargs)
-                        trace.return_value = stream
+                    stream = await self._connect_to_proxy(request, timeout)
 
                     # Connect to the remote host using socks5
                     kwargs = {
@@ -280,6 +272,29 @@ class AsyncSocks5Connection(AsyncConnectionInterface):
                 raise ConnectionNotAvailable()
 
         return await self._connection.handle_async_request(request)
+
+    async def _connect_to_proxy(self, request: Request, timeout: float | None) -> AsyncNetworkStream:
+        retries_left = self._retries
+        delays = exponential_backoff(factor=RETRIES_BACKOFF_FACTOR)
+
+        while True:
+            kwargs: dict[str, typing.Any] = {
+                "host": self._proxy_origin.host.decode("ascii"),
+                "port": self._proxy_origin.port,
+                "timeout": timeout,
+            }
+            try:
+                async with Trace("connect_tcp", logger, request, kwargs) as trace:
+                    stream = await self._network_backend.connect_tcp(**kwargs)
+                    trace.return_value = stream
+                return stream
+            except (ConnectError, ConnectTimeout):
+                if retries_left <= 0:
+                    raise
+                retries_left -= 1
+                delay = next(delays)
+                async with Trace("retry", logger, request, kwargs) as trace:
+                    await self._network_backend.sleep(delay)
 
     def can_handle_request(self, origin: Origin) -> bool:
         return origin == self._remote_origin

--- a/src/httpcore2/httpcore2/_sync/connection_pool.py
+++ b/src/httpcore2/httpcore2/_sync/connection_pool.py
@@ -130,6 +130,7 @@ class ConnectionPool(RequestInterface):
                     keepalive_expiry=self._keepalive_expiry,
                     http1=self._http1,
                     http2=self._http2,
+                    retries=self._retries,
                     network_backend=self._network_backend,
                 )
             elif origin.scheme == b"http":
@@ -141,7 +142,11 @@ class ConnectionPool(RequestInterface):
                     proxy_ssl_context=self._proxy.ssl_context,
                     remote_origin=origin,
                     keepalive_expiry=self._keepalive_expiry,
+                    retries=self._retries,
+                    local_address=self._local_address,
+                    uds=self._uds,
                     network_backend=self._network_backend,
+                    socket_options=self._socket_options,
                 )
             from .http_proxy import TunnelHTTPConnection
 
@@ -154,7 +159,11 @@ class ConnectionPool(RequestInterface):
                 keepalive_expiry=self._keepalive_expiry,
                 http1=self._http1,
                 http2=self._http2,
+                retries=self._retries,
+                local_address=self._local_address,
+                uds=self._uds,
                 network_backend=self._network_backend,
+                socket_options=self._socket_options,
             )
 
         return HTTPConnection(

--- a/src/httpcore2/httpcore2/_sync/http_proxy.py
+++ b/src/httpcore2/httpcore2/_sync/http_proxy.py
@@ -140,7 +140,11 @@ class HTTPProxy(ConnectionPool):  # pragma: no cover
                 proxy_headers=self._proxy_headers,
                 remote_origin=origin,
                 keepalive_expiry=self._keepalive_expiry,
+                retries=self._retries,
+                local_address=self._local_address,
+                uds=self._uds,
                 network_backend=self._network_backend,
+                socket_options=self._socket_options,
                 proxy_ssl_context=self._proxy_ssl_context,
             )
         return TunnelHTTPConnection(
@@ -152,7 +156,11 @@ class HTTPProxy(ConnectionPool):  # pragma: no cover
             keepalive_expiry=self._keepalive_expiry,
             http1=self._http1,
             http2=self._http2,
+            retries=self._retries,
+            local_address=self._local_address,
+            uds=self._uds,
             network_backend=self._network_backend,
+            socket_options=self._socket_options,
         )
 
 
@@ -163,6 +171,9 @@ class ForwardHTTPConnection(ConnectionInterface):
         remote_origin: Origin,
         proxy_headers: HeadersAsMapping | HeadersAsSequence | None = None,
         keepalive_expiry: float | None = None,
+        retries: int = 0,
+        local_address: str | None = None,
+        uds: str | None = None,
         network_backend: NetworkBackend | None = None,
         socket_options: typing.Iterable[SOCKET_OPTION] | None = None,
         proxy_ssl_context: ssl.SSLContext | None = None,
@@ -170,6 +181,9 @@ class ForwardHTTPConnection(ConnectionInterface):
         self._connection = HTTPConnection(
             origin=proxy_origin,
             keepalive_expiry=keepalive_expiry,
+            retries=retries,
+            local_address=local_address,
+            uds=uds,
             network_backend=network_backend,
             socket_options=socket_options,
             ssl_context=proxy_ssl_context,
@@ -234,12 +248,18 @@ class TunnelHTTPConnection(ConnectionInterface):
         keepalive_expiry: float | None = None,
         http1: bool = True,
         http2: bool = False,
+        retries: int = 0,
+        local_address: str | None = None,
+        uds: str | None = None,
         network_backend: NetworkBackend | None = None,
         socket_options: typing.Iterable[SOCKET_OPTION] | None = None,
     ) -> None:
         self._connection: ConnectionInterface = HTTPConnection(
             origin=proxy_origin,
             keepalive_expiry=keepalive_expiry,
+            retries=retries,
+            local_address=local_address,
+            uds=uds,
             network_backend=network_backend,
             socket_options=socket_options,
             ssl_context=proxy_ssl_context,

--- a/src/httpcore2/httpcore2/_sync/socks_proxy.py
+++ b/src/httpcore2/httpcore2/_sync/socks_proxy.py
@@ -2,16 +2,18 @@ from __future__ import annotations
 
 import logging
 import ssl
+import typing
 
 import socksio
 
 from .._backends.sync import SyncBackend
 from .._backends.base import NetworkBackend, NetworkStream
-from .._exceptions import ConnectionNotAvailable, ProxyError
+from .._exceptions import ConnectError, ConnectionNotAvailable, ConnectTimeout, ProxyError
 from .._models import URL, Origin, Request, Response, enforce_bytes, enforce_url
 from .._ssl import default_ssl_context
 from .._synchronization import Lock
 from .._trace import Trace
+from .connection import RETRIES_BACKOFF_FACTOR, exponential_backoff
 from .connection_pool import ConnectionPool
 from .http11 import HTTP11Connection
 from .interfaces import ConnectionInterface
@@ -139,13 +141,7 @@ class SOCKSProxy(ConnectionPool):  # pragma: no cover
             http2: A boolean indicating if HTTP/2 requests should be supported by
                 the connection pool. Defaults to False.
             retries: The maximum number of retries when trying to establish
-                a connection.
-            local_address: Local address to connect from. Can also be used to
-                connect using a particular address family. Using
-                `local_address="0.0.0.0"` will connect using an `AF_INET` address
-                (IPv4), while using `local_address="::"` will connect using an
-                `AF_INET6` address (IPv6).
-            uds: Path to a Unix Domain Socket to use instead of TCP sockets.
+                a connection to the proxy server.
             network_backend: A backend instance to use for handling network I/O.
         """
         super().__init__(
@@ -180,6 +176,7 @@ class SOCKSProxy(ConnectionPool):  # pragma: no cover
             keepalive_expiry=self._keepalive_expiry,
             http1=self._http1,
             http2=self._http2,
+            retries=self._retries,
             network_backend=self._network_backend,
         )
 
@@ -194,6 +191,7 @@ class Socks5Connection(ConnectionInterface):
         keepalive_expiry: float | None = None,
         http1: bool = True,
         http2: bool = False,
+        retries: int = 0,
         network_backend: NetworkBackend | None = None,
     ) -> None:
         self._proxy_origin = proxy_origin
@@ -203,6 +201,7 @@ class Socks5Connection(ConnectionInterface):
         self._keepalive_expiry = keepalive_expiry
         self._http1 = http1
         self._http2 = http2
+        self._retries = retries
 
         self._network_backend: NetworkBackend = SyncBackend() if network_backend is None else network_backend
         self._connect_lock = Lock()
@@ -218,14 +217,7 @@ class Socks5Connection(ConnectionInterface):
             if self._connection is None:
                 try:
                     # Connect to the proxy
-                    kwargs = {
-                        "host": self._proxy_origin.host.decode("ascii"),
-                        "port": self._proxy_origin.port,
-                        "timeout": timeout,
-                    }
-                    with Trace("connect_tcp", logger, request, kwargs) as trace:
-                        stream = self._network_backend.connect_tcp(**kwargs)
-                        trace.return_value = stream
+                    stream = self._connect_to_proxy(request, timeout)
 
                     # Connect to the remote host using socks5
                     kwargs = {
@@ -280,6 +272,29 @@ class Socks5Connection(ConnectionInterface):
                 raise ConnectionNotAvailable()
 
         return self._connection.handle_request(request)
+
+    def _connect_to_proxy(self, request: Request, timeout: float | None) -> NetworkStream:
+        retries_left = self._retries
+        delays = exponential_backoff(factor=RETRIES_BACKOFF_FACTOR)
+
+        while True:
+            kwargs: dict[str, typing.Any] = {
+                "host": self._proxy_origin.host.decode("ascii"),
+                "port": self._proxy_origin.port,
+                "timeout": timeout,
+            }
+            try:
+                with Trace("connect_tcp", logger, request, kwargs) as trace:
+                    stream = self._network_backend.connect_tcp(**kwargs)
+                    trace.return_value = stream
+                return stream
+            except (ConnectError, ConnectTimeout):
+                if retries_left <= 0:
+                    raise
+                retries_left -= 1
+                delay = next(delays)
+                with Trace("retry", logger, request, kwargs) as trace:
+                    self._network_backend.sleep(delay)
 
     def can_handle_request(self, origin: Origin) -> bool:
         return origin == self._remote_origin

--- a/src/httpx2/CHANGELOG.md
+++ b/src/httpx2/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Fixed
+
+* Forward `uds`, `local_address` and `retries` to the underlying connection pool when a `proxy` is configured on `HTTPTransport` and `AsyncHTTPTransport`. Previously these options were silently ignored for proxied connections. SOCKS proxies support `retries` only.
+  ([#1160](https://github.com/pydantic/httpx2/discussions/1160))
+
 ## 2.12.0 (August 18th, 2026)
 
 ### Changed

--- a/src/httpx2/httpx2/_transports/default.py
+++ b/src/httpx2/httpx2/_transports/default.py
@@ -178,6 +178,9 @@ class HTTPTransport(BaseTransport):
                 keepalive_expiry=limits.keepalive_expiry,
                 http1=http1,
                 http2=http2,
+                uds=uds,
+                local_address=local_address,
+                retries=retries,
                 socket_options=socket_options,
             )
         elif proxy.url.scheme in ("socks5", "socks5h"):
@@ -203,6 +206,7 @@ class HTTPTransport(BaseTransport):
                 keepalive_expiry=limits.keepalive_expiry,
                 http1=http1,
                 http2=http2,
+                retries=retries,
             )
         else:  # pragma: no cover
             raise ValueError(
@@ -321,6 +325,9 @@ class AsyncHTTPTransport(AsyncBaseTransport):
                 keepalive_expiry=limits.keepalive_expiry,
                 http1=http1,
                 http2=http2,
+                uds=uds,
+                local_address=local_address,
+                retries=retries,
                 socket_options=socket_options,
             )
         elif proxy.url.scheme in ("socks5", "socks5h"):
@@ -346,6 +353,7 @@ class AsyncHTTPTransport(AsyncBaseTransport):
                 keepalive_expiry=limits.keepalive_expiry,
                 http1=http1,
                 http2=http2,
+                retries=retries,
             )
         else:  # pragma: no cover
             raise ValueError(

--- a/tests/httpcore2/_async/test_http_proxy.py
+++ b/tests/httpcore2/_async/test_http_proxy.py
@@ -8,6 +8,7 @@ import pytest
 from httpcore2 import (
     SOCKET_OPTION,
     AsyncConnectionPool,
+    AsyncHTTPProxy,
     AsyncMockBackend,
     AsyncMockStream,
     AsyncNetworkStream,
@@ -15,6 +16,8 @@ from httpcore2 import (
     Proxy,
     ProxyError,
 )
+
+from .test_connection import NeedsRetryBackend
 
 
 @pytest.mark.anyio
@@ -227,6 +230,59 @@ async def test_proxy_tunneling_with_auth() -> None:
             url="http://localhost:8080/",
             auth=("username", "password"),
         ),
+        network_backend=network_backend,
+    ) as proxy:
+        response = await proxy.request("GET", "https://example.com/")
+        assert response.status == 200
+        assert response.content == b"Hello, world!"
+
+
+@pytest.mark.anyio
+async def test_proxy_forwarding_retries() -> None:
+    """
+    The `retries` option is honored when connecting to a forwarding proxy.
+    """
+    network_backend = NeedsRetryBackend(
+        [
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Type: plain/text\r\n",
+            b"Content-Length: 13\r\n",
+            b"\r\n",
+            b"Hello, world!",
+        ]
+    )
+
+    async with AsyncConnectionPool(
+        proxy=Proxy("http://localhost:8080/"),
+        retries=3,
+        network_backend=network_backend,
+    ) as proxy:
+        response = await proxy.request("GET", "http://example.com/")
+        assert response.status == 200
+        assert response.content == b"Hello, world!"
+
+
+@pytest.mark.anyio
+async def test_proxy_tunneling_retries() -> None:
+    """
+    The `retries` option is honored when connecting to a tunneling proxy.
+    """
+    network_backend = NeedsRetryBackend(
+        [
+            # The initial response to the proxy CONNECT
+            b"HTTP/1.1 200 OK\r\n\r\n",
+            # The actual response from the remote server
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Type: plain/text\r\n",
+            b"Content-Length: 13\r\n",
+            b"\r\n",
+            b"Hello, world!",
+        ]
+    )
+
+    async with AsyncHTTPProxy(
+        proxy_url="http://localhost:8080/",
+        retries=3,
         network_backend=network_backend,
     ) as proxy:
         response = await proxy.request("GET", "https://example.com/")

--- a/tests/httpcore2/_async/test_socks_proxy.py
+++ b/tests/httpcore2/_async/test_socks_proxy.py
@@ -2,6 +2,8 @@ import pytest
 
 import httpcore2
 
+from .test_connection import NeedsRetryBackend
+
 
 @pytest.mark.anyio
 async def test_socks5_request() -> None:
@@ -176,3 +178,43 @@ async def test_socks5_request_incorrect_auth() -> None:
         assert str(exc_info.value) == "Invalid username/password"
 
         assert not proxy.connections
+
+
+@pytest.mark.anyio
+async def test_socks5_request_retries() -> None:
+    """
+    The `retries` option is honored when connecting to a SOCKS proxy.
+    """
+    network_backend = NeedsRetryBackend(
+        [
+            # The initial socks CONNECT
+            #   v5 NOAUTH
+            b"\x05\x00",
+            #   v5 SUC RSV IP4 127  .0  .0  .1     :80
+            b"\x05\x00\x00\x01\xff\x00\x00\x01\x00\x50",
+            # The actual response from the remote server
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Type: plain/text\r\n",
+            b"Content-Length: 13\r\n",
+            b"\r\n",
+            b"Hello, world!",
+        ]
+    )
+
+    async with httpcore2.AsyncSOCKSProxy(
+        proxy_url="socks5://localhost:8080/",
+        retries=3,
+        network_backend=network_backend,
+    ) as proxy:
+        response = await proxy.request("GET", "https://example.com/")
+        assert response.status == 200
+        assert response.content == b"Hello, world!"
+
+    # Without retries the connect failure is raised.
+    network_backend = NeedsRetryBackend([])
+    async with httpcore2.AsyncSOCKSProxy(
+        proxy_url="socks5://localhost:8080/",
+        network_backend=network_backend,
+    ) as proxy:
+        with pytest.raises(httpcore2.ConnectError):
+            await proxy.request("GET", "https://example.com/")

--- a/tests/httpcore2/_sync/test_http_proxy.py
+++ b/tests/httpcore2/_sync/test_http_proxy.py
@@ -8,6 +8,7 @@ import pytest
 from httpcore2 import (
     SOCKET_OPTION,
     ConnectionPool,
+    HTTPProxy,
     MockBackend,
     MockStream,
     NetworkStream,
@@ -15,6 +16,8 @@ from httpcore2 import (
     Proxy,
     ProxyError,
 )
+
+from .test_connection import NeedsRetryBackend
 
 
 
@@ -227,6 +230,59 @@ def test_proxy_tunneling_with_auth() -> None:
             url="http://localhost:8080/",
             auth=("username", "password"),
         ),
+        network_backend=network_backend,
+    ) as proxy:
+        response = proxy.request("GET", "https://example.com/")
+        assert response.status == 200
+        assert response.content == b"Hello, world!"
+
+
+
+def test_proxy_forwarding_retries() -> None:
+    """
+    The `retries` option is honored when connecting to a forwarding proxy.
+    """
+    network_backend = NeedsRetryBackend(
+        [
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Type: plain/text\r\n",
+            b"Content-Length: 13\r\n",
+            b"\r\n",
+            b"Hello, world!",
+        ]
+    )
+
+    with ConnectionPool(
+        proxy=Proxy("http://localhost:8080/"),
+        retries=3,
+        network_backend=network_backend,
+    ) as proxy:
+        response = proxy.request("GET", "http://example.com/")
+        assert response.status == 200
+        assert response.content == b"Hello, world!"
+
+
+
+def test_proxy_tunneling_retries() -> None:
+    """
+    The `retries` option is honored when connecting to a tunneling proxy.
+    """
+    network_backend = NeedsRetryBackend(
+        [
+            # The initial response to the proxy CONNECT
+            b"HTTP/1.1 200 OK\r\n\r\n",
+            # The actual response from the remote server
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Type: plain/text\r\n",
+            b"Content-Length: 13\r\n",
+            b"\r\n",
+            b"Hello, world!",
+        ]
+    )
+
+    with HTTPProxy(
+        proxy_url="http://localhost:8080/",
+        retries=3,
         network_backend=network_backend,
     ) as proxy:
         response = proxy.request("GET", "https://example.com/")

--- a/tests/httpcore2/_sync/test_socks_proxy.py
+++ b/tests/httpcore2/_sync/test_socks_proxy.py
@@ -2,6 +2,8 @@ import pytest
 
 import httpcore2
 
+from .test_connection import NeedsRetryBackend
+
 
 
 def test_socks5_request() -> None:
@@ -176,3 +178,43 @@ def test_socks5_request_incorrect_auth() -> None:
         assert str(exc_info.value) == "Invalid username/password"
 
         assert not proxy.connections
+
+
+
+def test_socks5_request_retries() -> None:
+    """
+    The `retries` option is honored when connecting to a SOCKS proxy.
+    """
+    network_backend = NeedsRetryBackend(
+        [
+            # The initial socks CONNECT
+            #   v5 NOAUTH
+            b"\x05\x00",
+            #   v5 SUC RSV IP4 127  .0  .0  .1     :80
+            b"\x05\x00\x00\x01\xff\x00\x00\x01\x00\x50",
+            # The actual response from the remote server
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Type: plain/text\r\n",
+            b"Content-Length: 13\r\n",
+            b"\r\n",
+            b"Hello, world!",
+        ]
+    )
+
+    with httpcore2.SOCKSProxy(
+        proxy_url="socks5://localhost:8080/",
+        retries=3,
+        network_backend=network_backend,
+    ) as proxy:
+        response = proxy.request("GET", "https://example.com/")
+        assert response.status == 200
+        assert response.content == b"Hello, world!"
+
+    # Without retries the connect failure is raised.
+    network_backend = NeedsRetryBackend([])
+    with httpcore2.SOCKSProxy(
+        proxy_url="socks5://localhost:8080/",
+        network_backend=network_backend,
+    ) as proxy:
+        with pytest.raises(httpcore2.ConnectError):
+            proxy.request("GET", "https://example.com/")

--- a/tests/httpx2/client/test_proxies.py
+++ b/tests/httpx2/client/test_proxies.py
@@ -273,3 +273,31 @@ def test_proxy_with_mounts() -> None:
 
     transport = client._transport_for_url(httpx2.URL("http://example.com"))
     assert transport == proxy_transport
+
+
+def test_transport_options_forwarded_to_http_proxy_pool() -> None:
+    for transport in (
+        httpx2.HTTPTransport(
+            proxy="http://127.0.0.1",
+            uds="/tmp/socket.uds",
+            local_address="0.0.0.0",
+            retries=3,
+        ),
+        httpx2.AsyncHTTPTransport(
+            proxy="http://127.0.0.1",
+            uds="/tmp/socket.uds",
+            local_address="0.0.0.0",
+            retries=3,
+        ),
+    ):
+        assert transport._pool._uds == "/tmp/socket.uds"
+        assert transport._pool._local_address == "0.0.0.0"
+        assert transport._pool._retries == 3
+
+
+def test_transport_retries_forwarded_to_socks_proxy_pool() -> None:
+    for transport in (
+        httpx2.HTTPTransport(proxy="socks5://127.0.0.1", retries=3),
+        httpx2.AsyncHTTPTransport(proxy="socks5://127.0.0.1", retries=3),
+    ):
+        assert transport._pool._retries == 3


### PR DESCRIPTION
When a `proxy` was configured, `HTTPTransport` and `AsyncHTTPTransport`
silently dropped `uds`, `local_address` and `retries` instead of forwarding
them to the underlying pool.

The gap ran deeper than the transport layer:

- `httpcore2.HTTPProxy` accepted all three but its `create_connection` never
  handed them (or `socket_options`) to the proxy connections it built.
- `ConnectionPool(proxy=...)` had the same gap in all three of its proxy
  branches.
- `SOCKSProxy` accepted `retries` while the Socks5 connection had no retry
  logic at all.

## Changes

- Thread `retries`, `local_address` and `uds` through the forward and tunnel
  proxy connections down to the inner `HTTPConnection`.
- Implement connect retries for Socks5 connections, mirroring the backoff
  behaviour of `HTTPConnection` (same exception set, same
  `exponential_backoff` sequence, same `Trace("retry", ...)`).
- Forward the options from both transports. SOCKS proxies support `retries`
  only; `uds`, `local_address` and `socket_options` are not available there,
  now noted in the transports documentation.
- Drop the `local_address` and `uds` entries from the `SOCKSProxy` docstring,
  which documented parameters the constructor does not accept.

Note that `socket_options` remains silently ignored for SOCKS proxies rather
than raising — that would be a behaviour change for anyone currently passing
the combination, so it is documented instead.

See https://github.com/pydantic/httpx2/discussions/1160


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

