### PR TITLE
Trigger unified-docs deployment on every push to main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,3 +53,28 @@ jobs:
         uses: re-actors/alls-green@b5b5b37504aa4183270bd3d855c52a67f212be35 # v1.3.0
         with:
           jobs: ${{ toJSON(needs) }}
+
+  deploy-docs:
+    needs: [check]
+    if: success() && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Generate app token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          app-id: ${{ vars.DOCS_APP_ID }}
+          private-key: ${{ secrets.DOCS_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: unified-docs
+          permission-contents: write
+
+      - name: Trigger unified-docs deployment
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh api repos/pydantic/unified-docs/dispatches \
+            --method POST \
+            -f event_type=docs-update \
+            -f "client_payload[source]=pydantic/httpx2@${{ github.sha }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,28 +65,3 @@ jobs:
 
       - name: Publish distributions to PyPI
         run: uv publish --trusted-publishing always dist/*
-
-  deploy-docs:
-    runs-on: ubuntu-latest
-    needs: build
-
-    steps:
-      - name: Generate app token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        id: app-token
-        with:
-          app-id: ${{ vars.DOCS_APP_ID }}
-          private-key: ${{ secrets.DOCS_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: unified-docs
-          permission-contents: write
-
-      - name: Trigger unified-docs deployment
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          gh api repos/pydantic/unified-docs/dispatches \
-            --method POST \
-            -f event_type=docs-update \
-            -f "client_payload[source]=pydantic/httpx2@${{ github.sha }}"
-


### PR DESCRIPTION
The unified-docs library config for httpx2 pins its source to the `main` branch, so any rebuild of the unified site already pulls httpx2 docs from main. Dispatching only on tag pushes meant a release deployed docs at the tag SHA, and the next unrelated rebuild of the site would pull newer main content anyway. Logfire already dispatches on every push to main for the same reason.

This moves the `deploy-docs` job from `publish.yml` to `main.yml`. It depends on the `check` job and runs only when `success() && github.ref == 'refs/heads/main'`, so pull requests and failed test runs skip it. The dispatch payload still pins the exact commit SHA.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

