### PR TITLE
Validate a caller-supplied `extensions["timeout"]`

### DIFF
--- a/src/httpx2/httpx2/_client.py
+++ b/src/httpx2/httpx2/_client.py
@@ -113,6 +113,19 @@ USER_AGENT = f"python-httpx2/{__version__}"
 ACCEPT_ENCODING = ", ".join([key for key in SUPPORTED_DECODERS.keys() if key != "identity"])
 
 
+def _validate_timeout_extension(timeout: typing.Any) -> None:
+    # A caller-supplied `extensions["timeout"]` reaches the transport unchanged, and its
+    # values are passed to `socket.settimeout()`, which only accepts numbers.
+    if not isinstance(timeout, typing.Mapping):
+        raise TypeError(
+            f"extensions['timeout'] must be a mapping, got {type(timeout).__name__}. "
+            "Use `Timeout(...).as_dict()` to build one."
+        )
+    for name, value in timeout.items():
+        if value is not None and not isinstance(value, (int, float)):
+            raise TypeError(f"extensions['timeout'][{name!r}] must be a number or None, got {type(value).__name__}.")
+
+
 class ClientState(enum.Enum):
     # UNOPENED:
     #   The client has been instantiated, but has not been used to send a request,
@@ -357,6 +370,8 @@ class BaseClient:
         if "timeout" not in extensions:
             timeout = self.timeout if isinstance(timeout, UseClientDefault) else Timeout(timeout)
             extensions = dict(**extensions, timeout=timeout.as_dict())
+        else:
+            _validate_timeout_extension(extensions["timeout"])
         return Request(
             method,
             url,
@@ -561,6 +576,8 @@ class BaseClient:
         if "timeout" not in request.extensions:
             timeout = self.timeout if isinstance(self.timeout, UseClientDefault) else Timeout(self.timeout)
             request.extensions = dict(**request.extensions, timeout=timeout.as_dict())
+        else:
+            _validate_timeout_extension(request.extensions["timeout"])
 
 
 class Client(BaseClient):

--- a/tests/httpx2/test_timeouts.py
+++ b/tests/httpx2/test_timeouts.py
@@ -58,3 +58,27 @@ async def test_async_client_new_request_send_timeout(server: TestServer) -> None
     async with httpx2.AsyncClient(timeout=timeout) as client:
         with pytest.raises(httpx2.TimeoutException):
             await client.send(httpx2.Request("GET", server.url.copy_with(path="/slow_response")))
+
+
+@pytest.mark.parametrize("name", ["connect", "read", "write", "pool"])
+def test_timeout_extension_value_must_be_a_number(name: str) -> None:
+    request = httpx2.Request("GET", "http://127.0.0.1:1/")
+    request.extensions["timeout"] = {name: httpx2.Timeout(5.0)}
+
+    with pytest.raises(TypeError, match=f"extensions\\['timeout'\\]\\[{name!r}\\]"):
+        httpx2.Client().send(request)
+
+
+def test_timeout_extension_must_be_a_mapping() -> None:
+    request = httpx2.Request("GET", "http://127.0.0.1:1/")
+    request.extensions["timeout"] = httpx2.Timeout(5.0)
+
+    with pytest.raises(TypeError, match="extensions\\['timeout'\\] must be a mapping"):
+        httpx2.Client().send(request)
+
+
+@pytest.mark.parametrize("timeout", [{"connect": 5.0}, {"read": 5}, {"connect": None}, {}])
+def test_timeout_extension_accepts_numbers_and_none(timeout: dict[str, float | None]) -> None:
+    request = httpx2.Client().build_request("GET", "http://127.0.0.1:1/", extensions={"timeout": timeout})
+
+    assert request.extensions["timeout"] == timeout

--- a/tests/httpx2/test_timeouts.py
+++ b/tests/httpx2/test_timeouts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import typing
 
 import pytest
@@ -79,6 +80,9 @@ def test_timeout_extension_must_be_a_mapping() -> None:
 
 @pytest.mark.parametrize("timeout", [{"connect": 5.0}, {"read": 5}, {"connect": None}, {}])
 def test_timeout_extension_accepts_numbers_and_none(timeout: dict[str, float | None]) -> None:
+    # `Request` shallow-copies `extensions`, so the mapping reaching the transport is the
+    # caller's own object. Compare against a snapshot or the assertion is `x == x`.
+    expected = copy.deepcopy(timeout)
     request = httpx2.Client().build_request("GET", "http://127.0.0.1:1/", extensions={"timeout": timeout})
 
-    assert request.extensions["timeout"] == timeout
+    assert request.extensions["timeout"] == expected


### PR DESCRIPTION
# Summary

`extensions["timeout"]` reaches the transport unchanged and its values land in `socket.settimeout()`, so patching `connect_tcp` fixes the traceback in the issue but not the rest of it: put a `Timeout` in `read` or `write` and you get the same TypeError out of `_backends/sync.py:126` and `:137`. I put the check where the caller's mapping is accepted instead, so it covers every key and both the `build_request` and `send()` paths.

I went with raising rather than coercing. Coercing means guessing which attribute was meant, and the `getattr(timeout, "connect", None)` version turns any other object into `None`, which is no timeout at all rather than an error. Can switch it if you'd prefer.

The guard accepts `int`, `float` and `None`, which is what `socket.settimeout` itself accepts, so nothing that works today starts failing (`Decimal` and `Fraction` already raise there). The extensions doc already shows this as a mapping of floats, so there was nothing to change there.

This leaves httpcore2 alone, so using httpcore2 directly still reaches the stdlib error. That is why it is `Refs` and not `Fixes`.

Refs #1162

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

