### PR TITLE
perf: reduce async request overhead

### DIFF
--- a/src/httpcore2/httpcore2/_async/connection_pool.py
+++ b/src/httpcore2/httpcore2/_async/connection_pool.py
@@ -369,6 +369,8 @@ class AsyncConnectionPool(AsyncRequestInterface):
 
     async def _close_connections(self, closing: list[AsyncConnectionInterface]) -> None:
         # Close connections which have been removed from the pool.
+        if not closing:
+            return
         with AsyncShieldCancellation():
             for connection in closing:
                 await connection.aclose()

--- a/src/httpcore2/httpcore2/_sync/connection_pool.py
+++ b/src/httpcore2/httpcore2/_sync/connection_pool.py
@@ -369,6 +369,8 @@ class ConnectionPool(RequestInterface):
 
     def _close_connections(self, closing: list[ConnectionInterface]) -> None:
         # Close connections which have been removed from the pool.
+        if not closing:
+            return
         with ShieldCancellation():
             for connection in closing:
                 connection.close()

--- a/src/httpx2/httpx2/_client.py
+++ b/src/httpx2/httpx2/_client.py
@@ -408,6 +408,8 @@ class BaseClient:
         Merge a headers argument together with any headers on the client,
         to create the headers used for the outgoing request.
         """
+        if headers is None:
+            return self.headers
         merged_headers = Headers(self.headers)
         merged_headers.update(headers)
         return merged_headers

--- a/src/httpx2/httpx2/_models.py
+++ b/src/httpx2/httpx2/_models.py
@@ -987,6 +987,13 @@ class Response:
                 yield self._content[i : i + chunk_size]
         else:
             decoder = self._get_content_decoder()
+            if chunk_size is None and type(decoder) is IdentityDecoder:
+                with request_context(request=self._request):
+                    async with contextlib.aclosing(self.aiter_raw()) as raw_stream:
+                        async for raw_bytes in raw_stream:
+                            if raw_bytes:
+                                yield raw_bytes
+                return
             chunker = ByteChunker(chunk_size=chunk_size)
             with request_context(request=self._request):
                 async with contextlib.aclosing(self.aiter_raw()) as raw_stream:
@@ -1041,18 +1048,25 @@ class Response:
 
         self.is_stream_consumed = True
         self._num_bytes_downloaded = 0
-        chunker = ByteChunker(chunk_size=chunk_size)
+        chunker = None if chunk_size is None else ByteChunker(chunk_size=chunk_size)
 
         stream = self.stream.__aiter__()
         try:
             with request_context(request=self._request):
-                async for raw_stream_bytes in stream:
-                    self._num_bytes_downloaded += len(raw_stream_bytes)
-                    for chunk in chunker.decode(raw_stream_bytes):
-                        yield chunk
+                if chunker is None:
+                    async for raw_stream_bytes in stream:
+                        self._num_bytes_downloaded += len(raw_stream_bytes)
+                        if raw_stream_bytes:
+                            yield raw_stream_bytes
+                else:
+                    async for raw_stream_bytes in stream:
+                        self._num_bytes_downloaded += len(raw_stream_bytes)
+                        for chunk in chunker.decode(raw_stream_bytes):
+                            yield chunk
 
-            for chunk in chunker.flush():
-                yield chunk
+            if chunker is not None:
+                for chunk in chunker.flush():
+                    yield chunk
         finally:
             if isinstance(stream, AsyncGenerator):
                 await stream.aclose()

--- a/tests/httpx2/client/test_headers.py
+++ b/tests/httpx2/client/test_headers.py
@@ -115,6 +115,15 @@ def test_header_update() -> None:
     }
 
 
+def test_request_headers_are_independent_from_client_headers() -> None:
+    client = httpx2.Client(headers={"X-Test": "client"})
+    request = client.build_request("GET", "https://example.org")
+
+    request.headers["X-Test"] = "request"
+
+    assert client.headers["X-Test"] == "client"
+
+
 def test_header_repeated_items() -> None:
     url = "http://example.org/echo_headers"
     client = httpx2.Client(transport=httpx2.MockTransport(echo_repeated_headers_items))

--- a/tests/httpx2/models/test_responses.py
+++ b/tests/httpx2/models/test_responses.py
@@ -475,6 +475,47 @@ async def test_aiter_raw() -> None:
 
 
 @pytest.mark.anyio
+async def test_aiter_raw_and_bytes_dont_return_empty_chunks() -> None:
+    async def body() -> typing.AsyncIterator[bytes]:
+        yield b"Hello, "
+        yield b""
+        yield b"world!"
+
+    response = httpx2.Response(200, content=body())
+    assert [part async for part in response.aiter_raw()] == [b"Hello, ", b"world!"]
+    assert response.num_bytes_downloaded == 13
+    assert response.is_closed
+
+    response = httpx2.Response(200, headers={"Content-Encoding": "identity"}, content=body())
+    assert [part async for part in response.aiter_bytes()] == [b"Hello, ", b"world!"]
+    assert response.num_bytes_downloaded == 13
+    assert response.is_closed
+
+
+@pytest.mark.anyio
+async def test_aiter_bytes_closes_stream_when_closed_early() -> None:
+    close_count = 0
+
+    async def body() -> typing.AsyncIterator[bytes]:
+        nonlocal close_count
+        try:
+            yield b"Hello, "
+        finally:
+            close_count += 1
+
+    response = httpx2.Response(200, content=body())
+    parts = response.aiter_bytes()
+    try:
+        assert await anext(parts) == b"Hello, "
+        assert response.num_bytes_downloaded == 7
+    finally:
+        await parts.aclose()
+
+    assert close_count == 1
+    assert response.is_closed
+
+
+@pytest.mark.anyio
 async def test_aiter_raw_with_chunksize() -> None:
     response = httpx2.Response(200, content=async_streaming_body())
 


### PR DESCRIPTION
Closes #1182.

Discussion: #1181.

# Summary

This drops three bits of avoidable work from common request paths:

- Skip the cancellation shield when the connection pool has nothing to close.
- Reuse client headers when a request does not add any.
- Pass unencoded async response chunks through without no-op chunking work.

The changes are split into three commits so each one can be reviewed or reverted on its own.

# Performance

| Scenario | Requests/s | Client CPU/request |
|---|---:|---:|
| c1 / 1 KiB | 4,710 -> 4,994 (+6.0%) | 210.0 -> 198.1 us (-5.7%) |
| c32 / 1 KiB | 4,568 -> 4,813 (+5.4%) | 217.2 -> 206.2 us (-5.1%) |
| c32 / 64 KiB | 3,941 -> 4,114 (+4.4%) | 251.7 -> 241.1 us (-4.2%) |

These are medians from five interleaved 2.5-second runs on CPython 3.14.7 with stdlib asyncio and pinned server/client CPUs.

The benchmark used plain HTTP/1.1 on loopback, so the numbers should not be read as TLS, HTTP/2, or WAN results.

# Validation

- `scripts/test`
- `1995 passed, 1 skipped`
- 100% coverage
- Ruff, mypy, lockfile, and unasync checks pass

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion.
- [x] I've added regression tests for the behavior-sensitive changes and kept the commits atomic.
- [x] No documentation update is needed for these internal changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

