### PR TITLE
Preserve existing URL query parameters when params are provided

### DIFF
--- a/src/httpx2/httpx2/_urls.py
+++ b/src/httpx2/httpx2/_urls.py
@@ -114,13 +114,19 @@ class URL:
                     kwargs[key] = value.decode("ascii")
 
             if "params" in kwargs:
-                # Replace any "params" keyword with the raw "query" instead.
-                #
-                # Ensure that empty params use `kwargs["query"] = None` rather
-                # than `kwargs["query"] = ""`, so that generated URLs do not
-                # include an empty trailing "?".
                 params = kwargs.pop("params")
-                kwargs["query"] = None if not params else str(QueryParams(params))
+                if params:
+                    if "query" in kwargs:
+                        query = kwargs["query"]
+                    elif isinstance(url, str):
+                        query = urlparse(url).query
+                    elif isinstance(url, URL):
+                        query = url.query.decode("ascii")
+                    else:
+                        query = None
+
+                    encoded_params = str(QueryParams(params))
+                    kwargs["query"] = f"{query}&{encoded_params}" if query else encoded_params
 
         if isinstance(url, str):
             self._uri_reference = urlparse(url, **kwargs)
@@ -353,6 +359,9 @@ class URL:
         )
         assert url == "https://jo%40email.com:a%20secret@www.example.com"
         """
+        if "params" in kwargs:
+            params = kwargs.pop("params")
+            kwargs["query"] = None if not params else str(QueryParams(params)).encode("ascii")
         return URL(self, **kwargs)
 
     def copy_set_param(self, key: str, value: typing.Any = None) -> URL:

--- a/tests/httpx2/models/test_requests.py
+++ b/tests/httpx2/models/test_requests.py
@@ -240,7 +240,10 @@ def test_request_params() -> None:
     assert str(request.url) == "http://example.com"
 
     request = httpx2.Request("GET", "http://example.com?c=3", params={"a": "1", "b": "2"})
-    assert str(request.url) == "http://example.com?a=1&b=2"
+    assert str(request.url) == "http://example.com?c=3&a=1&b=2"
 
     request = httpx2.Request("GET", "http://example.com?a=1", params={})
-    assert str(request.url) == "http://example.com"
+    assert str(request.url) == "http://example.com?a=1"
+
+    request = httpx2.Request("GET", "http://example.com?a=old", params={"a": "new"})
+    assert str(request.url) == "http://example.com?a=old&a=new"

--- a/tests/httpx2/models/test_url.py
+++ b/tests/httpx2/models/test_url.py
@@ -239,8 +239,23 @@ def test_url_params() -> None:
     assert url.params == httpx2.QueryParams({"a": "123"})
 
     url = httpx2.URL("https://example.org:123/path/to/somewhere?b=456", params={"a": "123"})
-    assert str(url) == "https://example.org:123/path/to/somewhere?a=123"
-    assert url.params == httpx2.QueryParams({"a": "123"})
+    assert str(url) == "https://example.org:123/path/to/somewhere?b=456&a=123"
+    assert url.params == httpx2.QueryParams("b=456&a=123")
+
+    url = httpx2.URL("https://example.org/?a=old", params={"a": "new"})
+    assert str(url) == "https://example.org/?a=old&a=new"
+
+    url = httpx2.URL("https://example.org/?a=old", params=httpx2.QueryParams("a=new"))
+    assert str(url) == "https://example.org/?a=old&a=new"
+
+    url = httpx2.URL("https://example.org/?a=old", query=b"b=existing", params={"c": "new"})
+    assert str(url) == "https://example.org/?b=existing&c=new"
+
+
+@pytest.mark.parametrize("params", [None, {}, [], (), "", b"", httpx2.QueryParams()])
+def test_url_empty_params_preserve_existing_query(params: object) -> None:
+    url = httpx2.URL("https://example.org/?a=123", params=params)
+    assert str(url) == "https://example.org/?a=123"
 
 
 # Tests for username and password
@@ -541,6 +556,9 @@ def test_url_invalid_type() -> None:
     with pytest.raises(TypeError):
         httpx2.URL(ExternalURLClass())  # type: ignore
 
+    with pytest.raises(TypeError):
+        httpx2.URL(123, params={"a": "b"})  # type: ignore
+
 
 def test_url_with_invalid_component() -> None:
     with pytest.raises(TypeError) as exc:
@@ -709,6 +727,12 @@ def test_url_copywith_query() -> None:
     assert url.path == "/"
     assert url.query == b"a=123"
     assert url.raw_path == b"/?a=123"
+
+
+def test_url_copywith_params_replaces_query() -> None:
+    url = httpx2.URL("https://example.org/?a=123")
+    url = url.copy_with(params={"b": "456"})
+    assert str(url) == "https://example.org/?b=456"
 
 
 def test_url_copywith_raw_path() -> None:


### PR DESCRIPTION
# Summary

- preserve query parameters already present in a URL when additional `params` are provided
- append same-name parameters instead of applying dictionary-style replacement
- keep `copy_with(params=...)` and the query manipulation helpers replacement semantics unchanged
- cover `URL`, `Request`, empty parameter inputs, same-name values, explicit queries, and invalid URL types

Closes #1173

# Testing

- `uv run --frozen coverage run -m pytest -q` — 1998 passed, 1 skipped
- `uv run --frozen coverage report --fail-under=100` — 100%
- `uv run --frozen ruff format --check --diff src/httpx2 tests/httpx2 src/httpcore2 tests/httpcore2 benchmark`
- `uv run --frozen ruff check`
- `uv run --frozen mypy src/httpx2 tests/httpx2 src/httpcore2 tests/httpcore2 benchmark`
- `uv run --frozen python scripts/unasync.py --check`

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This does not apply to typos.)
- [x] I have added a test for each introduced behavior and kept the change atomic.
- [x] Documentation changes are not required for this bug fix.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

