### PR TITLE
Fix the docs index page header on the unified site

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,21 +1,12 @@
-<h1 align="center" style="font-size: 3rem; margin: -15px 0">
-HTTPX2
-</h1>
-
+---
+title: HTTPX2
 ---
 
-<div align="center">
-<p>
-<a href="https://github.com/pydantic/httpx2/actions">
-    <img src="https://github.com/pydantic/httpx2/workflows/Test%20Suite/badge.svg" alt="Test Suite">
-</a>
-<a href="https://pypi.org/project/httpx2/">
-    <img src="https://badge.fury.io/py/httpx2.svg" alt="Package version">
-</a>
-</p>
+[![Test Suite](https://github.com/pydantic/httpx2/workflows/Test%20Suite/badge.svg)](https://github.com/pydantic/httpx2/actions)
+[![Package version](https://badge.fury.io/py/httpx2.svg)](https://pypi.org/project/httpx2/)
+[![Join Slack](https://img.shields.io/badge/Slack-Join%20Slack-4A154B?logo=slack)](https://pydantic.dev/docs/logfire/join-slack/)
 
-<em>A next-generation HTTP client for Python.</em>
-</div>
+*A next-generation HTTP client for Python.*
 
 HTTPX2 is a fully featured HTTP client for Python, which provides sync and async APIs, and support for both HTTP/1.1 and HTTP/2.
 


### PR DESCRIPTION
The header of `docs/index.md` was raw centered HTML written for GitHub, and https://pydantic.dev/docs/httpx2/get-started/ rendered it badly.

- **Title.** The h1 read `Introduction`, taken from the `mkdocs.yml` nav label by `navOrderFrom` in unified-docs. A `title:` in the page's own frontmatter takes precedence, so the page now reads `HTTPX2`. The sidebar entry still says `Introduction`.
- **Stray "HTTPX2".** The site strips the raw `<h1>` tag but keeps its text, which rendered as a small paragraph under the page title.
- **Stacked badges.** The site styles badge rows with `.sl-markdown-content>p:has(>a>img[…badge…])`, matching a `<p>` that is a direct child of the markdown content. The badges sat inside `<div align="center">`, missed the rule, and fell back to `img{display:block}`. Written as a markdown paragraph they lay out in one row.
- **Slack badge** added, same as the README.

Verified by applying the equivalent DOM change to the live page: title `HTTPX2`, no stray line, three badges in a row. `uv run zensical build -c -f mkdocs.yml` still passes.

unified-docs clones this repo at `main` with no pin in `docs-source-lock.json`, so this reaches pydantic.dev on its next build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01La6PmwawEhiyrGgDkpsMyD

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

