### PR TITLE
Improve invalid header encoding errors

### DIFF
--- a/src/httpx2/httpx2/_models.py
+++ b/src/httpx2/httpx2/_models.py
@@ -152,15 +152,14 @@ class Headers(typing.MutableMapping[str, str]):
 
         if isinstance(headers, Headers):
             self._list = list(headers._list)
-        elif isinstance(headers, Mapping):
-            for k, v in headers.items():
-                bytes_key = _normalize_header_key(k, encoding)
-                bytes_value = _normalize_header_value(v, encoding)
-                self._list.append((bytes_key, bytes_key.lower(), bytes_value))
         elif headers is not None:
-            for k, v in headers:
+            header_items = headers.items() if isinstance(headers, Mapping) else headers
+            for k, v in header_items:
                 bytes_key = _normalize_header_key(k, encoding)
-                bytes_value = _normalize_header_value(v, encoding)
+                try:
+                    bytes_value = _normalize_header_value(v, encoding)
+                except UnicodeEncodeError as exc:
+                    raise ValueError(f"Unable to encode header value for {k!r}") from exc
                 self._list.append((bytes_key, bytes_key.lower(), bytes_value))
 
         self._encoding = encoding

--- a/tests/httpx2/models/test_headers.py
+++ b/tests/httpx2/models/test_headers.py
@@ -36,6 +36,22 @@ def test_headers() -> None:
     assert repr(h) == "Headers({'a': '123', 'b': '789'})"
 
 
+@pytest.mark.parametrize(
+    "headers",
+    [
+        {"auth": "שלום"},
+        [("auth", "שלום")],
+    ],
+)
+def test_header_value_encoding_error_includes_header_name(
+    headers: dict[str, str] | list[tuple[str, str]],
+) -> None:
+    with pytest.raises(ValueError, match="auth") as exc_info:
+        httpx2.Headers(headers)
+
+    assert isinstance(exc_info.value.__cause__, UnicodeEncodeError)
+
+
 def test_header_mutations() -> None:
     h = httpx2.Headers()
     assert dict(h) == {}


### PR DESCRIPTION
# Summary

Improve the error raised when a header value cannot be encoded.

Previously, invalid header values could surface a raw UnicodeEncodeError without indicating which header caused the failure. This change raises a clearer ValueError that includes the offending header name while preserving the original encoding error as the cause.

Regression tests cover both mapping-based and iterable header construction.

Closes #864.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/httpx2/pull/1194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

