### PR TITLE
Mention header name in encoding errors

### DIFF
--- a/src/httpx2/httpx2/_models.py
+++ b/src/httpx2/httpx2/_models.py
@@ -343,8 +343,12 @@ class Headers(typing.MutableMapping[str, str]):
         Set the header `key` to `value`, removing any duplicate entries.
         Retains insertion order.
         """
-        set_key = key.encode(self._encoding or "utf-8")
-        set_value = value.encode(self._encoding or "utf-8")
+        set_key = _normalize_header_key(key, self._encoding or "utf-8")
+        set_value = _normalize_header_value(
+            value,
+            self._encoding or "utf-8",
+            header_name=key,
+        )
         lookup_key = set_key.lower()
 
         found_indexes = [idx for idx, (_, item_key, _) in enumerate(self._list) if item_key == lookup_key]

--- a/src/httpx2/httpx2/_models.py
+++ b/src/httpx2/httpx2/_models.py
@@ -73,7 +73,11 @@ def _normalize_header_key(key: str | bytes, encoding: str | None = None) -> byte
     return key if isinstance(key, bytes) else key.encode(encoding or "ascii")
 
 
-def _normalize_header_value(value: str | bytes, encoding: str | None = None) -> bytes:
+def _normalize_header_value(
+    value: str | bytes,
+    encoding: str | None = None,
+    header_name: str | bytes | None = None,
+) -> bytes:
     """
     Coerce str/bytes into a strictly byte-wise HTTP header value.
     """
@@ -81,7 +85,17 @@ def _normalize_header_value(value: str | bytes, encoding: str | None = None) -> 
         return value
     if not isinstance(value, str):
         raise TypeError(f"Header value must be str or bytes, not {type(value)}")
-    return value.encode(encoding or "ascii")
+
+    try:
+        return value.encode(encoding or "ascii")
+    except UnicodeEncodeError as exc:
+        raise UnicodeEncodeError(
+            exc.encoding,
+            exc.object,
+            exc.start,
+            exc.end,
+            f"Header {header_name!r} value contains characters that cannot be encoded with {exc.encoding}",
+        ) from exc
 
 
 def _parse_content_type_charset(content_type: str) -> str | None:
@@ -155,12 +169,12 @@ class Headers(typing.MutableMapping[str, str]):
         elif isinstance(headers, Mapping):
             for k, v in headers.items():
                 bytes_key = _normalize_header_key(k, encoding)
-                bytes_value = _normalize_header_value(v, encoding)
+                bytes_value = _normalize_header_value(v, encoding, header_name=k)
                 self._list.append((bytes_key, bytes_key.lower(), bytes_value))
         elif headers is not None:
             for k, v in headers:
                 bytes_key = _normalize_header_key(k, encoding)
-                bytes_value = _normalize_header_value(v, encoding)
+                bytes_value = _normalize_header_value(v, encoding, header_name=k)
                 self._list.append((bytes_key, bytes_key.lower(), bytes_value))
 
         self._encoding = encoding

--- a/tests/httpx2/models/test_headers.py
+++ b/tests/httpx2/models/test_headers.py
@@ -145,6 +145,16 @@ def test_headers_encoding_in_repr() -> None:
     assert repr(headers) == "Headers({'custom': 'example ☃'}, encoding='utf-8')"
 
 
+def test_header_encoding_error_mentions_header_name() -> None:
+    with pytest.raises(UnicodeEncodeError, match="auth"):
+        httpx2.Headers({"auth": "здравейздравей"})
+
+
+def test_header_encoding_error_mentions_header_name_with_list() -> None:
+    with pytest.raises(UnicodeEncodeError, match="auth"):
+        httpx2.Headers([("auth", "здравейздравей")])
+
+
 def test_headers_list_repr() -> None:
     """
     Headers should display with a list repr if they include multiple identical keys.

--- a/tests/httpx2/models/test_headers.py
+++ b/tests/httpx2/models/test_headers.py
@@ -155,6 +155,20 @@ def test_header_encoding_error_mentions_header_name_with_list() -> None:
         httpx2.Headers([("auth", "здравейздравей")])
 
 
+def test_header_encoding_error_mentions_header_name_with_setitem() -> None:
+    headers = httpx2.Headers(encoding="ascii")
+
+    with pytest.raises(UnicodeEncodeError, match="auth"):
+        headers["auth"] = "здравейздравей"
+
+
+def test_header_encoding_error_mentions_header_name_with_update() -> None:
+    headers = httpx2.Headers()
+
+    with pytest.raises(UnicodeEncodeError, match="auth"):
+        headers.update({"auth": "здравейздравей"})
+
+
 def test_headers_list_repr() -> None:
     """
     Headers should display with a list repr if they include multiple identical keys.


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX2! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary
- Preserves the existing error behavior while including the header name in the error message.


<!-- Write a small summary about what is happening here. -->

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

