### PR TITLE
Restore `--no-verify` CLI flag

### DIFF
--- a/src/httpx2/httpx2/_main.py
+++ b/src/httpx2/httpx2/_main.py
@@ -77,7 +77,7 @@ def print_help() -> None:
     )
 
     table.add_row("--follow-redirects", "Automatically follow redirects.")
-    table.add_row("--verify / --no-verify", "Enable or disable SSL verification.")
+    table.add_row("--verify / --no-verify", "Enable SSL verification.")
     table.add_row("--http2", "Send the request using HTTP/2, if the remote server supports it.")
 
     table.add_row(
@@ -395,7 +395,7 @@ def handle_help(
 @click.option(
     "--verify/--no-verify",
     default=True,
-    help="Enable or disable SSL verification.",
+    help="Enable SSL verification.",
 )
 @click.option(
     "--http2",

--- a/src/httpx2/httpx2/_main.py
+++ b/src/httpx2/httpx2/_main.py
@@ -77,7 +77,7 @@ def print_help() -> None:
     )
 
     table.add_row("--follow-redirects", "Automatically follow redirects.")
-    table.add_row("--no-verify", "Disable SSL verification.")
+    table.add_row("--verify / --no-verify", "Enable or disable SSL verification.")
     table.add_row("--http2", "Send the request using HTTP/2, if the remote server supports it.")
 
     table.add_row(
@@ -393,11 +393,9 @@ def handle_help(
     help="Automatically follow redirects.",
 )
 @click.option(
-    "--verify",
-    "verify",
-    type=bool,
+    "--verify/--no-verify",
     default=True,
-    help="Enable SSL verification.",
+    help="Enable or disable SSL verification.",
 )
 @click.option(
     "--http2",

--- a/tests/httpx2/conftest.py
+++ b/tests/httpx2/conftest.py
@@ -277,3 +277,22 @@ def server(free_tcp_port_factory: typing.Callable[[], int]) -> typing.Iterator[T
     config = Config(app=app, lifespan="off", loop="asyncio", ws="none", port=free_tcp_port_factory())
     server = TestServer(config=config)
     yield from serve_in_thread(server)
+
+
+@pytest.fixture(scope="session")
+def https_server(
+    free_tcp_port_factory: typing.Callable[[], int],
+    cert_pem_file: str,
+    cert_private_key_file: str,
+) -> typing.Iterator[TestServer]:
+    config = Config(
+        app=app,
+        lifespan="off",
+        loop="asyncio",
+        ws="none",
+        port=free_tcp_port_factory(),
+        ssl_certfile=cert_pem_file,
+        ssl_keyfile=cert_private_key_file,
+    )
+    server = TestServer(config=config)
+    yield from serve_in_thread(server)

--- a/tests/httpx2/conftest.py
+++ b/tests/httpx2/conftest.py
@@ -277,22 +277,3 @@ def server(free_tcp_port_factory: typing.Callable[[], int]) -> typing.Iterator[T
     config = Config(app=app, lifespan="off", loop="asyncio", ws="none", port=free_tcp_port_factory())
     server = TestServer(config=config)
     yield from serve_in_thread(server)
-
-
-@pytest.fixture(scope="session")
-def https_server(
-    free_tcp_port_factory: typing.Callable[[], int],
-    cert_pem_file: str,
-    cert_private_key_file: str,
-) -> typing.Iterator[TestServer]:
-    config = Config(
-        app=app,
-        lifespan="off",
-        loop="asyncio",
-        ws="none",
-        port=free_tcp_port_factory(),
-        ssl_certfile=cert_pem_file,
-        ssl_keyfile=cert_private_key_file,
-    )
-    server = TestServer(config=config)
-    yield from serve_in_thread(server)

--- a/tests/httpx2/test_main.py
+++ b/tests/httpx2/test_main.py
@@ -26,7 +26,6 @@ def test_help() -> None:
     result = runner.invoke(main, ["--help"])
     assert result.exit_code == 0
     assert "A next generation HTTP client." in result.output
-    assert "--verify / --no-verify" in result.output
 
 
 @pytest.mark.parametrize(

--- a/tests/httpx2/test_main.py
+++ b/tests/httpx2/test_main.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import typing
 
+import pytest
 from click.testing import CliRunner
 
 import httpx2
@@ -28,10 +29,17 @@ def test_help() -> None:
     assert "--verify / --no-verify" in result.output
 
 
-def test_no_verify(https_server: TestServer) -> None:
-    runner = CliRunner()
-    result = runner.invoke(main, [str(https_server.url), "--no-verify"])
-    assert result.exit_code == 0
+@pytest.mark.parametrize(
+    ("option", "expected"),
+    [
+        ([], True),
+        (["--verify"], True),
+        (["--no-verify"], False),
+    ],
+)
+def test_verify_option(option: list[str], expected: bool) -> None:
+    with main.make_context("httpx2", ["https://example.com", *option]) as context:
+        assert context.params["verify"] is expected
 
 
 def test_get(server: TestServer) -> None:

--- a/tests/httpx2/test_main.py
+++ b/tests/httpx2/test_main.py
@@ -25,6 +25,13 @@ def test_help() -> None:
     result = runner.invoke(main, ["--help"])
     assert result.exit_code == 0
     assert "A next generation HTTP client." in result.output
+    assert "--verify / --no-verify" in result.output
+
+
+def test_no_verify(https_server: TestServer) -> None:
+    runner = CliRunner()
+    result = runner.invoke(main, [str(https_server.url), "--no-verify"])
+    assert result.exit_code == 0
 
 
 def test_get(server: TestServer) -> None:


### PR DESCRIPTION
## Summary

Preserve the existing `--no-verify` CLI flag while adding the explicit `--verify` counterpart. Update the custom help output and cover the parsed values for both flags.

## Tests

- `scripts/test -q`
- `uv run pytest tests/httpx2/test_main.py -q`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.